### PR TITLE
feat: Memory Package Foundation

### DIFF
--- a/packages/memory/package.json
+++ b/packages/memory/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "@bretwardjames/ghp-memory",
+  "version": "0.2.0-beta.1",
+  "description": "Memory abstraction layer with pluggable backends for GHP",
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup src/index.ts --format cjs,esm --dts",
+    "dev": "tsup src/index.ts --format cjs,esm --dts --watch",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "prepublishOnly": "npm run build"
+  },
+  "keywords": [
+    "memory",
+    "context",
+    "ai",
+    "llm",
+    "storage"
+  ],
+  "author": "bretwardjames",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/bretwardjames/ghp"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.10.0",
+    "tsup": "^8.0.0",
+    "typescript": "^5.3.2",
+    "vitest": "^1.0.0"
+  }
+}

--- a/packages/memory/src/__tests__/local-backend.test.ts
+++ b/packages/memory/src/__tests__/local-backend.test.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { promises as fs } from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { LocalMemoryBackend } from '../backends/local.js';
+
+describe('LocalMemoryBackend', () => {
+    let backend: LocalMemoryBackend;
+    let testDir: string;
+
+    beforeEach(async () => {
+        // Create a unique temp directory for each test
+        testDir = path.join(os.tmpdir(), `ghp-memory-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+        backend = new LocalMemoryBackend({ storagePath: testDir });
+    });
+
+    afterEach(async () => {
+        // Clean up test directory
+        try {
+            await fs.rm(testDir, { recursive: true, force: true });
+        } catch {
+            // Ignore cleanup errors
+        }
+    });
+
+    describe('save', () => {
+        it('should save a memory and return it with generated id', async () => {
+            const memory = await backend.save({
+                namespace: 'test-namespace',
+                content: 'Test content',
+                metadata: { foo: 'bar' },
+            });
+
+            expect(memory.id).toBeDefined();
+            expect(memory.namespace).toBe('test-namespace');
+            expect(memory.content).toBe('Test content');
+            expect(memory.metadata).toEqual({ foo: 'bar' });
+            expect(memory.createdAt).toBeInstanceOf(Date);
+            expect(memory.updatedAt).toBeInstanceOf(Date);
+        });
+
+        it('should generate unique ids for each memory', async () => {
+            const memory1 = await backend.save({ namespace: 'ns', content: 'content1' });
+            const memory2 = await backend.save({ namespace: 'ns', content: 'content2' });
+
+            expect(memory1.id).not.toBe(memory2.id);
+        });
+    });
+
+    describe('get', () => {
+        it('should retrieve a saved memory by id', async () => {
+            const saved = await backend.save({
+                namespace: 'test',
+                content: 'Hello world',
+            });
+
+            const retrieved = await backend.get(saved.id);
+
+            expect(retrieved).not.toBeNull();
+            expect(retrieved!.id).toBe(saved.id);
+            expect(retrieved!.content).toBe('Hello world');
+        });
+
+        it('should return null for non-existent id', async () => {
+            const result = await backend.get('non-existent-id');
+            expect(result).toBeNull();
+        });
+    });
+
+    describe('list', () => {
+        it('should list memories in a namespace', async () => {
+            await backend.save({ namespace: 'ns1', content: 'content1' });
+            await backend.save({ namespace: 'ns1', content: 'content2' });
+            await backend.save({ namespace: 'ns2', content: 'content3' });
+
+            const ns1Memories = await backend.list({ namespace: 'ns1' });
+            const ns2Memories = await backend.list({ namespace: 'ns2' });
+
+            expect(ns1Memories).toHaveLength(2);
+            expect(ns2Memories).toHaveLength(1);
+        });
+
+        it('should support pagination', async () => {
+            await backend.save({ namespace: 'ns', content: 'content1' });
+            await backend.save({ namespace: 'ns', content: 'content2' });
+            await backend.save({ namespace: 'ns', content: 'content3' });
+
+            const page1 = await backend.list({ namespace: 'ns', limit: 2, offset: 0 });
+            const page2 = await backend.list({ namespace: 'ns', limit: 2, offset: 2 });
+
+            expect(page1).toHaveLength(2);
+            expect(page2).toHaveLength(1);
+        });
+
+        it('should return empty array for non-existent namespace', async () => {
+            const result = await backend.list({ namespace: 'non-existent' });
+            expect(result).toEqual([]);
+        });
+    });
+
+    describe('search', () => {
+        beforeEach(async () => {
+            await backend.save({ namespace: 'search-ns', content: 'The quick brown fox jumps over the lazy dog' });
+            await backend.save({ namespace: 'search-ns', content: 'A quick response to the user query' });
+            await backend.save({ namespace: 'search-ns', content: 'Something completely different' });
+            await backend.save({ namespace: 'other-ns', content: 'Quick fox in another namespace' });
+        });
+
+        it('should find memories matching query', async () => {
+            const results = await backend.search({ query: 'quick fox' });
+
+            expect(results.length).toBeGreaterThan(0);
+            expect(results[0].score).toBeGreaterThan(0);
+        });
+
+        it('should filter by namespace', async () => {
+            const results = await backend.search({ query: 'quick', namespace: 'search-ns' });
+
+            expect(results.every(r => r.memory.namespace === 'search-ns')).toBe(true);
+        });
+
+        it('should respect limit', async () => {
+            const results = await backend.search({ query: 'quick', limit: 1 });
+
+            expect(results).toHaveLength(1);
+        });
+
+        it('should return results sorted by score descending', async () => {
+            const results = await backend.search({ query: 'quick' });
+
+            for (let i = 1; i < results.length; i++) {
+                expect(results[i - 1].score).toBeGreaterThanOrEqual(results[i].score);
+            }
+        });
+    });
+
+    describe('update', () => {
+        it('should update content', async () => {
+            const saved = await backend.save({ namespace: 'ns', content: 'original' });
+            const updated = await backend.update(saved.id, { content: 'modified' });
+
+            expect(updated.content).toBe('modified');
+            expect(updated.updatedAt.getTime()).toBeGreaterThanOrEqual(saved.updatedAt.getTime());
+        });
+
+        it('should merge metadata', async () => {
+            const saved = await backend.save({
+                namespace: 'ns',
+                content: 'test',
+                metadata: { a: 1, b: 2 },
+            });
+
+            const updated = await backend.update(saved.id, { metadata: { b: 3, c: 4 } });
+
+            expect(updated.metadata).toEqual({ a: 1, b: 3, c: 4 });
+        });
+
+        it('should throw for non-existent id', async () => {
+            await expect(backend.update('non-existent', { content: 'new' }))
+                .rejects.toThrow('Memory not found');
+        });
+    });
+
+    describe('delete', () => {
+        it('should delete a memory', async () => {
+            const saved = await backend.save({ namespace: 'ns', content: 'test' });
+
+            const deleted = await backend.delete(saved.id);
+
+            expect(deleted).toBe(true);
+            expect(await backend.get(saved.id)).toBeNull();
+        });
+
+        it('should return false for non-existent id', async () => {
+            const result = await backend.delete('non-existent');
+            expect(result).toBe(false);
+        });
+    });
+
+    describe('deleteNamespace', () => {
+        it('should delete all memories in namespace', async () => {
+            await backend.save({ namespace: 'ns1', content: 'a' });
+            await backend.save({ namespace: 'ns1', content: 'b' });
+            await backend.save({ namespace: 'ns2', content: 'c' });
+
+            const count = await backend.deleteNamespace('ns1');
+
+            expect(count).toBe(2);
+            expect(await backend.list({ namespace: 'ns1' })).toHaveLength(0);
+            expect(await backend.list({ namespace: 'ns2' })).toHaveLength(1);
+        });
+
+        it('should return 0 for non-existent namespace', async () => {
+            const count = await backend.deleteNamespace('non-existent');
+            expect(count).toBe(0);
+        });
+    });
+
+    describe('isAvailable', () => {
+        it('should return true when storage is accessible', async () => {
+            const available = await backend.isAvailable();
+            expect(available).toBe(true);
+        });
+    });
+});

--- a/packages/memory/src/__tests__/namespaces.test.ts
+++ b/packages/memory/src/__tests__/namespaces.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect } from 'vitest';
+import {
+    createNamespace,
+    issueNamespace,
+    branchNamespace,
+    userNamespace,
+    appNamespace,
+    sessionNamespace,
+    parseNamespace,
+    isNamespaceType,
+    getIssueRelatedNamespaces,
+} from '../namespaces.js';
+
+describe('namespaces', () => {
+    describe('createNamespace', () => {
+        it('should create namespace with default prefix', () => {
+            const ns = createNamespace('issue', 123);
+            expect(ns).toBe('ghp-issue-123');
+        });
+
+        it('should create namespace with custom prefix', () => {
+            const ns = createNamespace('issue', 123, { prefix: 'lift-care' });
+            expect(ns).toBe('lift-care-issue-123');
+        });
+
+        it('should sanitize identifiers', () => {
+            const ns = createNamespace('branch', 'feature/my-branch');
+            expect(ns).toBe('ghp-branch-feature-my-branch');
+        });
+
+        it('should lowercase identifiers', () => {
+            const ns = createNamespace('user', 'BretWardJames');
+            expect(ns).toBe('ghp-user-bretwardjames');
+        });
+
+        it('should handle special characters', () => {
+            const ns = createNamespace('branch', 'feat/add@something#weird!');
+            expect(ns).toBe('ghp-branch-feat-add-something-weird');
+        });
+    });
+
+    describe('typed namespace functions', () => {
+        it('issueNamespace creates issue namespace', () => {
+            expect(issueNamespace(42)).toBe('ghp-issue-42');
+        });
+
+        it('branchNamespace creates branch namespace', () => {
+            expect(branchNamespace('main')).toBe('ghp-branch-main');
+        });
+
+        it('userNamespace creates user namespace', () => {
+            expect(userNamespace('alice')).toBe('ghp-user-alice');
+        });
+
+        it('appNamespace creates app namespace', () => {
+            expect(appNamespace('settings')).toBe('ghp-app-settings');
+            expect(appNamespace()).toBe('ghp-app-general');
+        });
+
+        it('sessionNamespace creates session namespace', () => {
+            expect(sessionNamespace('abc123')).toBe('ghp-session-abc123');
+        });
+    });
+
+    describe('parseNamespace', () => {
+        it('should parse valid namespaces', () => {
+            const parsed = parseNamespace('ghp-issue-123');
+
+            expect(parsed).toEqual({
+                prefix: 'ghp',
+                type: 'issue',
+                identifier: '123',
+            });
+        });
+
+        it('should parse custom prefix', () => {
+            const parsed = parseNamespace('lift-care-branch-main');
+
+            expect(parsed).toEqual({
+                prefix: 'lift-care',
+                type: 'branch',
+                identifier: 'main',
+            });
+        });
+
+        it('should handle complex identifiers', () => {
+            const parsed = parseNamespace('ghp-branch-feature-add-tests');
+
+            expect(parsed).toEqual({
+                prefix: 'ghp',
+                type: 'branch',
+                identifier: 'feature-add-tests',
+            });
+        });
+
+        it('should return null for invalid namespaces', () => {
+            expect(parseNamespace('invalid')).toBeNull();
+            expect(parseNamespace('ghp-invalid-123')).toBeNull();
+            expect(parseNamespace('')).toBeNull();
+        });
+    });
+
+    describe('isNamespaceType', () => {
+        it('should return true for matching type', () => {
+            expect(isNamespaceType('ghp-issue-123', 'issue')).toBe(true);
+            expect(isNamespaceType('ghp-branch-main', 'branch')).toBe(true);
+        });
+
+        it('should return false for non-matching type', () => {
+            expect(isNamespaceType('ghp-issue-123', 'branch')).toBe(false);
+        });
+
+        it('should return false for invalid namespace', () => {
+            expect(isNamespaceType('invalid', 'issue')).toBe(false);
+        });
+    });
+
+    describe('getIssueRelatedNamespaces', () => {
+        it('should return just issue namespace without linked branch', () => {
+            const namespaces = getIssueRelatedNamespaces(42);
+            expect(namespaces).toEqual(['ghp-issue-42']);
+        });
+
+        it('should return issue and branch namespaces with linked branch', () => {
+            const namespaces = getIssueRelatedNamespaces(42, 'feature/issue-42');
+            expect(namespaces).toEqual([
+                'ghp-issue-42',
+                'ghp-branch-feature-issue-42',
+            ]);
+        });
+
+        it('should respect custom prefix', () => {
+            const namespaces = getIssueRelatedNamespaces(42, 'main', { prefix: 'custom' });
+            expect(namespaces).toEqual([
+                'custom-issue-42',
+                'custom-branch-main',
+            ]);
+        });
+    });
+});

--- a/packages/memory/src/backends/local.ts
+++ b/packages/memory/src/backends/local.ts
@@ -1,0 +1,300 @@
+import { promises as fs } from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import * as crypto from 'crypto';
+import type {
+    Memory,
+    MemoryBackend,
+    MemoryCreateOptions,
+    MemorySearchOptions,
+    MemorySearchResult,
+    MemoryListOptions,
+    MemoryUpdateOptions,
+} from '../types.js';
+
+export interface LocalBackendConfig {
+    /** Path to store memory files (default: ~/.ghp/memories) */
+    storagePath?: string;
+}
+
+interface StoredMemory {
+    id: string;
+    namespace: string;
+    content: string;
+    metadata?: Record<string, unknown>;
+    createdAt: string;
+    updatedAt: string;
+}
+
+interface MemoryIndex {
+    version: 1;
+    memories: Record<string, StoredMemory>;
+    namespaceIndex: Record<string, string[]>; // namespace -> memory IDs
+}
+
+/**
+ * File-based memory backend using JSON storage.
+ *
+ * This is the fallback backend that works without any external dependencies.
+ * It stores all memories in a single JSON file with an index for fast lookups.
+ *
+ * For search, it uses simple substring matching with a basic relevance score.
+ * For production use with large memory stores, consider using a vector database backend.
+ */
+export class LocalMemoryBackend implements MemoryBackend {
+    readonly name = 'local';
+    private readonly storagePath: string;
+    private readonly indexPath: string;
+    private indexCache: MemoryIndex | null = null;
+
+    constructor(config: LocalBackendConfig = {}) {
+        this.storagePath = config.storagePath || path.join(os.homedir(), '.ghp', 'memories');
+        this.indexPath = path.join(this.storagePath, 'index.json');
+    }
+
+    async save(options: MemoryCreateOptions): Promise<Memory> {
+        const index = await this.loadIndex();
+        const now = new Date();
+        const id = this.generateId();
+
+        const stored: StoredMemory = {
+            id,
+            namespace: options.namespace,
+            content: options.content,
+            metadata: options.metadata,
+            createdAt: now.toISOString(),
+            updatedAt: now.toISOString(),
+        };
+
+        index.memories[id] = stored;
+
+        // Update namespace index
+        if (!index.namespaceIndex[options.namespace]) {
+            index.namespaceIndex[options.namespace] = [];
+        }
+        index.namespaceIndex[options.namespace].push(id);
+
+        await this.saveIndex(index);
+
+        return this.toMemory(stored);
+    }
+
+    async search(options: MemorySearchOptions): Promise<MemorySearchResult[]> {
+        const index = await this.loadIndex();
+        const results: MemorySearchResult[] = [];
+        const queryLower = options.query.toLowerCase();
+        const queryTerms = queryLower.split(/\s+/).filter(t => t.length > 0);
+
+        // Get memories to search
+        let memoryIds: string[];
+        if (options.namespace) {
+            memoryIds = index.namespaceIndex[options.namespace] || [];
+        } else {
+            memoryIds = Object.keys(index.memories);
+        }
+
+        for (const id of memoryIds) {
+            const stored = index.memories[id];
+            if (!stored) continue;
+
+            const score = this.calculateRelevance(stored.content, queryTerms);
+            const minScore = options.minScore ?? 0;
+
+            if (score > minScore) {
+                results.push({
+                    memory: this.toMemory(stored),
+                    score,
+                });
+            }
+        }
+
+        // Sort by score descending
+        results.sort((a, b) => b.score - a.score);
+
+        // Apply limit
+        const limit = options.limit ?? 10;
+        return results.slice(0, limit);
+    }
+
+    async list(options: MemoryListOptions): Promise<Memory[]> {
+        const index = await this.loadIndex();
+        const memoryIds = index.namespaceIndex[options.namespace] || [];
+
+        const offset = options.offset ?? 0;
+        const limit = options.limit ?? 100;
+        const slicedIds = memoryIds.slice(offset, offset + limit);
+
+        return slicedIds
+            .map(id => index.memories[id])
+            .filter((m): m is StoredMemory => m !== undefined)
+            .map(m => this.toMemory(m));
+    }
+
+    async get(id: string): Promise<Memory | null> {
+        const index = await this.loadIndex();
+        const stored = index.memories[id];
+        return stored ? this.toMemory(stored) : null;
+    }
+
+    async update(id: string, options: MemoryUpdateOptions): Promise<Memory> {
+        const index = await this.loadIndex();
+        const stored = index.memories[id];
+
+        if (!stored) {
+            throw new Error(`Memory not found: ${id}`);
+        }
+
+        if (options.content !== undefined) {
+            stored.content = options.content;
+        }
+
+        if (options.metadata !== undefined) {
+            stored.metadata = { ...stored.metadata, ...options.metadata };
+        }
+
+        stored.updatedAt = new Date().toISOString();
+
+        await this.saveIndex(index);
+
+        return this.toMemory(stored);
+    }
+
+    async delete(id: string): Promise<boolean> {
+        const index = await this.loadIndex();
+        const stored = index.memories[id];
+
+        if (!stored) {
+            return false;
+        }
+
+        // Remove from namespace index
+        const namespaceIds = index.namespaceIndex[stored.namespace];
+        if (namespaceIds) {
+            const idx = namespaceIds.indexOf(id);
+            if (idx !== -1) {
+                namespaceIds.splice(idx, 1);
+            }
+            if (namespaceIds.length === 0) {
+                delete index.namespaceIndex[stored.namespace];
+            }
+        }
+
+        // Remove from memories
+        delete index.memories[id];
+
+        await this.saveIndex(index);
+
+        return true;
+    }
+
+    async deleteNamespace(namespace: string): Promise<number> {
+        const index = await this.loadIndex();
+        const memoryIds = index.namespaceIndex[namespace] || [];
+        const count = memoryIds.length;
+
+        // Delete all memories in namespace
+        for (const id of memoryIds) {
+            delete index.memories[id];
+        }
+
+        // Remove namespace from index
+        delete index.namespaceIndex[namespace];
+
+        await this.saveIndex(index);
+
+        return count;
+    }
+
+    async isAvailable(): Promise<boolean> {
+        try {
+            // Try to ensure storage directory exists
+            await fs.mkdir(this.storagePath, { recursive: true });
+            // Try to load or create index
+            await this.loadIndex();
+            return true;
+        } catch {
+            return false;
+        }
+    }
+
+    // Private methods
+
+    private async loadIndex(): Promise<MemoryIndex> {
+        if (this.indexCache) {
+            return this.indexCache;
+        }
+
+        try {
+            await fs.mkdir(this.storagePath, { recursive: true });
+            const data = await fs.readFile(this.indexPath, 'utf-8');
+            this.indexCache = JSON.parse(data) as MemoryIndex;
+            return this.indexCache;
+        } catch (err) {
+            if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+                // File doesn't exist, create empty index
+                const emptyIndex: MemoryIndex = {
+                    version: 1,
+                    memories: {},
+                    namespaceIndex: {},
+                };
+                this.indexCache = emptyIndex;
+                return emptyIndex;
+            }
+            throw err;
+        }
+    }
+
+    private async saveIndex(index: MemoryIndex): Promise<void> {
+        await fs.mkdir(this.storagePath, { recursive: true });
+        await fs.writeFile(this.indexPath, JSON.stringify(index, null, 2), 'utf-8');
+        this.indexCache = index;
+    }
+
+    private generateId(): string {
+        return crypto.randomUUID();
+    }
+
+    private toMemory(stored: StoredMemory): Memory {
+        return {
+            id: stored.id,
+            namespace: stored.namespace,
+            content: stored.content,
+            metadata: stored.metadata,
+            createdAt: new Date(stored.createdAt),
+            updatedAt: new Date(stored.updatedAt),
+        };
+    }
+
+    /**
+     * Calculate a simple relevance score based on term frequency.
+     * Score is normalized between 0 and 1.
+     */
+    private calculateRelevance(content: string, queryTerms: string[]): number {
+        if (queryTerms.length === 0) return 0;
+
+        const contentLower = content.toLowerCase();
+        let matchedTerms = 0;
+        let totalOccurrences = 0;
+
+        for (const term of queryTerms) {
+            const regex = new RegExp(this.escapeRegex(term), 'gi');
+            const matches = contentLower.match(regex);
+            if (matches) {
+                matchedTerms++;
+                totalOccurrences += matches.length;
+            }
+        }
+
+        // Score based on:
+        // - Percentage of query terms that matched
+        // - Density of matches in content
+        const termCoverage = matchedTerms / queryTerms.length;
+        const density = Math.min(1, totalOccurrences / (content.length / 100));
+
+        return (termCoverage * 0.7) + (density * 0.3);
+    }
+
+    private escapeRegex(str: string): string {
+        return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    }
+}

--- a/packages/memory/src/factory.ts
+++ b/packages/memory/src/factory.ts
@@ -1,0 +1,44 @@
+import type { MemoryBackend, MemoryConfig } from './types.js';
+import { LocalMemoryBackend } from './backends/local.js';
+
+/**
+ * Create a memory backend based on configuration.
+ *
+ * Currently only supports the local backend.
+ * Other backends (mem0, pinecone, weaviate, custom) will be added in future phases.
+ */
+export function createMemoryBackend(config?: MemoryConfig): MemoryBackend {
+    const backendType = config?.backend ?? 'local';
+
+    switch (backendType) {
+        case 'local':
+            return new LocalMemoryBackend(config?.local);
+
+        case 'mem0':
+            // TODO: Implement in Phase 7
+            throw new Error('mem0 backend not yet implemented. Use local backend for now.');
+
+        case 'pinecone':
+            // TODO: Implement in Phase 7
+            throw new Error('Pinecone backend not yet implemented. Use local backend for now.');
+
+        case 'weaviate':
+            // TODO: Implement in Phase 7
+            throw new Error('Weaviate backend not yet implemented. Use local backend for now.');
+
+        case 'custom':
+            // TODO: Implement in Phase 7
+            throw new Error('Custom backend not yet implemented. Use local backend for now.');
+
+        default:
+            throw new Error(`Unknown backend type: ${backendType}`);
+    }
+}
+
+/**
+ * Create the default local memory backend.
+ * Useful when you don't need configuration.
+ */
+export function createLocalBackend(storagePath?: string): LocalMemoryBackend {
+    return new LocalMemoryBackend({ storagePath });
+}

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -1,0 +1,32 @@
+// Types
+export type {
+    Memory,
+    MemoryBackend,
+    MemoryConfig,
+    MemoryCreateOptions,
+    MemorySearchOptions,
+    MemorySearchResult,
+    MemoryListOptions,
+    MemoryUpdateOptions,
+} from './types.js';
+
+// Backends
+export { LocalMemoryBackend } from './backends/local.js';
+export type { LocalBackendConfig } from './backends/local.js';
+
+// Factory
+export { createMemoryBackend, createLocalBackend } from './factory.js';
+
+// Namespace helpers
+export {
+    createNamespace,
+    issueNamespace,
+    branchNamespace,
+    userNamespace,
+    appNamespace,
+    sessionNamespace,
+    parseNamespace,
+    isNamespaceType,
+    getIssueRelatedNamespaces,
+} from './namespaces.js';
+export type { NamespaceType, NamespaceOptions } from './namespaces.js';

--- a/packages/memory/src/namespaces.ts
+++ b/packages/memory/src/namespaces.ts
@@ -1,0 +1,132 @@
+/**
+ * Namespace helpers for organizing memories.
+ *
+ * Namespaces follow the pattern: {prefix}-{type}-{identifier}
+ * Examples:
+ *   - ghp-issue-123
+ *   - ghp-branch-feature/my-feature
+ *   - ghp-user-bretwardjames
+ *   - ghp-app-general
+ */
+
+export type NamespaceType = 'issue' | 'branch' | 'user' | 'app' | 'session';
+
+export interface NamespaceOptions {
+    /** The prefix for all namespaces (default: "ghp") */
+    prefix?: string;
+}
+
+const DEFAULT_PREFIX = 'ghp';
+
+/**
+ * Create a namespace string from components
+ */
+export function createNamespace(
+    type: NamespaceType,
+    identifier: string | number,
+    options: NamespaceOptions = {}
+): string {
+    const prefix = options.prefix || DEFAULT_PREFIX;
+    // Sanitize identifier: replace invalid chars with dashes, lowercase
+    const sanitizedId = String(identifier)
+        .toLowerCase()
+        .replace(/[^a-z0-9-]/g, '-')
+        .replace(/-+/g, '-')
+        .replace(/^-|-$/g, '');
+
+    return `${prefix}-${type}-${sanitizedId}`;
+}
+
+/**
+ * Create a namespace for an issue
+ */
+export function issueNamespace(
+    issueNumber: number,
+    options: NamespaceOptions = {}
+): string {
+    return createNamespace('issue', issueNumber, options);
+}
+
+/**
+ * Create a namespace for a branch
+ */
+export function branchNamespace(
+    branchName: string,
+    options: NamespaceOptions = {}
+): string {
+    return createNamespace('branch', branchName, options);
+}
+
+/**
+ * Create a namespace for a user
+ */
+export function userNamespace(
+    username: string,
+    options: NamespaceOptions = {}
+): string {
+    return createNamespace('user', username, options);
+}
+
+/**
+ * Create a namespace for app-wide memories
+ */
+export function appNamespace(
+    appName: string = 'general',
+    options: NamespaceOptions = {}
+): string {
+    return createNamespace('app', appName, options);
+}
+
+/**
+ * Create a namespace for a work session
+ */
+export function sessionNamespace(
+    sessionId: string,
+    options: NamespaceOptions = {}
+): string {
+    return createNamespace('session', sessionId, options);
+}
+
+/**
+ * Parse a namespace string into its components
+ * @returns null if the namespace doesn't match the expected pattern
+ */
+export function parseNamespace(namespace: string): {
+    prefix: string;
+    type: NamespaceType;
+    identifier: string;
+} | null {
+    const match = namespace.match(/^([a-z0-9-]+)-(issue|branch|user|app|session)-(.+)$/);
+    if (!match) {
+        return null;
+    }
+
+    return {
+        prefix: match[1],
+        type: match[2] as NamespaceType,
+        identifier: match[3],
+    };
+}
+
+/**
+ * Check if a namespace belongs to a specific type
+ */
+export function isNamespaceType(namespace: string, type: NamespaceType): boolean {
+    const parsed = parseNamespace(namespace);
+    return parsed !== null && parsed.type === type;
+}
+
+/**
+ * Get all related namespaces for an issue (issue + its branch if linked)
+ */
+export function getIssueRelatedNamespaces(
+    issueNumber: number,
+    linkedBranch?: string,
+    options: NamespaceOptions = {}
+): string[] {
+    const namespaces = [issueNamespace(issueNumber, options)];
+    if (linkedBranch) {
+        namespaces.push(branchNamespace(linkedBranch, options));
+    }
+    return namespaces;
+}

--- a/packages/memory/src/types.ts
+++ b/packages/memory/src/types.ts
@@ -1,0 +1,172 @@
+/**
+ * Represents a single memory entry stored in the backend
+ */
+export interface Memory {
+    /** Unique identifier for this memory */
+    id: string;
+    /** The namespace this memory belongs to (e.g., "ghp-issue-123") */
+    namespace: string;
+    /** The actual content of the memory */
+    content: string;
+    /** Optional metadata attached to the memory */
+    metadata?: Record<string, unknown>;
+    /** Timestamp when the memory was created */
+    createdAt: Date;
+    /** Timestamp when the memory was last updated */
+    updatedAt: Date;
+}
+
+/**
+ * Options for creating a new memory
+ */
+export interface MemoryCreateOptions {
+    /** The namespace to store the memory in */
+    namespace: string;
+    /** The content to store */
+    content: string;
+    /** Optional metadata to attach */
+    metadata?: Record<string, unknown>;
+}
+
+/**
+ * Options for searching memories
+ */
+export interface MemorySearchOptions {
+    /** The query string to search for */
+    query: string;
+    /** Namespace to search within (optional - searches all if not specified) */
+    namespace?: string;
+    /** Maximum number of results to return */
+    limit?: number;
+    /** Minimum relevance score (0-1) for results */
+    minScore?: number;
+}
+
+/**
+ * A search result with relevance score
+ */
+export interface MemorySearchResult {
+    /** The matched memory */
+    memory: Memory;
+    /** Relevance score (0-1, higher is more relevant) */
+    score: number;
+}
+
+/**
+ * Options for listing memories
+ */
+export interface MemoryListOptions {
+    /** Namespace to list from */
+    namespace: string;
+    /** Maximum number of results */
+    limit?: number;
+    /** Offset for pagination */
+    offset?: number;
+}
+
+/**
+ * Options for updating a memory
+ */
+export interface MemoryUpdateOptions {
+    /** New content (optional) */
+    content?: string;
+    /** New/updated metadata (merged with existing) */
+    metadata?: Record<string, unknown>;
+}
+
+/**
+ * The core interface that all memory backends must implement.
+ *
+ * Backends can be:
+ * - Local file-based storage (always available)
+ * - mem0 cloud service
+ * - Pinecone vector database
+ * - Weaviate vector database
+ * - Custom user-provided implementations
+ */
+export interface MemoryBackend {
+    /** Human-readable name of this backend */
+    readonly name: string;
+
+    /**
+     * Save a new memory
+     * @returns The created memory with generated ID
+     */
+    save(options: MemoryCreateOptions): Promise<Memory>;
+
+    /**
+     * Search for memories by query
+     * @returns Matching memories with relevance scores
+     */
+    search(options: MemorySearchOptions): Promise<MemorySearchResult[]>;
+
+    /**
+     * List all memories in a namespace
+     */
+    list(options: MemoryListOptions): Promise<Memory[]>;
+
+    /**
+     * Get a specific memory by ID
+     * @returns The memory or null if not found
+     */
+    get(id: string): Promise<Memory | null>;
+
+    /**
+     * Update an existing memory
+     * @returns The updated memory
+     * @throws Error if memory not found
+     */
+    update(id: string, options: MemoryUpdateOptions): Promise<Memory>;
+
+    /**
+     * Delete a specific memory by ID
+     * @returns true if deleted, false if not found
+     */
+    delete(id: string): Promise<boolean>;
+
+    /**
+     * Delete all memories in a namespace
+     * @returns Number of memories deleted
+     */
+    deleteNamespace(namespace: string): Promise<number>;
+
+    /**
+     * Check if the backend is properly configured and available
+     */
+    isAvailable(): Promise<boolean>;
+}
+
+/**
+ * Configuration for the memory system
+ */
+export interface MemoryConfig {
+    /** Which backend to use */
+    backend: 'local' | 'mem0' | 'pinecone' | 'weaviate' | 'custom';
+    /** Prefix for all namespaces (default: "ghp") */
+    namespacePrefix?: string;
+    /** Local backend configuration */
+    local?: {
+        /** Path to store memory files (default: ~/.ghp/memories) */
+        storagePath?: string;
+    };
+    /** mem0 backend configuration */
+    mem0?: {
+        apiKey: string;
+    };
+    /** Pinecone backend configuration */
+    pinecone?: {
+        apiKey: string;
+        environment: string;
+        indexName: string;
+    };
+    /** Weaviate backend configuration */
+    weaviate?: {
+        host: string;
+        apiKey?: string;
+    };
+    /** Custom backend configuration */
+    custom?: {
+        /** Path to the custom backend module */
+        modulePath: string;
+    };
+}

--- a/packages/memory/tsconfig.json
+++ b/packages/memory/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/memory/vitest.config.ts
+++ b/packages/memory/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+    test: {
+        globals: false,
+        environment: 'node',
+        include: ['src/**/*.test.ts'],
+    },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,7 +76,7 @@ importers:
         version: 20.19.30
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(typescript@5.9.3)
+        version: 8.5.1(postcss@8.5.6)(typescript@5.9.3)
       typescript:
         specifier: ^5.3.2
         version: 5.9.3
@@ -98,10 +98,25 @@ importers:
         version: 20.19.30
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(typescript@5.9.3)
+        version: 8.5.1(postcss@8.5.6)(typescript@5.9.3)
       typescript:
         specifier: ^5.3.2
         version: 5.9.3
+
+  packages/memory:
+    devDependencies:
+      '@types/node':
+        specifier: ^20.10.0
+        version: 20.19.30
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.1(postcss@8.5.6)(typescript@5.9.3)
+      typescript:
+        specifier: ^5.3.2
+        version: 5.9.3
+      vitest:
+        specifier: ^1.0.0
+        version: 1.6.1(@types/node@20.19.30)
 
 packages:
 
@@ -164,16 +179,34 @@ packages:
   '@changesets/write@0.4.0':
     resolution: {integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==}
 
+  '@esbuild/aix-ppc64@0.21.5':
+    resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/aix-ppc64@0.27.2':
     resolution: {integrity: sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/android-arm64@0.21.5':
+    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
   '@esbuild/android-arm64@0.27.2':
     resolution: {integrity: sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.21.5':
+    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.27.2':
@@ -182,16 +215,34 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-x64@0.21.5':
+    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
   '@esbuild/android-x64@0.27.2':
     resolution: {integrity: sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
+  '@esbuild/darwin-arm64@0.21.5':
+    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-arm64@0.27.2':
     resolution: {integrity: sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.21.5':
+    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.27.2':
@@ -200,10 +251,22 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@esbuild/freebsd-arm64@0.21.5':
+    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-arm64@0.27.2':
     resolution: {integrity: sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.21.5':
+    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.27.2':
@@ -212,10 +275,22 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@esbuild/linux-arm64@0.21.5':
+    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm64@0.27.2':
     resolution: {integrity: sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.21.5':
+    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
+    engines: {node: '>=12'}
+    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.27.2':
@@ -224,10 +299,22 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.21.5':
+    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.27.2':
     resolution: {integrity: sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.21.5':
+    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.27.2':
@@ -236,10 +323,22 @@ packages:
     cpu: [loong64]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.21.5':
+    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.27.2':
     resolution: {integrity: sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw==}
     engines: {node: '>=18'}
     cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.21.5':
+    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.27.2':
@@ -248,16 +347,34 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.21.5':
+    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.27.2':
     resolution: {integrity: sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-s390x@0.21.5':
+    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.27.2':
     resolution: {integrity: sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w==}
     engines: {node: '>=18'}
     cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.21.5':
+    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [linux]
 
   '@esbuild/linux-x64@0.27.2':
@@ -272,6 +389,12 @@ packages:
     cpu: [arm64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.21.5':
+    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/netbsd-x64@0.27.2':
     resolution: {integrity: sha512-HwGDZ0VLVBY3Y+Nw0JexZy9o/nUAWq9MlV7cahpaXKW6TOzfVno3y3/M8Ga8u8Yr7GldLOov27xiCnqRZf0tCA==}
     engines: {node: '>=18'}
@@ -282,6 +405,12 @@ packages:
     resolution: {integrity: sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.21.5':
+    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.27.2':
@@ -296,11 +425,23 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
+  '@esbuild/sunos-x64@0.21.5':
+    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/sunos-x64@0.27.2':
     resolution: {integrity: sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
+
+  '@esbuild/win32-arm64@0.21.5':
+    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
 
   '@esbuild/win32-arm64@0.27.2':
     resolution: {integrity: sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==}
@@ -308,10 +449,22 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.21.5':
+    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.27.2':
     resolution: {integrity: sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.21.5':
+    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [win32]
 
   '@esbuild/win32-x64@0.27.2':
@@ -365,6 +518,10 @@ packages:
     peerDependenciesMeta:
       '@types/node':
         optional: true
+
+  '@jest/schemas@29.6.3':
+    resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -576,6 +733,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@sinclair/typebox@0.27.8':
+    resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
@@ -655,6 +815,21 @@ packages:
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
 
+  '@vitest/expect@1.6.1':
+    resolution: {integrity: sha512-jXL+9+ZNIJKruofqXuuTClf44eSpcHlgj3CiuNihUF3Ioujtmc0zIa3UJOW5RjDK1YLBJZnWBlPuqhYycLioog==}
+
+  '@vitest/runner@1.6.1':
+    resolution: {integrity: sha512-3nSnYXkVkf3mXFfE7vVyPmi3Sazhb/2cfZGGs0JRzFsPFvAMBEcrweV1V1GsrstdXeKCTXlJbvnQwGWgEIHmOA==}
+
+  '@vitest/snapshot@1.6.1':
+    resolution: {integrity: sha512-WvidQuWAzU2p95u8GAKlRMqMyN1yOJkGHnx3M1PL9Raf7AQ1kwLKg04ADlCa3+OXUZE7BceOhVZiuWAbzCKcUQ==}
+
+  '@vitest/spy@1.6.1':
+    resolution: {integrity: sha512-MGcMmpGkZebsMZhbQKkAf9CX5zGvjkBTqf8Zx3ApYWXr3wG+QvEu2eXWfnIIWYSJExIp4V9FCKDEeygzkYrXMw==}
+
+  '@vitest/utils@1.6.1':
+    resolution: {integrity: sha512-jOrrUvXM4Av9ZWiG1EajNto0u96kWAhJ1LmPmJhXXQx/32MecEKd10pOLYgS2BQx1TgkGhloPU1ArDW2vvaY6g==}
+
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
@@ -663,6 +838,10 @@ packages:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  acorn-walk@8.3.4:
+    resolution: {integrity: sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==}
+    engines: {node: '>=0.4.0'}
 
   acorn@8.15.0:
     resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
@@ -695,6 +874,10 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
   any-promise@1.3.0:
     resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
 
@@ -707,6 +890,9 @@ packages:
   array-union@2.1.0:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
     engines: {node: '>=8'}
+
+  assertion-error@1.1.0:
+    resolution: {integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==}
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
@@ -755,6 +941,10 @@ packages:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
 
+  chai@4.5.0:
+    resolution: {integrity: sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==}
+    engines: {node: '>=4'}
+
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
@@ -765,6 +955,9 @@ packages:
 
   chardet@2.1.1:
     resolution: {integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==}
+
+  check-error@1.0.3:
+    resolution: {integrity: sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==}
 
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
@@ -832,6 +1025,10 @@ packages:
       supports-color:
         optional: true
 
+  deep-eql@4.1.4:
+    resolution: {integrity: sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==}
+    engines: {node: '>=6'}
+
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
@@ -845,6 +1042,10 @@ packages:
   detect-indent@6.1.0:
     resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
     engines: {node: '>=8'}
+
+  diff-sequences@29.6.3:
+    resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
@@ -880,6 +1081,11 @@ packages:
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
+
+  esbuild@0.21.5:
+    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
+    engines: {node: '>=12'}
+    hasBin: true
 
   esbuild@0.27.2:
     resolution: {integrity: sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==}
@@ -928,6 +1134,9 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
@@ -943,6 +1152,10 @@ packages:
   eventsource@3.0.7:
     resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
     engines: {node: '>=18.0.0'}
+
+  execa@8.0.1:
+    resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
+    engines: {node: '>=16.17'}
 
   express-rate-limit@7.5.1:
     resolution: {integrity: sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==}
@@ -1045,6 +1258,9 @@ packages:
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
+  get-func-name@2.0.2:
+    resolution: {integrity: sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==}
+
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
@@ -1052,6 +1268,10 @@ packages:
   get-proto@1.0.1:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
+
+  get-stream@8.0.1:
+    resolution: {integrity: sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==}
+    engines: {node: '>=16'}
 
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
@@ -1107,6 +1327,10 @@ packages:
     resolution: {integrity: sha512-tsYlhAYpjCKa//8rXZ9DqKEawhPoSytweBC2eNvcaDK+57RZLHGqNs3PZTQO6yekLFSuvA6AlnAfrw1uBvtb+Q==}
     hasBin: true
 
+  human-signals@5.0.0:
+    resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
+    engines: {node: '>=16.17.0'}
+
   iconv-lite@0.7.2:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
@@ -1153,6 +1377,10 @@ packages:
   is-promise@4.0.0:
     resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
+  is-stream@3.0.0:
+    resolution: {integrity: sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   is-subdir@1.2.0:
     resolution: {integrity: sha512-2AT6j+gXe/1ueqbW6fLZJiIw3F8iXGJtt0yDrZaBhAZEG1raiTxKWU+IPqMCzQAXOUCKdA4UDMgacKH25XG2Cw==}
     engines: {node: '>=4'}
@@ -1170,6 +1398,9 @@ packages:
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
     engines: {node: '>=10'}
+
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
   js-yaml@3.14.2:
     resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
@@ -1215,6 +1446,10 @@ packages:
     resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
+  local-pkg@0.5.1:
+    resolution: {integrity: sha512-9rrA30MRRP3gBD3HTGnC6cDFpaE1kVDWxWgqWJUN0RvDNAo+Nz/9GxB+nHOH0ifbVFy0hSA1V6vFDvnx54lTEQ==}
+    engines: {node: '>=14'}
+
   locate-path@5.0.0:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
     engines: {node: '>=8'}
@@ -1228,6 +1463,9 @@ packages:
 
   lodash.startcase@4.4.0:
     resolution: {integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==}
+
+  loupe@2.3.7:
+    resolution: {integrity: sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==}
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -1244,6 +1482,9 @@ packages:
     resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
     engines: {node: '>=18'}
 
+  merge-stream@2.0.0:
+    resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
+
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
@@ -1259,6 +1500,10 @@ packages:
   mime-types@3.0.2:
     resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
     engines: {node: '>=18'}
+
+  mimic-fn@4.0.0:
+    resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
+    engines: {node: '>=12'}
 
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
@@ -1280,12 +1525,21 @@ packages:
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
+  nanoid@3.3.11:
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
   negotiator@1.0.0:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
+
+  npm-run-path@5.3.0:
+    resolution: {integrity: sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -1301,6 +1555,10 @@ packages:
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  onetime@6.0.0:
+    resolution: {integrity: sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==}
+    engines: {node: '>=12'}
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -1320,6 +1578,10 @@ packages:
   p-limit@3.1.0:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
     engines: {node: '>=10'}
+
+  p-limit@5.0.0:
+    resolution: {integrity: sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==}
+    engines: {node: '>=18'}
 
   p-locate@4.1.0:
     resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
@@ -1360,6 +1622,10 @@ packages:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
 
+  path-key@4.0.0:
+    resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
+    engines: {node: '>=12'}
+
   path-to-regexp@8.3.0:
     resolution: {integrity: sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==}
 
@@ -1367,8 +1633,14 @@ packages:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
 
+  pathe@1.1.2:
+    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@1.1.1:
+    resolution: {integrity: sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -1414,6 +1686,10 @@ packages:
       yaml:
         optional: true
 
+  postcss@8.5.6:
+    resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
+    engines: {node: ^10 || ^12 || >=14}
+
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
@@ -1422,6 +1698,10 @@ packages:
     resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
     engines: {node: '>=10.13.0'}
     hasBin: true
+
+  pretty-format@29.7.0:
+    resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
@@ -1448,6 +1728,9 @@ packages:
   raw-body@3.0.2:
     resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
     engines: {node: '>= 0.10'}
+
+  react-is@18.3.1:
+    resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
   read-yaml-file@1.1.0:
     resolution: {integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==}
@@ -1533,6 +1816,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
@@ -1540,6 +1826,10 @@ packages:
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
 
   source-map@0.7.6:
     resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
@@ -1551,9 +1841,15 @@ packages:
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
@@ -1563,9 +1859,16 @@ packages:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
 
+  strip-final-newline@3.0.0:
+    resolution: {integrity: sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==}
+    engines: {node: '>=12'}
+
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
+
+  strip-literal@2.1.1:
+    resolution: {integrity: sha512-631UJ6O00eNGfMiWG78ck80dfBab8X6IVFB51jZK5Icd7XAs60Z5y7QdSd/wGIklnWvRbUNloVzhOKKmutxQ6Q==}
 
   sucrase@3.35.1:
     resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
@@ -1590,12 +1893,23 @@ packages:
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
   tinyexec@0.3.2:
     resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
 
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
+
+  tinypool@0.8.4:
+    resolution: {integrity: sha512-i11VH5gS6IFeLY3gMBQ00/MmLncVP7JLXOw1vlgkytLmJK7QnEr7NXf0LBdxfmNPAeyetukOk0bOYrJrFGjYJQ==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@2.2.1:
+    resolution: {integrity: sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==}
+    engines: {node: '>=14.0.0'}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -1675,6 +1989,10 @@ packages:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
 
+  type-detect@4.1.0:
+    resolution: {integrity: sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==}
+    engines: {node: '>=4'}
+
   type-fest@0.20.2:
     resolution: {integrity: sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==}
     engines: {node: '>=10'}
@@ -1715,9 +2033,75 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
+  vite-node@1.6.1:
+    resolution: {integrity: sha512-YAXkfvGtuTzwWbDSACdJSg4A4DZiAqckWe90Zapc/sEX3XvHcw1NdurM/6od8J207tSDqNbSsgdCacBgvJKFuA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+
+  vite@5.4.21:
+    resolution: {integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+
+  vitest@1.6.1:
+    resolution: {integrity: sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': 1.6.1
+      '@vitest/ui': 1.6.1
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   word-wrap@1.2.5:
@@ -1730,6 +2114,10 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  yocto-queue@1.2.2:
+    resolution: {integrity: sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==}
+    engines: {node: '>=12.20'}
 
   zod-to-json-schema@3.25.1:
     resolution: {integrity: sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==}
@@ -1887,52 +2275,103 @@ snapshots:
       human-id: 4.1.3
       prettier: 2.8.8
 
+  '@esbuild/aix-ppc64@0.21.5':
+    optional: true
+
   '@esbuild/aix-ppc64@0.27.2':
+    optional: true
+
+  '@esbuild/android-arm64@0.21.5':
     optional: true
 
   '@esbuild/android-arm64@0.27.2':
     optional: true
 
+  '@esbuild/android-arm@0.21.5':
+    optional: true
+
   '@esbuild/android-arm@0.27.2':
+    optional: true
+
+  '@esbuild/android-x64@0.21.5':
     optional: true
 
   '@esbuild/android-x64@0.27.2':
     optional: true
 
+  '@esbuild/darwin-arm64@0.21.5':
+    optional: true
+
   '@esbuild/darwin-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/darwin-x64@0.21.5':
     optional: true
 
   '@esbuild/darwin-x64@0.27.2':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.21.5':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.21.5':
     optional: true
 
   '@esbuild/freebsd-x64@0.27.2':
     optional: true
 
+  '@esbuild/linux-arm64@0.21.5':
+    optional: true
+
   '@esbuild/linux-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/linux-arm@0.21.5':
     optional: true
 
   '@esbuild/linux-arm@0.27.2':
     optional: true
 
+  '@esbuild/linux-ia32@0.21.5':
+    optional: true
+
   '@esbuild/linux-ia32@0.27.2':
+    optional: true
+
+  '@esbuild/linux-loong64@0.21.5':
     optional: true
 
   '@esbuild/linux-loong64@0.27.2':
     optional: true
 
+  '@esbuild/linux-mips64el@0.21.5':
+    optional: true
+
   '@esbuild/linux-mips64el@0.27.2':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.21.5':
     optional: true
 
   '@esbuild/linux-ppc64@0.27.2':
     optional: true
 
+  '@esbuild/linux-riscv64@0.21.5':
+    optional: true
+
   '@esbuild/linux-riscv64@0.27.2':
     optional: true
 
+  '@esbuild/linux-s390x@0.21.5':
+    optional: true
+
   '@esbuild/linux-s390x@0.27.2':
+    optional: true
+
+  '@esbuild/linux-x64@0.21.5':
     optional: true
 
   '@esbuild/linux-x64@0.27.2':
@@ -1941,10 +2380,16 @@ snapshots:
   '@esbuild/netbsd-arm64@0.27.2':
     optional: true
 
+  '@esbuild/netbsd-x64@0.21.5':
+    optional: true
+
   '@esbuild/netbsd-x64@0.27.2':
     optional: true
 
   '@esbuild/openbsd-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.21.5':
     optional: true
 
   '@esbuild/openbsd-x64@0.27.2':
@@ -1953,13 +2398,25 @@ snapshots:
   '@esbuild/openharmony-arm64@0.27.2':
     optional: true
 
+  '@esbuild/sunos-x64@0.21.5':
+    optional: true
+
   '@esbuild/sunos-x64@0.27.2':
+    optional: true
+
+  '@esbuild/win32-arm64@0.21.5':
     optional: true
 
   '@esbuild/win32-arm64@0.27.2':
     optional: true
 
+  '@esbuild/win32-ia32@0.21.5':
+    optional: true
+
   '@esbuild/win32-ia32@0.27.2':
+    optional: true
+
+  '@esbuild/win32-x64@0.21.5':
     optional: true
 
   '@esbuild/win32-x64@0.27.2':
@@ -2010,6 +2467,10 @@ snapshots:
       iconv-lite: 0.7.2
     optionalDependencies:
       '@types/node': 20.19.30
+
+  '@jest/schemas@29.6.3':
+    dependencies:
+      '@sinclair/typebox': 0.27.8
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -2209,6 +2670,8 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.55.2':
     optional: true
 
+  '@sinclair/typebox@0.27.8': {}
+
   '@types/estree@1.0.8': {}
 
   '@types/json-schema@7.0.15': {}
@@ -2311,12 +2774,45 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
+  '@vitest/expect@1.6.1':
+    dependencies:
+      '@vitest/spy': 1.6.1
+      '@vitest/utils': 1.6.1
+      chai: 4.5.0
+
+  '@vitest/runner@1.6.1':
+    dependencies:
+      '@vitest/utils': 1.6.1
+      p-limit: 5.0.0
+      pathe: 1.1.2
+
+  '@vitest/snapshot@1.6.1':
+    dependencies:
+      magic-string: 0.30.21
+      pathe: 1.1.2
+      pretty-format: 29.7.0
+
+  '@vitest/spy@1.6.1':
+    dependencies:
+      tinyspy: 2.2.1
+
+  '@vitest/utils@1.6.1':
+    dependencies:
+      diff-sequences: 29.6.3
+      estree-walker: 3.0.3
+      loupe: 2.3.7
+      pretty-format: 29.7.0
+
   accepts@2.0.0:
     dependencies:
       mime-types: 3.0.2
       negotiator: 1.0.0
 
   acorn-jsx@5.3.2(acorn@8.15.0):
+    dependencies:
+      acorn: 8.15.0
+
+  acorn-walk@8.3.4:
     dependencies:
       acorn: 8.15.0
 
@@ -2348,6 +2844,8 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
+  ansi-styles@5.2.0: {}
+
   any-promise@1.3.0: {}
 
   argparse@1.0.10:
@@ -2357,6 +2855,8 @@ snapshots:
   argparse@2.0.1: {}
 
   array-union@2.1.0: {}
+
+  assertion-error@1.1.0: {}
 
   balanced-match@1.0.2: {}
 
@@ -2412,6 +2912,16 @@ snapshots:
 
   callsites@3.1.0: {}
 
+  chai@4.5.0:
+    dependencies:
+      assertion-error: 1.1.0
+      check-error: 1.0.3
+      deep-eql: 4.1.4
+      get-func-name: 2.0.2
+      loupe: 2.3.7
+      pathval: 1.1.1
+      type-detect: 4.1.0
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
@@ -2420,6 +2930,10 @@ snapshots:
   chalk@5.6.2: {}
 
   chardet@2.1.1: {}
+
+  check-error@1.0.3:
+    dependencies:
+      get-func-name: 2.0.2
 
   chokidar@4.0.3:
     dependencies:
@@ -2466,6 +2980,10 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  deep-eql@4.1.4:
+    dependencies:
+      type-detect: 4.1.0
+
   deep-is@0.1.4: {}
 
   depd@2.0.0: {}
@@ -2473,6 +2991,8 @@ snapshots:
   deprecation@2.3.1: {}
 
   detect-indent@6.1.0: {}
+
+  diff-sequences@29.6.3: {}
 
   dir-glob@3.0.1:
     dependencies:
@@ -2504,6 +3024,32 @@ snapshots:
   es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
+
+  esbuild@0.21.5:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.21.5
+      '@esbuild/android-arm': 0.21.5
+      '@esbuild/android-arm64': 0.21.5
+      '@esbuild/android-x64': 0.21.5
+      '@esbuild/darwin-arm64': 0.21.5
+      '@esbuild/darwin-x64': 0.21.5
+      '@esbuild/freebsd-arm64': 0.21.5
+      '@esbuild/freebsd-x64': 0.21.5
+      '@esbuild/linux-arm': 0.21.5
+      '@esbuild/linux-arm64': 0.21.5
+      '@esbuild/linux-ia32': 0.21.5
+      '@esbuild/linux-loong64': 0.21.5
+      '@esbuild/linux-mips64el': 0.21.5
+      '@esbuild/linux-ppc64': 0.21.5
+      '@esbuild/linux-riscv64': 0.21.5
+      '@esbuild/linux-s390x': 0.21.5
+      '@esbuild/linux-x64': 0.21.5
+      '@esbuild/netbsd-x64': 0.21.5
+      '@esbuild/openbsd-x64': 0.21.5
+      '@esbuild/sunos-x64': 0.21.5
+      '@esbuild/win32-arm64': 0.21.5
+      '@esbuild/win32-ia32': 0.21.5
+      '@esbuild/win32-x64': 0.21.5
 
   esbuild@0.27.2:
     optionalDependencies:
@@ -2606,6 +3152,10 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   esutils@2.0.3: {}
 
   etag@1.8.1: {}
@@ -2615,6 +3165,18 @@ snapshots:
   eventsource@3.0.7:
     dependencies:
       eventsource-parser: 3.0.6
+
+  execa@8.0.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      get-stream: 8.0.1
+      human-signals: 5.0.0
+      is-stream: 3.0.0
+      merge-stream: 2.0.0
+      npm-run-path: 5.3.0
+      onetime: 6.0.0
+      signal-exit: 4.1.0
+      strip-final-newline: 3.0.0
 
   express-rate-limit@7.5.1(express@5.2.1):
     dependencies:
@@ -2747,6 +3309,8 @@ snapshots:
 
   function-bind@1.1.2: {}
 
+  get-func-name@2.0.2: {}
+
   get-intrinsic@1.3.0:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -2764,6 +3328,8 @@ snapshots:
     dependencies:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
+
+  get-stream@8.0.1: {}
 
   glob-parent@5.1.2:
     dependencies:
@@ -2821,6 +3387,8 @@ snapshots:
 
   human-id@4.1.3: {}
 
+  human-signals@5.0.0: {}
+
   iconv-lite@0.7.2:
     dependencies:
       safer-buffer: 2.1.2
@@ -2855,6 +3423,8 @@ snapshots:
 
   is-promise@4.0.0: {}
 
+  is-stream@3.0.0: {}
+
   is-subdir@1.2.0:
     dependencies:
       better-path-resolve: 1.0.0
@@ -2866,6 +3436,8 @@ snapshots:
   jose@6.1.3: {}
 
   joycon@3.1.1: {}
+
+  js-tokens@9.0.1: {}
 
   js-yaml@3.14.2:
     dependencies:
@@ -2905,6 +3477,11 @@ snapshots:
 
   load-tsconfig@0.2.5: {}
 
+  local-pkg@0.5.1:
+    dependencies:
+      mlly: 1.8.0
+      pkg-types: 1.3.1
+
   locate-path@5.0.0:
     dependencies:
       p-locate: 4.1.0
@@ -2917,6 +3494,10 @@ snapshots:
 
   lodash.startcase@4.4.0: {}
 
+  loupe@2.3.7:
+    dependencies:
+      get-func-name: 2.0.2
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -2926,6 +3507,8 @@ snapshots:
   media-typer@1.1.0: {}
 
   merge-descriptors@2.0.0: {}
+
+  merge-stream@2.0.0: {}
 
   merge2@1.4.1: {}
 
@@ -2939,6 +3522,8 @@ snapshots:
   mime-types@3.0.2:
     dependencies:
       mime-db: 1.54.0
+
+  mimic-fn@4.0.0: {}
 
   minimatch@3.1.2:
     dependencies:
@@ -2965,9 +3550,15 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
+  nanoid@3.3.11: {}
+
   natural-compare@1.4.0: {}
 
   negotiator@1.0.0: {}
+
+  npm-run-path@5.3.0:
+    dependencies:
+      path-key: 4.0.0
 
   object-assign@4.1.1: {}
 
@@ -2980,6 +3571,10 @@ snapshots:
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
+
+  onetime@6.0.0:
+    dependencies:
+      mimic-fn: 4.0.0
 
   optionator@0.9.4:
     dependencies:
@@ -3003,6 +3598,10 @@ snapshots:
   p-limit@3.1.0:
     dependencies:
       yocto-queue: 0.1.0
+
+  p-limit@5.0.0:
+    dependencies:
+      yocto-queue: 1.2.2
 
   p-locate@4.1.0:
     dependencies:
@@ -3032,11 +3631,17 @@ snapshots:
 
   path-key@3.1.1: {}
 
+  path-key@4.0.0: {}
+
   path-to-regexp@8.3.0: {}
 
   path-type@4.0.0: {}
 
+  pathe@1.1.2: {}
+
   pathe@2.0.3: {}
+
+  pathval@1.1.1: {}
 
   picocolors@1.1.1: {}
 
@@ -3056,13 +3661,27 @@ snapshots:
       mlly: 1.8.0
       pathe: 2.0.3
 
-  postcss-load-config@6.0.1:
+  postcss-load-config@6.0.1(postcss@8.5.6):
     dependencies:
       lilconfig: 3.1.3
+    optionalDependencies:
+      postcss: 8.5.6
+
+  postcss@8.5.6:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
 
   prelude-ls@1.2.1: {}
 
   prettier@2.8.8: {}
+
+  pretty-format@29.7.0:
+    dependencies:
+      '@jest/schemas': 29.6.3
+      ansi-styles: 5.2.0
+      react-is: 18.3.1
 
   proxy-addr@2.0.7:
     dependencies:
@@ -3087,6 +3706,8 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       unpipe: 1.0.0
+
+  react-is@18.3.1: {}
 
   read-yaml-file@1.1.0:
     dependencies:
@@ -3219,9 +3840,13 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@4.1.0: {}
 
   slash@3.0.0: {}
+
+  source-map-js@1.2.1: {}
 
   source-map@0.7.6: {}
 
@@ -3232,7 +3857,11 @@ snapshots:
 
   sprintf-js@1.0.3: {}
 
+  stackback@0.0.2: {}
+
   statuses@2.0.2: {}
+
+  std-env@3.10.0: {}
 
   strip-ansi@6.0.1:
     dependencies:
@@ -3240,7 +3869,13 @@ snapshots:
 
   strip-bom@3.0.0: {}
 
+  strip-final-newline@3.0.0: {}
+
   strip-json-comments@3.1.1: {}
+
+  strip-literal@2.1.1:
+    dependencies:
+      js-tokens: 9.0.1
 
   sucrase@3.35.1:
     dependencies:
@@ -3268,12 +3903,18 @@ snapshots:
     dependencies:
       any-promise: 1.3.0
 
+  tinybench@2.9.0: {}
+
   tinyexec@0.3.2: {}
 
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
+
+  tinypool@0.8.4: {}
+
+  tinyspy@2.2.1: {}
 
   to-regex-range@5.0.1:
     dependencies:
@@ -3289,7 +3930,7 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  tsup@8.5.1(typescript@5.9.3):
+  tsup@8.5.1(postcss@8.5.6)(typescript@5.9.3):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.2)
       cac: 6.7.14
@@ -3300,7 +3941,7 @@ snapshots:
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1
+      postcss-load-config: 6.0.1(postcss@8.5.6)
       resolve-from: 5.0.0
       rollup: 4.55.2
       source-map: 0.7.6
@@ -3309,6 +3950,7 @@ snapshots:
       tinyglobby: 0.2.15
       tree-kill: 1.2.2
     optionalDependencies:
+      postcss: 8.5.6
       typescript: 5.9.3
     transitivePeerDependencies:
       - jiti
@@ -3347,6 +3989,8 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
 
+  type-detect@4.1.0: {}
+
   type-fest@0.20.2: {}
 
   type-is@2.0.1:
@@ -3375,15 +4019,83 @@ snapshots:
 
   vary@1.1.2: {}
 
+  vite-node@1.6.1(@types/node@20.19.30):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      pathe: 1.1.2
+      picocolors: 1.1.1
+      vite: 5.4.21(@types/node@20.19.30)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  vite@5.4.21(@types/node@20.19.30):
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.5.6
+      rollup: 4.55.2
+    optionalDependencies:
+      '@types/node': 20.19.30
+      fsevents: 2.3.3
+
+  vitest@1.6.1(@types/node@20.19.30):
+    dependencies:
+      '@vitest/expect': 1.6.1
+      '@vitest/runner': 1.6.1
+      '@vitest/snapshot': 1.6.1
+      '@vitest/spy': 1.6.1
+      '@vitest/utils': 1.6.1
+      acorn-walk: 8.3.4
+      chai: 4.5.0
+      debug: 4.4.3
+      execa: 8.0.1
+      local-pkg: 0.5.1
+      magic-string: 0.30.21
+      pathe: 1.1.2
+      picocolors: 1.1.1
+      std-env: 3.10.0
+      strip-literal: 2.1.1
+      tinybench: 2.9.0
+      tinypool: 0.8.4
+      vite: 5.4.21(@types/node@20.19.30)
+      vite-node: 1.6.1(@types/node@20.19.30)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 20.19.30
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   word-wrap@1.2.5: {}
 
   wrappy@1.0.2: {}
 
   yocto-queue@0.1.0: {}
+
+  yocto-queue@1.2.2: {}
 
   zod-to-json-schema@3.25.1(zod@3.25.76):
     dependencies:


### PR DESCRIPTION
## Summary

- Adds new `@bretwardjames/ghp-memory` package with pluggable memory backend architecture
- Implements `LocalMemoryBackend` as the always-available file-based storage option
- Creates namespace helpers for consistent memory organization across the codebase
- Includes comprehensive test coverage (39 passing tests)

## Implementation Details

### MemoryBackend Interface
Core interface supporting: `save`, `search`, `list`, `get`, `update`, `delete`, `deleteNamespace`, `isAvailable`

### LocalMemoryBackend
- File-based JSON storage in `~/.ghp/memories/`
- Simple term-frequency search with relevance scoring
- Namespace indexing for fast lookups
- Pagination support for list operations

### Namespace Helpers
Pattern: `{prefix}-{type}-{identifier}` (e.g., `ghp-issue-123`, `ghp-branch-feature-x`)
- `issueNamespace(42)` → `ghp-issue-42`
- `branchNamespace('feature/x')` → `ghp-branch-feature-x`
- Custom prefixes supported for multi-tool setups (e.g., `lift-care`)

### Factory
`createMemoryBackend(config)` creates appropriate backend from configuration. Future backends (mem0, Pinecone, Weaviate) will be added in Phase 7.

## Test plan
- [x] All 39 unit tests passing
- [x] Package builds successfully (ESM + CJS outputs)
- [x] TypeScript types exported correctly

Relates to bretwardjames/handoff#6

🤖 Generated with [Claude Code](https://claude.com/claude-code)