### PR TITLE
feat(dashboard): add hook execution and rendering (#149)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -286,6 +286,10 @@ export {
     getFullDiff,
     getChangedFiles,
     gatherDashboardData,
+    // Hook execution
+    getGitHubRepo,
+    executeHook,
+    executeAllHooks,
 } from './dashboard/index.js';
 
 export type {
@@ -294,6 +298,7 @@ export type {
     Commit,
     BranchDashboardData,
     DashboardOptions,
+    HookExecutionResult,
 } from './dashboard/index.js';
 
 // Dashboard Hooks


### PR DESCRIPTION
## Summary

- Add hook execution system to run registered dashboard hooks when `ghp dashboard` is invoked
- Execute hooks in parallel with git data gathering for optimal performance
- Display hook results grouped by category with proper error handling
- Add `getGitHubRepo()` helper to detect repository from git remote

## Implementation Details

### Core Package (`packages/core/src/dashboard/index.ts`)

- `HookExecutionResult` interface to represent hook execution outcomes
- `shellEscape()` function to safely escape shell arguments (prevents command injection)
- `getGitHubRepo()` to extract owner/repo from git remote URLs (SSH and HTTPS)
- `executeHook()` to run a single hook with timeout and JSON parsing
- `executeAllHooks()` to run all hooks in parallel using Promise.all

### CLI Package (`packages/cli/src/commands/dashboard.ts`)

- `formatHookItem()` to format individual hook items with title, summary, timestamp
- `renderHookResults()` to display results grouped by category
- Updated `dashboardCommand()` to fetch enabled hooks and execute them in parallel

## Test plan

- [x] Add a test hook: `ghp dashboard hooks add test-hook --command /path/to/script.sh --category testing`
- [x] Run dashboard: `ghp dashboard` - verify hook output appears in Testing section
- [x] Test failing hook: Hook with `{"success": false, "error": "..."}` shows error message dimmed
- [x] Test invalid JSON: Hook with malformed output shows parse error
- [x] Remove test hook: `ghp dashboard hooks remove test-hook`

Relates to #149

---

Generated with [Claude Code](https://claude.com/claude-code)
