### PR TITLE
fix(extension): ask for base branch when creating worktree

### DIFF
--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -423,6 +423,12 @@
           "default": true,
           "description": "Automatically run setup command in new worktrees"
         },
+        "ghProjects.worktree.defaultBaseBranch": {
+          "type": "string",
+          "enum": ["ask", "main", "current"],
+          "default": "ask",
+          "description": "Default behavior when creating a new branch for a worktree: 'ask' prompts each time, 'main' always uses main branch (with pull), 'current' uses whatever branch is checked out"
+        },
         "ghProjects.parallelWork.autoRunClaude": {
           "type": "boolean",
           "default": true,


### PR DESCRIPTION
## Summary
- Adds prompt asking which branch to base new worktree branches on (main vs current)
- Defaults to main with pull from remote to ensure clean branch lineage
- Adds `ghProjects.worktree.defaultBaseBranch` setting (`ask`/`main`/`current`)

## Problem
Previously, the extension silently created branches from whatever was currently checked out. If you were on a feature branch, your new worktree branch would accidentally be based on that feature branch instead of main.

## Test plan
- [x] Start worktree on issue without linked branch - prompts for base
- [ ] Set `defaultBaseBranch: "main"` - should skip prompt and use main
- [ ] Set `defaultBaseBranch: "current"` - should skip prompt and use current branch
- [ ] Cancel the prompt - should abort worktree creation

Closes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)