### PR TITLE
docs: add gh to ghp command mapping table

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,32 @@ gh issue create --title "..."
 gh issue view 123
 ```
 
+### Command Mapping Table
+
+| Instead of... | Use... | Notes |
+|---------------|--------|-------|
+| `gh issue create` | `ghp add "title"` | Automatically adds to project |
+| `gh issue view 123` | `ghp open 123` | Shows project fields too |
+| `gh issue list` | `ghp plan` or `ghp work` | `plan` = board view, `work` = my items |
+| `gh issue edit` | `ghp edit 123` | Opens in $EDITOR |
+| `gh issue comment` | `ghp comment 123 -m "msg"` | |
+| `gh issue close` | `ghp done 123` | Also updates project status |
+| `gh pr create` | `ghp pr --create` | Links to issue, sets status |
+| `gh pr view` | `ghp pr` | Shows linked issue context |
+
+### When to Still Use `gh`
+
+These commands don't have `ghp` equivalents - use `gh` directly:
+
+```bash
+gh api ...        # Raw GitHub API calls
+gh auth ...       # Authentication management
+gh release ...    # Release management
+gh repo ...       # Repository operations
+gh gist ...       # Gist operations
+gh ssh-key ...    # SSH key management
+```
+
 ## Project Structure
 
 - `packages/core/` - Shared library (@bretwardjames/ghp-core)


### PR DESCRIPTION
## Summary

- Adds a comprehensive command mapping table to CLAUDE.md showing `gh` → `ghp` equivalents
- Documents which `gh` commands are still preferred (api, auth, release, repo, gist, ssh-key)

## Changes

| Instead of... | Use... | Notes |
|---------------|--------|-------|
| `gh issue create` | `ghp add "title"` | Automatically adds to project |
| `gh issue view 123` | `ghp open 123` | Shows project fields too |
| `gh issue list` | `ghp plan` or `ghp work` | `plan` = board view, `work` = my items |
| `gh issue edit` | `ghp edit 123` | Opens in $EDITOR |
| `gh issue comment` | `ghp comment 123 -m "msg"` | |
| `gh issue close` | `ghp done 123` | Also updates project status |
| `gh pr create` | `ghp pr --create` | Links to issue, sets status |
| `gh pr view` | `ghp pr` | Shows linked issue context |

## Test plan

- [x] Verify CLAUDE.md renders correctly
- [x] Confirm mapping table is accurate against ghp-cli-reference memory

Closes #66

🤖 Generated with [Claude Code](https://claude.ai/code)