### PR TITLE
fix: make check-coordination hook silent to prevent settings corruption

### DIFF
--- a/scripts/check-coordination.sh
+++ b/scripts/check-coordination.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# Coordination check script - runs on Stop/SubagentStop hook
+# Updates heartbeat in agent-status.json
+#
+# IMPORTANT: This script must be SILENT (no stdout output) to comply with
+# Claude Code's hook contract. Any output would be misinterpreted as JSON
+# and could corrupt settings.local.json.
+#
+# Install to: ~/.config/ghp-cli/bin/check-coordination.sh
+
+COORD_DIR="$HOME/.config/ghp-cli/coordination"
+STATUS_FILE="$COORD_DIR/agent-status.json"
+ROLE="${CLAUDE_AGENT_ROLE:-unknown}"
+
+# Exit silently if no role configured
+if [ "$ROLE" = "unknown" ]; then
+    exit 0
+fi
+
+# Ensure coordination directory exists
+mkdir -p "$COORD_DIR"
+
+# Ensure status file exists
+if [ ! -f "$STATUS_FILE" ]; then
+    echo '{}' > "$STATUS_FILE"
+fi
+
+# Update heartbeat
+TIMESTAMP=$(date -Iseconds)
+TMP_FILE=$(mktemp)
+if jq --arg role "$ROLE" \
+   --arg time "$TIMESTAMP" \
+   '.[$role].lastSeen = $time | .[$role].status = "active"' \
+   "$STATUS_FILE" > "$TMP_FILE" 2>/dev/null; then
+    mv "$TMP_FILE" "$STATUS_FILE"
+else
+    rm -f "$TMP_FILE"
+fi
+
+# Exit silently - all coordination data is in agent-status.json
+# Use `ghp agents` or read agent-status.json directly to check status
+exit 0


### PR DESCRIPTION
## Summary

- Fixed `check-coordination.sh` hook that was outputting plain text to stdout
- Claude Code's Stop/SubagentStop hooks expect JSON or silence - plain text violated this contract
- The output was being written to `settings.local.json`, corrupting Claude Code configuration

## Root Cause

The hook script was outputting human-readable text like:
```
=== COORDINATION UPDATE ===
--- epics/146/chat.md ---
...message content...
===========================
```

Claude Code's hook system expects either valid JSON with fields like `continue`, `decision`, etc., or complete silence.

## Fix

- Removed all `echo` statements that output to stdout
- Script still updates `agent-status.json` with heartbeat timestamps
- Added documentation explaining why the script must be silent

## Test plan

- [x] Verify script produces no stdout output with no role set
- [x] Verify script produces no stdout output with `CLAUDE_AGENT_ROLE=principal`
- [x] Verify `agent-status.json` is still updated with heartbeat
- [ ] Run a Claude Code session with the hook and verify `settings.local.json` is not corrupted

Closes #159

🤖 Generated with [Claude Code](https://claude.ai/code)