### PR TITLE
fix: centralize extractIssueNumberFromBranch in core

### DIFF
--- a/apps/vscode/src/git-utils.ts
+++ b/apps/vscode/src/git-utils.ts
@@ -25,7 +25,7 @@ import {
 import type { WorktreeInfo } from '@bretwardjames/ghp-core';
 
 // Re-export pure functions that don't need cwd
-export { sanitizeForBranchName } from '@bretwardjames/ghp-core';
+export { sanitizeForBranchName, extractIssueNumberFromBranch } from '@bretwardjames/ghp-core';
 
 export interface GitStatus {
     currentBranch: string;

--- a/apps/vscode/src/pr-workflow.ts
+++ b/apps/vscode/src/pr-workflow.ts
@@ -1,37 +1,14 @@
 import * as vscode from 'vscode';
 import { GitHubAPI } from './github-api';
-import { getCurrentBranch } from './git-utils';
+import { getCurrentBranch, extractIssueNumberFromBranch } from './git-utils';
 import type { NormalizedProjectItem, ProjectWithViews } from './types';
 
 /**
  * PR Workflow module - handles status transitions based on PR lifecycle
  */
 
-/**
- * Extract issue number from a branch name.
- * Supports common patterns like:
- * - user/123-feature-name
- * - feature/123-something
- * - 123-fix-bug
- */
-export function extractIssueNumber(branchName: string): number | null {
-    // Try to find a number pattern like /123- or -123- or just 123 at start
-    const patterns = [
-        /\/(\d+)-/,      // user/123-title
-        /^(\d+)-/,       // 123-title
-        /-(\d+)-/,       // feature-123-title
-        /[/#](\d+)$/,    // ends with #123 or /123
-    ];
-
-    for (const pattern of patterns) {
-        const match = branchName.match(pattern);
-        if (match) {
-            return parseInt(match[1], 10);
-        }
-    }
-
-    return null;
-}
+// Re-export for backwards compatibility
+export const extractIssueNumber = extractIssueNumberFromBranch;
 
 /**
  * Find a project item by issue number

--- a/packages/cli/src/branch-linker.ts
+++ b/packages/cli/src/branch-linker.ts
@@ -11,6 +11,7 @@ import {
     parseBranchLink,
     setBranchLinkInBody,
     removeBranchLinkFromBody,
+    extractIssueNumberFromBranch,
     type RepoInfo,
 } from '@bretwardjames/ghp-core';
 import { api } from './github-api.js';
@@ -75,31 +76,8 @@ export async function getBranchForIssue(
     }
 }
 
-/**
- * Extract issue number from a branch name.
- * Supports common patterns:
- * - user/123-feature-name
- * - feature/123-something
- * - 123-fix-bug
- * - fix-123-something
- */
-export function extractIssueNumberFromBranch(branchName: string): number | null {
-    const patterns = [
-        /\/(\d+)-/,      // user/123-title
-        /^(\d+)-/,       // 123-title
-        /-(\d+)-/,       // feature-123-title
-        /[/#](\d+)$/,    // ends with #123 or /123
-    ];
-
-    for (const pattern of patterns) {
-        const match = branchName.match(pattern);
-        if (match) {
-            return parseInt(match[1], 10);
-        }
-    }
-
-    return null;
-}
+// Re-export from core for backwards compatibility
+export { extractIssueNumberFromBranch };
 
 /**
  * Result of finding an issue for a branch.

--- a/packages/core/src/git-utils.ts
+++ b/packages/core/src/git-utils.ts
@@ -256,6 +256,33 @@ export function generateBranchName(
 }
 
 /**
+ * Extract issue number from a branch name.
+ * Supports common patterns:
+ * - user/123-feature-name
+ * - feature/123-something
+ * - 123-fix-bug
+ * - fix-123-something
+ * - ends with #123 or /123
+ */
+export function extractIssueNumberFromBranch(branchName: string): number | null {
+    const patterns = [
+        /\/(\d+)-/,      // user/123-title
+        /^(\d+)-/,       // 123-title
+        /-(\d+)-/,       // feature-123-title
+        /[/#](\d+)$/,    // ends with #123 or /123
+    ];
+
+    for (const pattern of patterns) {
+        const match = branchName.match(pattern);
+        if (match) {
+            return parseInt(match[1], 10);
+        }
+    }
+
+    return null;
+}
+
+/**
  * Get all local branches
  */
 export async function getLocalBranches(options: GitOptions = {}): Promise<string[]> {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -54,6 +54,7 @@ export {
     getRepositoryRoot,
     sanitizeForBranchName,
     generateBranchName,
+    extractIssueNumberFromBranch,
     getDefaultBranch,
     getLocalBranches,
     getRemoteBranches,


### PR DESCRIPTION
## Summary

- Add `extractIssueNumberFromBranch` to core's git-utils
- CLI: Import from core and re-export for backwards compatibility
- VS Code: Import from core via git-utils, alias as `extractIssueNumber`

Relates to #65

## Test plan

- [x] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)