### PR TITLE
fix(cli): include issue body in issue-started hook payload

### DIFF
--- a/.changeset/include-issue-body-in-hooks.md
+++ b/.changeset/include-issue-body-in-hooks.md
@@ -1,0 +1,9 @@
+---
+"@bretwardjames/ghp-cli": patch
+---
+
+fix(cli): include issue body in issue-started hook payload
+
+The `issue-started` event hook now includes the actual issue body instead of an empty string. This enables hooks to access the full issue description via `${issue.body}` or `${issue.json}` template variables.
+
+Relates to #217

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -723,13 +723,15 @@ export async function startCommand(issue: string, options: StartOptions): Promis
         console.log();
         console.log(chalk.dim('Running issue-started hooks...'));
 
-        // Note: ProjectItem doesn't include body, but hooks can fetch it if needed
+        // Fetch full issue details for hooks (ProjectItem doesn't include body)
+        const issueDetails = await api.getIssueDetails(repo, issueNumber);
+
         const payload: IssueStartedPayload = {
             repo: `${repo.owner}/${repo.name}`,
             issue: {
                 number: issueNumber,
                 title: item.title,
-                body: '', // Body not available from ProjectItem, hooks can fetch via API
+                body: issueDetails?.body || '',
                 url: `https://github.com/${repo.owner}/${repo.name}/issues/${issueNumber}`,
             },
             branch: finalBranch,

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -53,7 +53,7 @@ addEventHook({
 // Execute hooks for an event
 const payload: IssueStartedPayload = {
   repo: 'owner/repo',
-  issue: { number: 123, title: 'Fix bug', body: '', url: '...' },
+  issue: { number: 123, title: 'Fix bug', body: 'Issue description here...', url: '...' },
   branch: 'feature/123-fix-bug',
 };
 const results = await executeHooksForEvent('issue-started', payload);


### PR DESCRIPTION
## Summary
- Fixes the `issue-started` hook payload to include the actual issue body instead of an empty string
- Fetches full issue details via `api.getIssueDetails()` before building the hook payload
- Updates documentation example in core README to show non-empty body

## Test plan
- [ ] Run `ghp start <issue>` with an `issue-started` hook that uses `${issue.body}`
- [ ] Verify the hook receives the actual issue body content
- [ ] Verify hooks still work if issue body fetch fails (falls back to empty string)

Relates to #217

🤖 Generated with [Claude Code](https://claude.com/claude-code)