### PR TITLE
feat(cli): add stop command to pause work on an issue

### DIFF
--- a/packages/cli/src/commands/stop.ts
+++ b/packages/cli/src/commands/stop.ts
@@ -1,0 +1,85 @@
+import chalk from 'chalk';
+import { api } from '../github-api.js';
+import { detectRepository, listWorktrees, removeWorktree } from '../git-utils.js';
+import { removeActiveLabelSafely } from '../active-label.js';
+import { getBranchForIssue, unlinkBranch } from '../branch-linker.js';
+
+interface StopOptions {
+    unlink?: boolean;
+    worktree?: boolean;
+}
+
+export async function stopCommand(issue: string, options: StopOptions): Promise<void> {
+    const issueNumber = parseInt(issue, 10);
+    if (isNaN(issueNumber)) {
+        console.error(chalk.red('Error:'), 'Issue must be a number');
+        process.exit(1);
+    }
+
+    // Detect repository
+    const repo = await detectRepository();
+    if (!repo) {
+        console.error(chalk.red('Error:'), 'Not in a git repository with a GitHub remote');
+        process.exit(1);
+    }
+
+    // Authenticate
+    const authenticated = await api.authenticate();
+    if (!authenticated) {
+        console.error(chalk.red('Error:'), 'Not authenticated. Run', chalk.cyan('ghp auth'));
+        process.exit(1);
+    }
+
+    // Find the item to verify it exists
+    const item = await api.findItemByNumber(repo, issueNumber);
+    if (!item) {
+        console.error(chalk.red('Error:'), `Issue #${issueNumber} not found in any project`);
+        process.exit(1);
+    }
+
+    console.log(chalk.blue('Stopping work on:'), item.title);
+
+    // Remove active label from this issue
+    await removeActiveLabelSafely(repo, issueNumber, false);
+
+    // Get the linked branch for potential operations
+    const branchName = await getBranchForIssue(repo, issueNumber);
+
+    // Handle --unlink flag: remove branch link from issue
+    if (options.unlink) {
+        if (branchName) {
+            const unlinked = await unlinkBranch(repo, issueNumber);
+            if (unlinked) {
+                console.log(chalk.green('✓'), 'Unlinked branch from issue');
+            } else {
+                console.log(chalk.yellow('⚠'), 'No branch link to remove');
+            }
+        } else {
+            console.log(chalk.dim('No branch linked to this issue'));
+        }
+    }
+
+    // Handle --worktree flag: remove the worktree if it exists
+    if (options.worktree) {
+        if (branchName) {
+            const worktrees = await listWorktrees();
+            const worktree = worktrees.find(wt => wt.branch === branchName && !wt.isMain);
+
+            if (worktree) {
+                try {
+                    await removeWorktree(worktree.path);
+                    console.log(chalk.green('✓'), 'Removed worktree:', worktree.path);
+                } catch {
+                    console.log(chalk.yellow('⚠'), 'Could not remove worktree (may have uncommitted changes)');
+                    console.log(chalk.dim('Run:'), `git worktree remove --force "${worktree.path}"`);
+                }
+            } else {
+                console.log(chalk.dim('No worktree found for this issue'));
+            }
+        } else {
+            console.log(chalk.dim('No branch linked to this issue'));
+        }
+    }
+
+    console.log(chalk.green('✓'), 'Stopped work on issue');
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -9,6 +9,7 @@ import { workCommand } from './commands/work.js';
 import { planCommand } from './commands/plan.js';
 import { startCommand } from './commands/start.js';
 import { doneCommand } from './commands/done.js';
+import { stopCommand } from './commands/stop.js';
 import { moveCommand } from './commands/move.js';
 import { switchCommand } from './commands/switch.js';
 import { linkBranchCommand } from './commands/link-branch.js';
@@ -211,6 +212,13 @@ program
     .alias('d')
     .description('Mark an issue as done')
     .action(doneCommand);
+
+program
+    .command('stop <issue>')
+    .description('Stop working on an issue (removes active label without changing status)')
+    .option('--unlink', 'Remove the branch link from the issue')
+    .option('--worktree', 'Remove the worktree for this issue')
+    .action(stopCommand);
 
 program
     .command('move <issue> <status>')


### PR DESCRIPTION
## Summary
- Adds `ghp stop <issue>` command that removes the active label without changing status
- Includes `--unlink` flag to remove the branch link from the issue
- Includes `--worktree` flag to remove the worktree for this issue

## Test plan
- [ ] Run `ghp stop --help` to verify command is registered
- [ ] Test `ghp stop <issue>` removes active label
- [ ] Test `ghp stop <issue> --unlink` removes branch link
- [ ] Test `ghp stop <issue> --worktree` removes worktree

Relates to #167

🤖 Generated with [Claude Code](https://claude.com/claude-code)