### PR TITLE
feat: Add Memory MCP tools for persistent context storage

### DIFF
--- a/packages/cli/src/commands/mcp.ts
+++ b/packages/cli/src/commands/mcp.ts
@@ -58,7 +58,7 @@ export async function mcpCommand(options: McpOptions): Promise<void> {
 
         // Show category status
         console.log(chalk.bold('Tool Categories:'));
-        const categories = ['read', 'action'] as const;
+        const categories = ['read', 'action', 'memory'] as const;
         for (const cat of categories) {
             const enabled = mcpConfig.tools?.[cat] !== false;
             const status = enabled
@@ -84,7 +84,8 @@ export async function mcpCommand(options: McpOptions): Promise<void> {
   "mcp": {
     "tools": {
       "read": true,
-      "action": false
+      "action": true,
+      "memory": true
     },
     "disabledTools": ["create_issue"]
   }

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -71,6 +71,8 @@ export interface McpToolsConfig {
     read?: boolean;
     /** Enable action tools (move, done, start, add-issue, etc.) */
     action?: boolean;
+    /** Enable memory tools (memory_save, memory_search, etc.) */
+    memory?: boolean;
 }
 
 /**

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -33,6 +33,7 @@
   "license": "MIT",
   "dependencies": {
     "@bretwardjames/ghp-core": "workspace:*",
+    "@bretwardjames/ghp-memory": "workspace:*",
     "@modelcontextprotocol/sdk": "^1.0.0",
     "zod": "^3.22.0"
   },

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -1,5 +1,6 @@
 import { McpServer, ResourceTemplate } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { GitHubAPI, type TokenProvider, type RepoInfo } from '@bretwardjames/ghp-core';
+import { createMemoryBackend, type MemoryBackend } from '@bretwardjames/ghp-memory';
 import { createRequire } from 'module';
 import { RepoContext } from './context/repo-context.js';
 
@@ -9,6 +10,7 @@ const pkg = require('../package.json');
 export interface ServerContext {
     api: GitHubAPI;
     repoContext: RepoContext;
+    memory: MemoryBackend;
     getRepo: () => Promise<RepoInfo | null>;
     ensureAuthenticated: () => Promise<boolean>;
 }
@@ -27,10 +29,12 @@ export function createServer(tokenProvider: TokenProvider): {
 
     const api = new GitHubAPI({ tokenProvider });
     const repoContext = new RepoContext();
+    const memory = createMemoryBackend();
 
     const context: ServerContext = {
         api,
         repoContext,
+        memory,
         getRepo: () => repoContext.getRepo(),
         ensureAuthenticated: async () => {
             if (api.isAuthenticated) {

--- a/packages/mcp/src/tool-registry.ts
+++ b/packages/mcp/src/tool-registry.ts
@@ -18,6 +18,11 @@ import * as assignTool from './tools/assign.js';
 import * as commentTool from './tools/comment.js';
 import * as setFieldTool from './tools/set-field.js';
 import * as worktreeTool from './tools/worktree.js';
+import * as memorySaveTool from './tools/memory-save.js';
+import * as memorySearchTool from './tools/memory-search.js';
+import * as memoryListTool from './tools/memory-list.js';
+import * as memoryDeleteTool from './tools/memory-delete.js';
+import * as memoryGetTool from './tools/memory-get.js';
 
 // Re-export types
 export type { ToolCategory, McpConfig, McpToolsConfig } from './types.js';
@@ -45,6 +50,12 @@ const TOOLS: ToolModule[] = [
     commentTool,
     setFieldTool,
     worktreeTool,
+    // Memory tools
+    memorySaveTool,
+    memorySearchTool,
+    memoryListTool,
+    memoryDeleteTool,
+    memoryGetTool,
 ];
 
 /**
@@ -54,6 +65,7 @@ const DEFAULT_MCP_CONFIG: McpConfig = {
     tools: {
         read: true,
         action: true,
+        memory: true,
     },
     disabledTools: [],
 };

--- a/packages/mcp/src/tools/index.ts
+++ b/packages/mcp/src/tools/index.ts
@@ -12,6 +12,11 @@ import { register as registerAssign } from './assign.js';
 import { register as registerComment } from './comment.js';
 import { register as registerSetField } from './set-field.js';
 import { register as registerWorktree } from './worktree.js';
+import { register as registerMemorySave } from './memory-save.js';
+import { register as registerMemorySearch } from './memory-search.js';
+import { register as registerMemoryList } from './memory-list.js';
+import { register as registerMemoryDelete } from './memory-delete.js';
+import { register as registerMemoryGet } from './memory-get.js';
 
 /**
  * @deprecated Use registerEnabledTools from '../tool-registry.js' instead.
@@ -34,4 +39,11 @@ export function registerAllTools(server: McpServer, context: ServerContext): voi
 
     // Worktree tools (parallel work)
     registerWorktree(server, context);
+
+    // Memory tools
+    registerMemorySave(server, context);
+    registerMemorySearch(server, context);
+    registerMemoryList(server, context);
+    registerMemoryDelete(server, context);
+    registerMemoryGet(server, context);
 }

--- a/packages/mcp/src/tools/memory-delete.ts
+++ b/packages/mcp/src/tools/memory-delete.ts
@@ -1,0 +1,63 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import * as z from 'zod';
+import type { ServerContext } from '../server.js';
+import type { ToolMeta } from '../types.js';
+
+/** Tool metadata for registry */
+export const meta: ToolMeta = {
+    name: 'memory_delete',
+    category: 'memory',
+};
+
+/**
+ * Registers the memory_delete tool.
+ * Deletes a specific memory by ID.
+ */
+export function register(server: McpServer, context: ServerContext): void {
+    server.registerTool(
+        'memory_delete',
+        {
+            title: 'Delete Memory',
+            description: 'Delete a specific memory by its ID.',
+            inputSchema: {
+                id: z.string().describe('The ID of the memory to delete'),
+            },
+        },
+        async ({ id }) => {
+            try {
+                const deleted = await context.memory.delete(id);
+
+                if (deleted) {
+                    return {
+                        content: [
+                            {
+                                type: 'text',
+                                text: `Successfully deleted memory with ID: ${id}`,
+                            },
+                        ],
+                    };
+                } else {
+                    return {
+                        content: [
+                            {
+                                type: 'text',
+                                text: `Memory with ID "${id}" not found.`,
+                            },
+                        ],
+                        isError: true,
+                    };
+                }
+            } catch (error) {
+                return {
+                    content: [
+                        {
+                            type: 'text',
+                            text: `Error deleting memory: ${error instanceof Error ? error.message : String(error)}`,
+                        },
+                    ],
+                    isError: true,
+                };
+            }
+        }
+    );
+}

--- a/packages/mcp/src/tools/memory-get.ts
+++ b/packages/mcp/src/tools/memory-get.ts
@@ -1,0 +1,77 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import * as z from 'zod';
+import type { ServerContext } from '../server.js';
+import type { ToolMeta } from '../types.js';
+
+/** Tool metadata for registry */
+export const meta: ToolMeta = {
+    name: 'memory_get',
+    category: 'memory',
+};
+
+/**
+ * Registers the memory_get tool.
+ * Gets a specific memory by ID.
+ */
+export function register(server: McpServer, context: ServerContext): void {
+    server.registerTool(
+        'memory_get',
+        {
+            title: 'Get Memory',
+            description: 'Retrieve a specific memory by its ID.',
+            inputSchema: {
+                id: z.string().describe('The ID of the memory to retrieve'),
+            },
+        },
+        async ({ id }) => {
+            try {
+                const memory = await context.memory.get(id);
+
+                if (!memory) {
+                    return {
+                        content: [
+                            {
+                                type: 'text',
+                                text: `Memory with ID "${id}" not found.`,
+                            },
+                        ],
+                        isError: true,
+                    };
+                }
+
+                const lines = [
+                    `ID: ${memory.id}`,
+                    `Namespace: ${memory.namespace}`,
+                    `Created: ${memory.createdAt.toISOString()}`,
+                    `Updated: ${memory.updatedAt.toISOString()}`,
+                    '',
+                    'Content:',
+                    memory.content,
+                ];
+
+                if (memory.metadata && Object.keys(memory.metadata).length > 0) {
+                    lines.push('', 'Metadata:', JSON.stringify(memory.metadata, null, 2));
+                }
+
+                return {
+                    content: [
+                        {
+                            type: 'text',
+                            text: lines.join('\n'),
+                        },
+                    ],
+                };
+            } catch (error) {
+                return {
+                    content: [
+                        {
+                            type: 'text',
+                            text: `Error retrieving memory: ${error instanceof Error ? error.message : String(error)}`,
+                        },
+                    ],
+                    isError: true,
+                };
+            }
+        }
+    );
+}

--- a/packages/mcp/src/tools/memory-list.ts
+++ b/packages/mcp/src/tools/memory-list.ts
@@ -1,0 +1,77 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import * as z from 'zod';
+import type { ServerContext } from '../server.js';
+import type { ToolMeta } from '../types.js';
+
+/** Tool metadata for registry */
+export const meta: ToolMeta = {
+    name: 'memory_list',
+    category: 'memory',
+};
+
+/**
+ * Registers the memory_list tool.
+ * Lists all memories in a namespace.
+ */
+export function register(server: McpServer, context: ServerContext): void {
+    server.registerTool(
+        'memory_list',
+        {
+            title: 'List Memories',
+            description: 'List all memories in a specific namespace.',
+            inputSchema: {
+                namespace: z.string().describe('Namespace to list memories from'),
+                limit: z.number().optional().describe('Maximum number of results (default: 50)'),
+                offset: z.number().optional().describe('Offset for pagination'),
+            },
+        },
+        async ({ namespace, limit, offset }) => {
+            try {
+                const memories = await context.memory.list({
+                    namespace,
+                    limit: limit ?? 50,
+                    offset,
+                });
+
+                if (memories.length === 0) {
+                    return {
+                        content: [
+                            {
+                                type: 'text',
+                                text: `No memories found in namespace "${namespace}".`,
+                            },
+                        ],
+                    };
+                }
+
+                const formatted = memories.map((m, i) => {
+                    const lines = [
+                        `[${i + 1}] ID: ${m.id}`,
+                        `    Created: ${m.createdAt.toISOString()}`,
+                        `    Content: ${m.content.substring(0, 150)}${m.content.length > 150 ? '...' : ''}`,
+                    ];
+                    return lines.join('\n');
+                }).join('\n\n');
+
+                return {
+                    content: [
+                        {
+                            type: 'text',
+                            text: `Found ${memories.length} memories in "${namespace}":\n\n${formatted}`,
+                        },
+                    ],
+                };
+            } catch (error) {
+                return {
+                    content: [
+                        {
+                            type: 'text',
+                            text: `Error listing memories: ${error instanceof Error ? error.message : String(error)}`,
+                        },
+                    ],
+                    isError: true,
+                };
+            }
+        }
+    );
+}

--- a/packages/mcp/src/tools/memory-save.ts
+++ b/packages/mcp/src/tools/memory-save.ts
@@ -1,0 +1,57 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import * as z from 'zod';
+import type { ServerContext } from '../server.js';
+import type { ToolMeta } from '../types.js';
+
+/** Tool metadata for registry */
+export const meta: ToolMeta = {
+    name: 'memory_save',
+    category: 'memory',
+};
+
+/**
+ * Registers the memory_save tool.
+ * Saves content to memory with a namespace.
+ */
+export function register(server: McpServer, context: ServerContext): void {
+    server.registerTool(
+        'memory_save',
+        {
+            title: 'Save Memory',
+            description: 'Save content to memory with a namespace for later retrieval.',
+            inputSchema: {
+                namespace: z.string().describe('Namespace to store the memory in (e.g., "issue-123", "project-notes")'),
+                content: z.string().describe('The content to save'),
+                metadata: z.record(z.unknown()).optional().describe('Optional metadata to attach to the memory'),
+            },
+        },
+        async ({ namespace, content, metadata }) => {
+            try {
+                const memory = await context.memory.save({
+                    namespace,
+                    content,
+                    metadata,
+                });
+
+                return {
+                    content: [
+                        {
+                            type: 'text',
+                            text: `Saved memory with ID: ${memory.id}\nNamespace: ${namespace}\nCreated: ${memory.createdAt.toISOString()}`,
+                        },
+                    ],
+                };
+            } catch (error) {
+                return {
+                    content: [
+                        {
+                            type: 'text',
+                            text: `Error saving memory: ${error instanceof Error ? error.message : String(error)}`,
+                        },
+                    ],
+                    isError: true,
+                };
+            }
+        }
+    );
+}

--- a/packages/mcp/src/tools/memory-search.ts
+++ b/packages/mcp/src/tools/memory-search.ts
@@ -1,0 +1,80 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import * as z from 'zod';
+import type { ServerContext } from '../server.js';
+import type { ToolMeta } from '../types.js';
+
+/** Tool metadata for registry */
+export const meta: ToolMeta = {
+    name: 'memory_search',
+    category: 'memory',
+};
+
+/**
+ * Registers the memory_search tool.
+ * Searches memories by query with optional namespace filter.
+ */
+export function register(server: McpServer, context: ServerContext): void {
+    server.registerTool(
+        'memory_search',
+        {
+            title: 'Search Memories',
+            description: 'Search for memories by query. Optionally filter by namespace.',
+            inputSchema: {
+                query: z.string().describe('Search query to find relevant memories'),
+                namespace: z.string().optional().describe('Optional namespace to search within'),
+                limit: z.number().optional().describe('Maximum number of results (default: 10)'),
+            },
+        },
+        async ({ query, namespace, limit }) => {
+            try {
+                const results = await context.memory.search({
+                    query,
+                    namespace,
+                    limit: limit ?? 10,
+                });
+
+                if (results.length === 0) {
+                    return {
+                        content: [
+                            {
+                                type: 'text',
+                                text: `No memories found matching "${query}"${namespace ? ` in namespace "${namespace}"` : ''}.`,
+                            },
+                        ],
+                    };
+                }
+
+                const formatted = results.map((r, i) => {
+                    const lines = [
+                        `[${i + 1}] ID: ${r.memory.id} (score: ${r.score.toFixed(2)})`,
+                        `    Namespace: ${r.memory.namespace}`,
+                        `    Content: ${r.memory.content.substring(0, 200)}${r.memory.content.length > 200 ? '...' : ''}`,
+                    ];
+                    if (r.memory.metadata && Object.keys(r.memory.metadata).length > 0) {
+                        lines.push(`    Metadata: ${JSON.stringify(r.memory.metadata)}`);
+                    }
+                    return lines.join('\n');
+                }).join('\n\n');
+
+                return {
+                    content: [
+                        {
+                            type: 'text',
+                            text: `Found ${results.length} memories:\n\n${formatted}`,
+                        },
+                    ],
+                };
+            } catch (error) {
+                return {
+                    content: [
+                        {
+                            type: 'text',
+                            text: `Error searching memories: ${error instanceof Error ? error.message : String(error)}`,
+                        },
+                    ],
+                    isError: true,
+                };
+            }
+        }
+    );
+}

--- a/packages/mcp/src/types.ts
+++ b/packages/mcp/src/types.ts
@@ -1,7 +1,7 @@
 /**
  * Tool categories for grouping and enabling/disabling tools
  */
-export type ToolCategory = 'read' | 'action';
+export type ToolCategory = 'read' | 'action' | 'memory';
 
 /**
  * Metadata about a tool for registry purposes
@@ -21,6 +21,8 @@ export interface McpToolsConfig {
     read?: boolean;
     /** Enable action tools (move, done, start, add-issue, etc.) */
     action?: boolean;
+    /** Enable memory tools (memory_save, memory_search, etc.) */
+    memory?: boolean;
 }
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,6 +89,9 @@ importers:
       '@bretwardjames/ghp-core':
         specifier: workspace:*
         version: link:../core
+      '@bretwardjames/ghp-memory':
+        specifier: workspace:*
+        version: link:../memory
       '@modelcontextprotocol/sdk':
         specifier: ^1.0.0
         version: 1.25.3(hono@4.11.4)(zod@3.25.76)


### PR DESCRIPTION
## Summary

- Implements the 5 memory MCP tools: `memory_save`, `memory_search`, `memory_list`, `memory_delete`, `memory_get`
- Integrates `@bretwardjames/ghp-memory` backend into MCP server context
- Adds `memory` as a new tool category (enabled by default)
- Updates `ghp mcp --status` to show memory category

## Test plan

- [x] Run `ghp mcp --status` and verify memory category shows as enabled
- [x] Build MCP package successfully with `pnpm --filter @bretwardjames/ghp-mcp build`
- [x] Memory package tests pass (39/39)
- [x] MCP server starts and lists all 5 memory tools
- [x] Code review passed - no high-confidence issues found

Relates to bretwardjames/handoff#7

🤖 Generated with [Claude Code](https://claude.com/claude-code)