### PR TITLE
feat: Support labels, assignees, and project fields in add-issue

### DIFF
--- a/packages/cli/src/commands/label.ts
+++ b/packages/cli/src/commands/label.ts
@@ -1,0 +1,78 @@
+import chalk from 'chalk';
+import { api } from '../github-api.js';
+import { detectRepository } from '../git-utils.js';
+
+interface LabelOptions {
+    remove?: boolean;
+}
+
+export async function labelCommand(
+    issue: string, 
+    labels: string[], 
+    options: LabelOptions
+): Promise<void> {
+    const issueNumber = parseInt(issue, 10);
+    if (isNaN(issueNumber)) {
+        console.error(chalk.red('Error:'), 'Issue must be a number');
+        process.exit(1);
+    }
+
+    if (labels.length === 0) {
+        console.error(chalk.red('Error:'), 'At least one label is required');
+        console.log(chalk.dim('Usage: ghp label <issue> <labels...>'));
+        process.exit(1);
+    }
+
+    // Detect repository
+    const repo = await detectRepository();
+    if (!repo) {
+        console.error(chalk.red('Error:'), 'Not in a git repository with a GitHub remote');
+        process.exit(1);
+    }
+
+    // Authenticate
+    const authenticated = await api.authenticate();
+    if (!authenticated) {
+        console.error(chalk.red('Error:'), 'Not authenticated. Run', chalk.cyan('ghp auth'));
+        process.exit(1);
+    }
+
+    const applied: string[] = [];
+    const failed: string[] = [];
+
+    for (const label of labels) {
+        let success: boolean;
+        if (options.remove) {
+            success = await api.removeLabelFromIssue(repo, issueNumber, label);
+        } else {
+            success = await api.addLabelToIssue(repo, issueNumber, label);
+        }
+
+        if (success) {
+            applied.push(label);
+        } else {
+            failed.push(label);
+        }
+    }
+
+    if (options.remove) {
+        if (applied.length > 0) {
+            console.log(chalk.green('✓'), `Removed labels from #${issueNumber}:`, applied.join(', '));
+        }
+        if (failed.length > 0) {
+            console.log(chalk.yellow('Warning:'), `Labels not found or couldn't remove:`, failed.join(', '));
+        }
+    } else {
+        if (applied.length > 0) {
+            console.log(chalk.green('✓'), `Added labels to #${issueNumber}:`, applied.join(', '));
+        }
+        if (failed.length > 0) {
+            console.log(chalk.yellow('Warning:'), `Labels not found in repo:`, failed.join(', '));
+            console.log(chalk.dim('Tip: Labels must exist in the repository before applying'));
+        }
+    }
+
+    if (applied.length === 0) {
+        process.exit(1);
+    }
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -14,6 +14,7 @@ import { linkBranchCommand } from './commands/link-branch.js';
 import { unlinkBranchCommand } from './commands/unlink-branch.js';
 import { prCommand } from './commands/pr.js';
 import { assignCommand } from './commands/assign.js';
+import { labelCommand } from './commands/label.js';
 import { authCommand } from './commands/auth.js';
 import { configCommand } from './commands/config.js';
 import { addIssueCommand } from './commands/add-issue.js';
@@ -170,6 +171,13 @@ program
     .option('--remove', 'Remove assignment instead of adding')
     .action(assignCommand);
 
+// Labels
+program
+    .command('label <issue> <labels...>')
+    .description('Add or remove labels from an issue')
+    .option('--remove', 'Remove labels instead of adding')
+    .action(labelCommand);
+
 // Issue creation
 program
     .command('add-issue [title]')
@@ -183,6 +191,9 @@ program
     .option('--list-templates', 'List available issue templates')
     .option('--ai', 'Expand brief title into full issue using AI')
     .option('--parent <issue>', 'Set parent issue number (links as sub-issue)')
+    .option('-l, --labels <labels>', 'Labels to apply (comma-separated)')
+    .option('-a, --assign [users]', 'Assign users (comma-separated, empty for self)')
+    .option('-F, --field <field=value>', 'Set project field (repeatable)', (val: string, acc: string[]) => { acc.push(val); return acc; }, [])
     // Non-interactive flags
     .option('--no-template', 'Skip template selection (blank issue)')
     .option('-fd, --force-defaults', 'Use default values for all prompts (non-interactive mode)')


### PR DESCRIPTION
## Summary
- Add `--labels`, `--assign`, `--field` options to `add-issue` command
- Modify `expandIssueWithAI` to return and apply AI-suggested labels automatically
- Create standalone `label` command for adding/removing labels from existing issues

## Changes
- **packages/cli/src/commands/add-issue.ts**: Added new options and label/assign/field application logic after issue creation
- **packages/cli/src/commands/label.ts**: New command for managing labels on existing issues
- **packages/cli/src/index.ts**: Registered new options and label command

## Usage Examples
```bash
# Create issue with labels
ghp add-issue "Fix bug" --labels bug,high-priority

# Create issue with AI expansion (labels auto-applied)
ghp add-issue "Add auth" --ai

# Create issue with assignment and project fields
ghp add-issue "New feature" --assign --field Priority=High

# Add labels to existing issue
ghp label 42 enhancement documentation

# Remove labels from existing issue
ghp label 42 --remove wontfix
```

## Test plan
- [x] Test `--labels` option with comma-separated labels
- [x] Test `--assign` option (self-assign when empty)
- [x] Test `--field` option with SingleSelect field
- [x] Test standalone `label` command (add/remove)

Relates to #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)