### PR TITLE
feat: Add agent registry MVP for multi-agent dashboard

### DIFF
--- a/packages/cli/src/commands/agents.ts
+++ b/packages/cli/src/commands/agents.ts
@@ -1,0 +1,287 @@
+/**
+ * Agent management commands for ghp CLI.
+ *
+ * Tracks and manages parallel Claude agents working on issues.
+ */
+
+import chalk from 'chalk';
+import {
+    listAgents,
+    getAgentSummaries,
+    getAgent,
+    getAgentByIssue,
+    unregisterAgent,
+    updateAgent,
+    type AgentSummary,
+    type AgentStatus,
+} from '@bretwardjames/ghp-core';
+import { confirmWithDefault, isInteractive } from '../prompts.js';
+import { killTmuxWindow, isInsideTmux } from '../terminal-utils.js';
+
+// Status colors
+const STATUS_COLORS: Record<AgentStatus, (s: string) => string> = {
+    starting: chalk.yellow,
+    running: chalk.green,
+    stopped: chalk.gray,
+    error: chalk.red,
+};
+
+// Status symbols
+const STATUS_SYMBOLS: Record<AgentStatus, string> = {
+    starting: '○',
+    running: '●',
+    stopped: '○',
+    error: '✗',
+};
+
+/**
+ * Format a single agent row for display
+ */
+function formatAgentRow(agent: AgentSummary): string {
+    const statusColor = STATUS_COLORS[agent.status];
+    const symbol = STATUS_SYMBOLS[agent.status];
+    const portStr = agent.port ? `:${agent.port}` : '';
+
+    return [
+        statusColor(`${symbol} ${agent.status.padEnd(8)}`),
+        chalk.cyan(`#${agent.issueNumber.toString().padEnd(5)}`),
+        agent.issueTitle.substring(0, 40).padEnd(40),
+        chalk.dim(agent.uptime.padStart(8)),
+        chalk.dim(portStr.padStart(6)),
+    ].join('  ');
+}
+
+/**
+ * List all registered agents
+ */
+export async function agentsListCommand(): Promise<void> {
+    const summaries = getAgentSummaries();
+
+    if (summaries.length === 0) {
+        console.log(chalk.dim('No agents running.'));
+        console.log();
+        console.log('Start an agent with:');
+        console.log(chalk.cyan('  ghp start <issue> --parallel'));
+        return;
+    }
+
+    // Header
+    console.log();
+    console.log(chalk.bold('Running Agents'));
+    console.log(chalk.dim('─'.repeat(80)));
+    console.log(
+        chalk.dim('Status'.padEnd(12)),
+        chalk.dim('Issue'.padEnd(7)),
+        chalk.dim('Title'.padEnd(42)),
+        chalk.dim('Uptime'.padStart(8)),
+        chalk.dim('Port'.padStart(6))
+    );
+    console.log(chalk.dim('─'.repeat(80)));
+
+    // Rows
+    for (const agent of summaries) {
+        console.log(formatAgentRow(agent));
+    }
+
+    console.log(chalk.dim('─'.repeat(80)));
+    console.log(chalk.dim(`${summaries.length} agent(s)`));
+    console.log();
+}
+
+interface AgentsStopOptions {
+    force?: boolean;
+    all?: boolean;
+}
+
+/**
+ * Stop an agent (or all agents)
+ */
+export async function agentsStopCommand(
+    issueArg: string | undefined,
+    options: AgentsStopOptions = {}
+): Promise<void> {
+    if (options.all) {
+        await stopAllAgents(options.force);
+        return;
+    }
+
+    if (!issueArg) {
+        console.error(chalk.red('Error:'), 'Issue number required (or use --all)');
+        console.log(chalk.dim('Usage: ghp agents stop <issue> [--force]'));
+        console.log(chalk.dim('       ghp agents stop --all [--force]'));
+        process.exit(1);
+    }
+
+    const issueNumber = parseInt(issueArg, 10);
+    if (isNaN(issueNumber)) {
+        console.error(chalk.red('Error:'), 'Issue must be a number');
+        process.exit(1);
+    }
+
+    const agent = getAgentByIssue(issueNumber);
+    if (!agent) {
+        console.error(chalk.red('Error:'), `No agent found for issue #${issueNumber}`);
+        process.exit(1);
+    }
+
+    // Confirm unless --force
+    if (!options.force && isInteractive()) {
+        const confirmed = await confirmWithDefault(
+            `Stop agent working on #${issueNumber} (${agent.issueTitle})?`,
+            true
+        );
+        if (!confirmed) {
+            console.log('Aborted.');
+            return;
+        }
+    }
+
+    await stopAgent(agent.id, issueNumber);
+}
+
+/**
+ * Stop a single agent by ID
+ */
+async function stopAgent(agentId: string, issueNumber: number): Promise<void> {
+    const agent = getAgent(agentId);
+    if (!agent) {
+        console.error(chalk.red('Error:'), 'Agent not found');
+        return;
+    }
+
+    console.log(chalk.dim(`Stopping agent for #${issueNumber}...`));
+
+    // Try to kill the tmux window if we're in tmux
+    if (isInsideTmux()) {
+        const windowName = `ghp-${issueNumber}`;
+        const result = await killTmuxWindow(windowName);
+        if (result.success) {
+            console.log(chalk.dim(`Killed tmux window: ${windowName}`));
+        } else {
+            console.log(chalk.dim(`Tmux window not found: ${windowName}`));
+        }
+    } else if (agent.pid > 0) {
+        // Fall back to PID-based kill if not in tmux
+        try {
+            process.kill(agent.pid, 'SIGTERM');
+            console.log(chalk.dim(`Sent SIGTERM to PID ${agent.pid}`));
+        } catch (error) {
+            // Process might already be dead
+            console.log(chalk.dim(`Process ${agent.pid} not running`));
+        }
+    }
+
+    // Update status and unregister
+    updateAgent(agentId, { status: 'stopped' });
+    unregisterAgent(agentId);
+
+    console.log(chalk.green('✓'), `Stopped agent for #${issueNumber}`);
+}
+
+/**
+ * Stop all agents
+ */
+async function stopAllAgents(force?: boolean): Promise<void> {
+    const agents = listAgents();
+
+    if (agents.length === 0) {
+        console.log(chalk.dim('No agents running.'));
+        return;
+    }
+
+    // Confirm unless --force
+    if (!force && isInteractive()) {
+        const confirmed = await confirmWithDefault(
+            `Stop all ${agents.length} agent(s)?`,
+            false
+        );
+        if (!confirmed) {
+            console.log('Aborted.');
+            return;
+        }
+    }
+
+    let stopped = 0;
+    for (const agent of agents) {
+        // Try to kill tmux window
+        if (isInsideTmux()) {
+            const windowName = `ghp-${agent.issueNumber}`;
+            await killTmuxWindow(windowName);
+        } else if (agent.pid > 0) {
+            try {
+                process.kill(agent.pid, 'SIGTERM');
+            } catch {
+                // Process might already be dead
+            }
+        }
+        unregisterAgent(agent.id);
+        stopped++;
+    }
+
+    console.log(chalk.green('✓'), `Stopped ${stopped} agent(s)`);
+}
+
+interface AgentsWatchOptions {
+    interval?: string;
+}
+
+/**
+ * Watch agents with auto-refresh (simple dashboard)
+ */
+export async function agentsWatchCommand(options: AgentsWatchOptions = {}): Promise<void> {
+    const intervalSec = parseInt(options.interval || '2', 10);
+    const intervalMs = intervalSec * 1000;
+
+    console.log(chalk.dim(`Watching agents (refresh every ${intervalSec}s, Ctrl+C to exit)`));
+    console.log();
+
+    const refresh = () => {
+        // Clear screen (keep some context)
+        process.stdout.write('\x1b[2J\x1b[H');
+
+        const summaries = getAgentSummaries();
+        const now = new Date().toLocaleTimeString();
+
+        console.log(chalk.bold('Agent Dashboard'), chalk.dim(`[${now}]`));
+        console.log(chalk.dim('─'.repeat(80)));
+
+        if (summaries.length === 0) {
+            console.log();
+            console.log(chalk.dim('No agents running.'));
+            console.log();
+        } else {
+            console.log(
+                chalk.dim('Status'.padEnd(12)),
+                chalk.dim('Issue'.padEnd(7)),
+                chalk.dim('Title'.padEnd(42)),
+                chalk.dim('Uptime'.padStart(8)),
+                chalk.dim('Port'.padStart(6))
+            );
+            console.log(chalk.dim('─'.repeat(80)));
+
+            for (const agent of summaries) {
+                console.log(formatAgentRow(agent));
+            }
+        }
+
+        console.log(chalk.dim('─'.repeat(80)));
+        console.log(chalk.dim(`${summaries.length} agent(s) | Refresh: ${intervalSec}s | Ctrl+C to exit`));
+    };
+
+    // Initial render
+    refresh();
+
+    // Set up refresh interval
+    const timer = setInterval(refresh, intervalMs);
+
+    // Handle Ctrl+C gracefully
+    process.on('SIGINT', () => {
+        clearInterval(timer);
+        console.log();
+        console.log(chalk.dim('Stopped watching.'));
+        process.exit(0);
+    });
+
+    // Keep process alive
+    await new Promise(() => {});
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -28,6 +28,7 @@ import { installCommandsCommand } from './commands/install-commands.js';
 import { worktreeRemoveCommand, worktreeListCommand } from './commands/worktree.js';
 import { planEpicCommand } from './commands/plan-epic.js';
 import { setParentCommand } from './commands/set-parent.js';
+import { agentsListCommand, agentsStopCommand, agentsWatchCommand } from './commands/agents.js';
 
 const program = new Command();
 
@@ -276,5 +277,31 @@ worktreeCmd
     .alias('ls')
     .description('List all worktrees')
     .action(worktreeListCommand);
+
+// Agent management
+const agentsCmd = program
+    .command('agents')
+    .alias('ag')
+    .description('Manage parallel Claude agents');
+
+agentsCmd
+    .command('list')
+    .alias('ls')
+    .description('List all running agents')
+    .action(agentsListCommand);
+
+agentsCmd
+    .command('stop [issue]')
+    .description('Stop an agent (by issue number) or all agents')
+    .option('-f, --force', 'Skip confirmation')
+    .option('-a, --all', 'Stop all agents')
+    .action(agentsStopCommand);
+
+agentsCmd
+    .command('watch')
+    .alias('w')
+    .description('Watch agents with auto-refresh (simple dashboard)')
+    .option('-i, --interval <seconds>', 'Refresh interval in seconds', '2')
+    .action(agentsWatchCommand);
 
 program.parse();

--- a/packages/core/src/agents/index.ts
+++ b/packages/core/src/agents/index.ts
@@ -1,0 +1,30 @@
+/**
+ * Agent Registry Module
+ *
+ * Tracks parallel Claude agents working on issues.
+ */
+
+// Types
+export type {
+    AgentStatus,
+    AgentInstance,
+    AgentRegistry,
+    AgentSummary,
+    RegisterAgentOptions,
+    UpdateAgentOptions,
+} from './types.js';
+
+// Registry functions
+export {
+    getRegistryPath,
+    loadRegistry,
+    saveRegistry,
+    registerAgent,
+    updateAgent,
+    unregisterAgent,
+    getAgent,
+    getAgentByIssue,
+    listAgents,
+    getAgentSummaries,
+    cleanupStaleAgents,
+} from './registry.js';

--- a/packages/core/src/agents/registry.ts
+++ b/packages/core/src/agents/registry.ts
@@ -1,0 +1,236 @@
+/**
+ * File-based Agent Registry
+ *
+ * MVP implementation using JSON file storage.
+ * Future: IPC socket for real-time updates (#107)
+ *
+ * File location: ~/.ghp/agents.json
+ */
+
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
+import { homedir } from 'os';
+import { join, dirname } from 'path';
+import { randomUUID } from 'crypto';
+import type {
+    AgentInstance,
+    AgentRegistry,
+    AgentSummary,
+    AgentStatus,
+    RegisterAgentOptions,
+    UpdateAgentOptions,
+} from './types.js';
+
+const REGISTRY_VERSION = 1;
+
+/**
+ * Get the path to the registry file
+ */
+export function getRegistryPath(): string {
+    return join(homedir(), '.ghp', 'agents.json');
+}
+
+/**
+ * Load the registry from disk, creating if needed
+ */
+export function loadRegistry(): AgentRegistry {
+    const path = getRegistryPath();
+
+    if (!existsSync(path)) {
+        return {
+            version: REGISTRY_VERSION,
+            agents: {},
+            updatedAt: new Date().toISOString(),
+        };
+    }
+
+    try {
+        const content = readFileSync(path, 'utf-8');
+        const registry = JSON.parse(content) as AgentRegistry;
+
+        // Version migration could happen here
+        if (registry.version !== REGISTRY_VERSION) {
+            // For now, just update version
+            registry.version = REGISTRY_VERSION;
+        }
+
+        return registry;
+    } catch (error) {
+        // Corrupted file - start fresh
+        console.error('Warning: Could not parse agents.json, starting fresh');
+        return {
+            version: REGISTRY_VERSION,
+            agents: {},
+            updatedAt: new Date().toISOString(),
+        };
+    }
+}
+
+/**
+ * Save the registry to disk
+ */
+export function saveRegistry(registry: AgentRegistry): void {
+    const path = getRegistryPath();
+    const dir = dirname(path);
+
+    if (!existsSync(dir)) {
+        mkdirSync(dir, { recursive: true });
+    }
+
+    registry.updatedAt = new Date().toISOString();
+    writeFileSync(path, JSON.stringify(registry, null, 2));
+}
+
+/**
+ * Register a new agent
+ */
+export function registerAgent(options: RegisterAgentOptions): AgentInstance {
+    const registry = loadRegistry();
+
+    const agent: AgentInstance = {
+        id: randomUUID(),
+        issueNumber: options.issueNumber,
+        issueTitle: options.issueTitle,
+        pid: options.pid,
+        port: options.port,
+        worktreePath: options.worktreePath,
+        branch: options.branch,
+        status: 'starting',
+        startedAt: new Date().toISOString(),
+    };
+
+    registry.agents[agent.id] = agent;
+    saveRegistry(registry);
+
+    return agent;
+}
+
+/**
+ * Update an existing agent
+ */
+export function updateAgent(id: string, options: UpdateAgentOptions): AgentInstance | null {
+    const registry = loadRegistry();
+    const agent = registry.agents[id];
+
+    if (!agent) {
+        return null;
+    }
+
+    if (options.status !== undefined) {
+        agent.status = options.status;
+    }
+    if (options.port !== undefined) {
+        agent.port = options.port;
+    }
+    if (options.error !== undefined) {
+        agent.error = options.error;
+    }
+
+    agent.lastSeen = new Date().toISOString();
+    saveRegistry(registry);
+
+    return agent;
+}
+
+/**
+ * Unregister an agent (remove from registry)
+ */
+export function unregisterAgent(id: string): boolean {
+    const registry = loadRegistry();
+
+    if (!registry.agents[id]) {
+        return false;
+    }
+
+    delete registry.agents[id];
+    saveRegistry(registry);
+
+    return true;
+}
+
+/**
+ * Get an agent by ID
+ */
+export function getAgent(id: string): AgentInstance | null {
+    const registry = loadRegistry();
+    return registry.agents[id] || null;
+}
+
+/**
+ * Get an agent by issue number
+ */
+export function getAgentByIssue(issueNumber: number): AgentInstance | null {
+    const registry = loadRegistry();
+
+    for (const agent of Object.values(registry.agents)) {
+        if (agent.issueNumber === issueNumber) {
+            return agent;
+        }
+    }
+
+    return null;
+}
+
+/**
+ * List all registered agents
+ */
+export function listAgents(): AgentInstance[] {
+    const registry = loadRegistry();
+    return Object.values(registry.agents);
+}
+
+/**
+ * Calculate human-readable uptime
+ */
+function formatUptime(startedAt: string): string {
+    const start = new Date(startedAt).getTime();
+    const now = Date.now();
+    const diffMs = now - start;
+
+    const seconds = Math.floor(diffMs / 1000);
+    const minutes = Math.floor(seconds / 60);
+    const hours = Math.floor(minutes / 60);
+    const days = Math.floor(hours / 24);
+
+    if (days > 0) {
+        return `${days}d ${hours % 24}h`;
+    }
+    if (hours > 0) {
+        return `${hours}h ${minutes % 60}m`;
+    }
+    if (minutes > 0) {
+        return `${minutes}m ${seconds % 60}s`;
+    }
+    return `${seconds}s`;
+}
+
+/**
+ * Get summaries of all agents for display
+ */
+export function getAgentSummaries(): AgentSummary[] {
+    const agents = listAgents();
+
+    return agents.map((agent) => ({
+        id: agent.id,
+        issueNumber: agent.issueNumber,
+        issueTitle: agent.issueTitle,
+        status: agent.status,
+        port: agent.port,
+        branch: agent.branch,
+        uptime: formatUptime(agent.startedAt),
+    }));
+}
+
+/**
+ * Clean up stale agents (process no longer running)
+ *
+ * TODO: This is a placeholder for the stale detection logic.
+ * The actual implementation depends on how we want to handle this:
+ * - Check if PID exists?
+ * - Use heartbeat mechanism?
+ * - Trust explicit unregister only?
+ */
+export function cleanupStaleAgents(): number {
+    // Placeholder - will be implemented based on chosen strategy
+    // See comment in function for design decision needed
+    return 0;
+}

--- a/packages/core/src/agents/types.ts
+++ b/packages/core/src/agents/types.ts
@@ -1,0 +1,97 @@
+/**
+ * Agent Registry Types
+ *
+ * Defines the data structures for tracking parallel Claude agents.
+ * MVP uses file-based storage; IPC socket planned for #107.
+ */
+
+/**
+ * Current status of an agent
+ */
+export type AgentStatus = 'starting' | 'running' | 'stopped' | 'error';
+
+/**
+ * Represents a running Claude agent working on an issue
+ */
+export interface AgentInstance {
+    /** Unique identifier for this agent instance */
+    id: string;
+
+    /** GitHub issue number this agent is working on */
+    issueNumber: number;
+
+    /** Issue title for display */
+    issueTitle: string;
+
+    /** Process ID of the Claude process */
+    pid: number;
+
+    /** Dev server port (if known/running) */
+    port?: number;
+
+    /** Path to the git worktree */
+    worktreePath: string;
+
+    /** Git branch name */
+    branch: string;
+
+    /** Current status */
+    status: AgentStatus;
+
+    /** ISO timestamp when agent started */
+    startedAt: string;
+
+    /** ISO timestamp of last heartbeat (for future use) */
+    lastSeen?: string;
+
+    /** Optional error message if status is 'error' */
+    error?: string;
+}
+
+/**
+ * The registry file structure
+ */
+export interface AgentRegistry {
+    /** Schema version for future migrations */
+    version: number;
+
+    /** Map of agent ID to instance */
+    agents: Record<string, AgentInstance>;
+
+    /** Last modified timestamp */
+    updatedAt: string;
+}
+
+/**
+ * Options for registering a new agent
+ */
+export interface RegisterAgentOptions {
+    issueNumber: number;
+    issueTitle: string;
+    pid: number;
+    worktreePath: string;
+    branch: string;
+    port?: number;
+}
+
+/**
+ * Options for updating an agent
+ */
+export interface UpdateAgentOptions {
+    status?: AgentStatus;
+    port?: number;
+    error?: string;
+}
+
+/**
+ * Agent summary for display (lightweight)
+ */
+export interface AgentSummary {
+    id: string;
+    issueNumber: number;
+    issueTitle: string;
+    status: AgentStatus;
+    port?: number;
+    branch: string;
+    uptime: string; // Human-readable like "2h 15m"
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -186,6 +186,38 @@ export type { ProjectConventions } from './conventions.js';
 // Types
 // =============================================================================
 
+// =============================================================================
+// Agent Registry (parallel agent tracking)
+// =============================================================================
+
+export {
+    // Registry functions
+    getRegistryPath,
+    loadRegistry,
+    saveRegistry,
+    registerAgent,
+    updateAgent,
+    unregisterAgent,
+    getAgent,
+    getAgentByIssue,
+    listAgents,
+    getAgentSummaries,
+    cleanupStaleAgents,
+} from './agents/index.js';
+
+export type {
+    AgentStatus,
+    AgentInstance,
+    AgentRegistry,
+    AgentSummary,
+    RegisterAgentOptions,
+    UpdateAgentOptions,
+} from './agents/index.js';
+
+// =============================================================================
+// Types
+// =============================================================================
+
 export type {
     // Authentication & Configuration
     TokenProvider,


### PR DESCRIPTION
## Summary

Adds core infrastructure for tracking and managing parallel Claude agents working on issues.

- **Agent Registry**: File-based registry (`~/.ghp/agents.json`) with CRUD operations for tracking agent instances
- **CLI Commands**: `ghp agents list|stop|watch` for managing running agents
- **Tmux Integration**: Named windows (`ghp-{issueNumber}`), automatic cleanup, admin pane
- **Auto-registration**: Agents registered when using `ghp start --parallel`

## Test plan

- [x] `ghp start <issue> --parallel` creates worktree, opens agent window named `ghp-{issue}`, opens admin pane
- [x] `ghp agents list` shows running agents with status, issue, uptime
- [x] `ghp agents stop <issue>` kills tmux window and removes from registry  
- [x] `ghp agents stop --all` stops all agents
- [x] `ghp agents watch` shows auto-refreshing dashboard

## Next steps

- Session Watcher to show real-time agent status and permission requests (#96 follow-up)
- Port detection and allocation for web dev agents

🤖 Generated with [Claude Code](https://claude.com/claude-code)