### PR TITLE
fix: Active label not removed from closed issues

### DIFF
--- a/apps/vscode/src/github-api.ts
+++ b/apps/vscode/src/github-api.ts
@@ -1858,7 +1858,7 @@ export class GitHubAPI {
             }>(`
                 query($owner: String!, $repo: String!, $labels: [String!]!) {
                     repository(owner: $owner, name: $repo) {
-                        issues(first: 50, states: [OPEN], labels: $labels) {
+                        issues(first: 50, states: [OPEN, CLOSED], labels: $labels) {
                             nodes {
                                 number
                                 title

--- a/packages/core/src/queries.ts
+++ b/packages/core/src/queries.ts
@@ -387,7 +387,7 @@ export const REMOVE_LABELS_MUTATION = `
 export const ISSUES_WITH_LABEL_QUERY = `
     query($owner: String!, $name: String!, $labels: [String!]) {
         repository(owner: $owner, name: $name) {
-            issues(first: 10, labels: $labels, states: [OPEN]) {
+            issues(first: 10, labels: $labels, states: [OPEN, CLOSED]) {
                 nodes {
                     number
                 }


### PR DESCRIPTION
## Summary
- Fixed `findIssuesWithLabel` query to search both OPEN and CLOSED issues
- Previously, closed issues would retain the `@user:active` label forever because they were never found in the search

## Changes
- `packages/core/src/queries.ts`: Added `CLOSED` to states array
- `apps/vscode/src/github-api.ts`: Added `CLOSED` to states array

## Test plan
- [x] Tested locally - label was removed from 3 closed issues (#1, #25, #27) when starting #32

Fixes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)