### PR TITLE
fix: Read workspace config from main repo in worktrees

### DIFF
--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -167,10 +167,21 @@ const DEFAULT_CONFIG: Config = {
 };
 
 /**
- * Get the git repository root directory
+ * Get the git repository root directory.
+ * For worktrees, returns the main repository path (where .ghp/config.json lives).
  */
 function getRepoRoot(): string | null {
     try {
+        // Get the common git directory (same for main repo and all worktrees)
+        const gitCommonDir = execSync('git rev-parse --git-common-dir', { encoding: 'utf-8' }).trim();
+
+        // The common dir is typically /path/to/repo/.git
+        // For worktrees it's /path/to/main-repo/.git (not the worktree's .git file)
+        // Remove the /.git suffix to get the repo root
+        if (gitCommonDir.endsWith('/.git')) {
+            return gitCommonDir.slice(0, -5);
+        }
+        // Handle bare repos or unusual setups - fall back to toplevel
         return execSync('git rev-parse --show-toplevel', { encoding: 'utf-8' }).trim();
     } catch {
         return null;


### PR DESCRIPTION
## Summary

- `getRepoRoot()` now uses `git rev-parse --git-common-dir` to find the main repository path
- Fixes `.ghp/config.json` not being found when running from a worktree

## Test plan

- [x] Build passes
- [x] Tested config loading from worktree - correctly reads main repo's `.ghp/config.json`

Relates to #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)