### PR TITLE
Add hook modes (fire-and-forget, blocking, interactive)

### DIFF
--- a/.changeset/hook-modes.md
+++ b/.changeset/hook-modes.md
@@ -1,0 +1,18 @@
+---
+"@bretwardjames/ghp-core": minor
+"@bretwardjames/ghp-cli": minor
+---
+
+Add hook execution modes (fire-and-forget, blocking, interactive)
+
+Hooks can now specify a `mode` that controls behavior on completion:
+
+- `fire-and-forget` (default): Silent execution, logged only, never aborts workflow
+- `blocking`: Shows output on failure, non-zero exit aborts workflow
+- `interactive`: Always shows output, prompts user to continue (y), abort (N), or view full output (v)
+
+New CLI options for `ghp hooks add`:
+- `--mode <mode>`: Set the execution mode
+- `--continue-prompt <text>`: Custom prompt text for interactive mode
+
+Hooks can also configure custom exit code classification via the `exitCodes` field in the config file.

--- a/.ragtime/branches/bretwardjames-212-add-hook-modes-fire-and-forget-blocking-in/context.md
+++ b/.ragtime/branches/bretwardjames-212-add-hook-modes-fire-and-forget-blocking-in/context.md
@@ -1,0 +1,83 @@
+---
+type: context
+branch: bretwardjames/212-add-hook-modes-fire-and-forget-blocking-in
+issue: 212
+status: complete
+created: '2026-02-01'
+author: bretwardjames
+---
+
+## Issue
+
+**#212**: Add hook modes (fire-and-forget, blocking, interactive)
+
+
+
+## Description
+
+Extend the hook schema with a `mode` field to control hook behavior:
+- `fire-and-forget` - Silent, logged, cannot abort (default, current behavior)
+- `blocking` - Output shown on failure, exit 1 aborts workflow
+- `interactive` - Always show output, prompt user to continue/abort/view
+
+## Plan
+
+### 1. Schema Changes (`packages/core/src/plugins/types.ts`) ✅
+- [x] Add `HookMode` type: `'fire-and-forget' | 'blocking' | 'interactive'`
+- [x] Add `mode?: HookMode` to `EventHook` interface
+- [x] Add `continuePrompt?: string` for interactive mode custom prompts
+- [x] Add `exitCodes?: { success?: number[]; abort?: number[]; warn?: number[] }`
+- [x] Update `HookResult` with exit code and user decision fields
+
+### 2. Registry Validation (`packages/core/src/plugins/registry.ts`) ✅
+- [x] Add `VALID_MODES` constant
+- [x] Add `isValidMode()` validation function
+- [x] Update `normalizeHook()` to default mode to `'fire-and-forget'`
+- [x] Validate exitCodes structure in `isValidHook()`
+
+### 3. Executor Logic (`packages/core/src/plugins/executor.ts`) ✅
+- [x] Capture exit code from process execution (using spawn instead of exec)
+- [x] Add `classifyExitCode()` function using exitCodes config
+- [x] Implement mode-specific behavior:
+  - `fire-and-forget`: Log silently, never abort
+  - `blocking`: Show output on failure, abort on non-success exit
+  - `interactive`: Show output, prompt y/N/v
+- [x] Add `promptUser()` for interactive mode
+- [x] Add `showInPager()` for "view full output" option
+
+### 4. CLI Interface (`packages/cli/src/commands/event-hooks.ts`) ✅
+- [x] Add `--mode` flag to `ghp hooks add`
+- [x] Add `--continue-prompt` flag
+- [x] Update `HooksAddOptions` interface
+- [x] Update `printHookDetails()` to show mode
+- [x] Update `printHookSummary()` to indicate mode (with color badges)
+
+## Acceptance Criteria
+
+- [x] Hooks can specify mode in config
+- [x] `ghp hooks add` supports `--mode` flag
+- [x] Blocking hooks abort workflow on non-zero exit
+- [x] Interactive hooks prompt user with y/N/v
+- [x] View option opens full output in $PAGER
+
+## Notes
+
+- Used `spawn` instead of `exec` to properly capture exit codes
+- Added `shouldAbort()` helper to check if workflow should be aborted
+- Interactive mode loops on 'v' to allow viewing then re-prompting
+
+## Files Changed
+
+### Core Package (`packages/core/src/plugins/`)
+- `types.ts` - Added HookMode, HookExitCodes, HookOutcome types; extended EventHook and HookResult
+- `registry.ts` - Added VALID_MODES, isValidMode(), getValidModes(); updated normalization and validation
+- `executor.ts` - Replaced exec with spawn; added classifyExitCode(), promptUser(), showInPager(), formatOutputBox()
+- `index.ts` - Exported new types and shouldAbort function
+
+### CLI Package (`packages/cli/src/`)
+- `commands/event-hooks.ts` - Added --mode and --continue-prompt handling; updated display functions
+- `index.ts` - Added --mode and --continue-prompt options to commander
+
+### Documentation
+- `packages/cli/README.md` - Added Hook Modes section with examples
+

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -267,11 +267,21 @@ ghp hooks add <name>                # Register a new hook
                                     #        worktree-created, worktree-removed
   --command <cmd>                   # Shell command with ${var} templates
   --timeout <ms>                    # Timeout in milliseconds (default: 30000)
+  --mode <mode>                     # Execution mode (see below)
+  --continue-prompt <text>          # Custom prompt for interactive mode
 ghp hooks remove <name>             # Remove a hook
 ghp hooks enable <name>             # Enable a hook
 ghp hooks disable <name>            # Disable a hook
 ghp hooks show <name>               # Show hook details
 ```
+
+**Hook Modes:**
+
+| Mode | Behavior |
+|------|----------|
+| `fire-and-forget` | Silent execution, logged only, never aborts (default) |
+| `blocking` | Shows output on failure, non-zero exit aborts workflow |
+| `interactive` | Always shows output, prompts user to continue/abort/view |
 
 **Events and Template Variables:**
 
@@ -295,6 +305,27 @@ ghp hooks add ragtime-context \
 # Now `ghp start 42` will:
 # 1. Create/switch to branch
 # 2. Run ragtime to generate context in .claude/memory/
+```
+
+**Example: Pre-commit Validation (Blocking)**
+
+```bash
+# Block PR creation if tests fail
+ghp hooks add run-tests \
+  --event pr-created \
+  --mode blocking \
+  --command "npm test"
+```
+
+**Example: Interactive Code Review**
+
+```bash
+# Prompt for review before PR creation
+ghp hooks add ai-review \
+  --event pr-created \
+  --mode interactive \
+  --continue-prompt "AI review complete. Proceed with PR?" \
+  --command "ai-review check --branch \${branch}"
 ```
 
 **Example: Tailscale Funnel Integration**

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -215,6 +215,8 @@ eventHooksCmd
     .option('-c, --command <cmd>', 'Shell command to execute (supports ${var} templates)')
     .option('-d, --display-name <name>', 'Human-readable display name')
     .option('-t, --timeout <ms>', 'Timeout in milliseconds (default: 30000)')
+    .option('-m, --mode <mode>', 'Execution mode: fire-and-forget, blocking, or interactive (default: fire-and-forget)')
+    .option('--continue-prompt <text>', 'Custom prompt text for interactive mode (default: "Continue?")')
     .action(eventHooksAddCommand);
 
 eventHooksCmd

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -394,15 +394,20 @@ export {
     enableEventHook,
     disableEventHook,
     getValidEventTypes,
+    getValidModes,
     // Executor
     substituteTemplateVariables,
     executeEventHook,
     executeHooksForEvent,
     hasHooksForEvent,
+    shouldAbort,
 } from './plugins/index.js';
 
 export type {
     EventType,
+    HookMode,
+    HookExitCodes,
+    HookOutcome,
     EventHook,
     EventHooksConfig,
     BaseEventPayload,

--- a/packages/core/src/plugins/executor.ts
+++ b/packages/core/src/plugins/executor.ts
@@ -2,12 +2,10 @@
  * Event Hook Executor - Runs hooks with template variable substitution
  */
 
-import { exec } from 'child_process';
-import { promisify } from 'util';
-import type { EventHook, EventType, EventPayload, HookResult } from './types.js';
+import { spawn } from 'child_process';
+import * as readline from 'readline';
+import type { EventHook, EventType, EventPayload, HookResult, HookOutcome, HookExitCodes } from './types.js';
 import { getHooksForEvent } from './registry.js';
-
-const execAsync = promisify(exec);
 
 // =============================================================================
 // Template Variable Substitution
@@ -102,11 +100,183 @@ export interface HookExecutionOptions {
 }
 
 // =============================================================================
+// Exit Code Classification
+// =============================================================================
+
+/**
+ * Default exit code classification
+ */
+const DEFAULT_EXIT_CODES: Required<HookExitCodes> = {
+    success: [0],
+    abort: [1],
+    warn: [],
+};
+
+/**
+ * Determine the outcome of a hook based on its exit code and configuration
+ */
+function classifyExitCode(exitCode: number | null, exitCodes?: HookExitCodes): HookOutcome {
+    const codes = { ...DEFAULT_EXIT_CODES, ...exitCodes };
+
+    // Null exit code means killed by signal - treat as abort
+    if (exitCode === null) {
+        return 'abort';
+    }
+
+    if (codes.success.includes(exitCode)) {
+        return 'success';
+    }
+    if (codes.warn.includes(exitCode)) {
+        return 'warn';
+    }
+    if (codes.abort.includes(exitCode)) {
+        return 'abort';
+    }
+
+    // Unclassified exit codes default to abort (exitCode 0 already matched above)
+    return 'abort';
+}
+
+// =============================================================================
+// Interactive Mode Support
+// =============================================================================
+
+/**
+ * Format hook output for display in a box
+ */
+function formatOutputBox(hookName: string, output: string, maxLines = 10): string {
+    const lines = output.split('\n');
+    const truncated = lines.length > maxLines;
+    const displayLines = truncated ? lines.slice(0, maxLines) : lines;
+
+    const width = 60;
+    const topBorder = `┌─ ${hookName} ${'─'.repeat(Math.max(0, width - hookName.length - 4))}┐`;
+    const bottomBorder = `└${'─'.repeat(width)}┘`;
+
+    const formattedLines = displayLines.map((line) => {
+        const truncatedLine = line.length > width - 4 ? line.slice(0, width - 7) + '...' : line;
+        return `│ ${truncatedLine.padEnd(width - 2)} │`;
+    });
+
+    if (truncated) {
+        formattedLines.push(`│ ${'... (truncated)'.padEnd(width - 2)} │`);
+    }
+
+    return [topBorder, ...formattedLines, bottomBorder].join('\n');
+}
+
+/**
+ * Prompt user for interactive mode decision
+ * Returns: 'continue' | 'abort' | 'view'
+ */
+async function promptUser(prompt: string): Promise<'continue' | 'abort' | 'view'> {
+    // Safe default for non-interactive contexts (piped input, scripts)
+    if (!process.stdin.isTTY) {
+        return 'abort';
+    }
+
+    const rl = readline.createInterface({
+        input: process.stdin,
+        output: process.stdout,
+    });
+
+    return new Promise((resolve) => {
+        rl.question(`${prompt} (y/N/v) `, (answer) => {
+            rl.close();
+            const normalized = answer.trim().toLowerCase();
+            if (normalized === 'y' || normalized === 'yes') {
+                resolve('continue');
+            } else if (normalized === 'v' || normalized === 'view') {
+                resolve('view');
+            } else {
+                resolve('abort');
+            }
+        });
+    });
+}
+
+/**
+ * Display full output in $PAGER or fallback to console
+ */
+async function showInPager(output: string): Promise<void> {
+    const pager = process.env.PAGER || 'less';
+
+    return new Promise((resolve) => {
+        const child = spawn(pager, [], {
+            stdio: ['pipe', 'inherit', 'inherit'],
+        });
+
+        child.stdin?.write(output);
+        child.stdin?.end();
+
+        child.on('close', () => resolve());
+        child.on('error', () => {
+            // Fallback: just print to console
+            console.log(output);
+            resolve();
+        });
+    });
+}
+
+// =============================================================================
 // Hook Execution
 // =============================================================================
 
 /**
- * Execute a single event hook
+ * Execute a shell command and return stdout, stderr, and exit code
+ */
+async function runCommand(
+    command: string,
+    timeout: number,
+    cwd?: string
+): Promise<{ stdout: string; stderr: string; exitCode: number | null; timedOut: boolean }> {
+    return new Promise((resolve) => {
+        const child = spawn('/bin/sh', ['-c', command], {
+            stdio: ['ignore', 'pipe', 'pipe'],
+            cwd,
+        });
+
+        let stdout = '';
+        let stderr = '';
+        let timedOut = false;
+
+        const timer = setTimeout(() => {
+            timedOut = true;
+            child.kill('SIGTERM');
+        }, timeout);
+
+        child.stdout?.on('data', (data) => {
+            stdout += data.toString();
+        });
+
+        child.stderr?.on('data', (data) => {
+            stderr += data.toString();
+        });
+
+        child.on('close', (code) => {
+            clearTimeout(timer);
+            resolve({
+                stdout: stdout.trim(),
+                stderr: stderr.trim(),
+                exitCode: code,
+                timedOut,
+            });
+        });
+
+        child.on('error', (err) => {
+            clearTimeout(timer);
+            resolve({
+                stdout: '',
+                stderr: err.message,
+                exitCode: null,
+                timedOut: false,
+            });
+        });
+    });
+}
+
+/**
+ * Execute a single event hook with mode-specific behavior
  *
  * @param hook - The hook to execute
  * @param payload - Event payload with template variables
@@ -118,38 +288,80 @@ export async function executeEventHook(
     options: HookExecutionOptions = {}
 ): Promise<HookResult> {
     const startTime = Date.now();
+    const mode = hook.mode || 'fire-and-forget';
 
-    try {
-        // Substitute template variables
-        const command = substituteTemplateVariables(hook.command, payload);
+    // Substitute template variables
+    const command = substituteTemplateVariables(hook.command, payload);
 
-        // Use sh as the shell for maximum portability
-        // /bin/sh exists on all POSIX systems including minimal containers
-        const { stdout } = await execAsync(command, {
-            timeout: hook.timeout || 30000,
-            shell: '/bin/sh',
-            cwd: options.cwd,
-        });
+    // Run the command
+    const { stdout, stderr, exitCode, timedOut } = await runCommand(
+        command,
+        hook.timeout || 30000,
+        options.cwd
+    );
 
-        return {
-            hookName: hook.name,
-            success: true,
-            output: stdout.trim(),
-            duration: Date.now() - startTime,
-        };
-    } catch (error) {
-        const err = error as { stderr?: string; message?: string; killed?: boolean };
-        const errorMessage = err.killed
-            ? `Hook timed out after ${hook.timeout || 30000}ms`
-            : err.stderr || err.message || 'Hook execution failed';
+    const duration = Date.now() - startTime;
 
-        return {
-            hookName: hook.name,
-            success: false,
-            error: errorMessage,
-            duration: Date.now() - startTime,
-        };
+    // Determine outcome based on exit code
+    const outcome = timedOut ? 'abort' : classifyExitCode(exitCode, hook.exitCodes);
+    const success = outcome === 'success' || outcome === 'warn';
+
+    // Build base result
+    const result: HookResult = {
+        hookName: hook.name,
+        success,
+        output: stdout,
+        stderr,
+        duration,
+        exitCode,
+        mode,
+        outcome,
+        aborted: false,
+    };
+
+    // Handle timeout
+    if (timedOut) {
+        result.error = `Hook timed out after ${hook.timeout || 30000}ms`;
+        result.outcome = 'abort';
+        result.success = false;
     }
+
+    // Mode-specific behavior
+    switch (mode) {
+        case 'fire-and-forget':
+            // Silent - just return the result, never abort
+            result.aborted = false;
+            break;
+
+        case 'blocking':
+            // Show output on failure, abort on non-success
+            if (!success) {
+                console.error(formatOutputBox(hook.displayName || hook.name, stderr || stdout));
+                result.aborted = true;
+            }
+            break;
+
+        case 'interactive': {
+            // Always show output, prompt user
+            const displayOutput = stderr || stdout || '(no output)';
+            console.log(formatOutputBox(hook.displayName || hook.name, displayOutput));
+
+            const promptText = hook.continuePrompt || 'Continue?';
+            let decision = await promptUser(promptText);
+
+            // Handle view option - show in pager then re-prompt
+            while (decision === 'view') {
+                await showInPager(stderr || stdout || '(no output)');
+                decision = await promptUser(promptText);
+            }
+
+            result.aborted = decision === 'abort';
+            result.outcome = decision === 'continue' ? 'continue' : 'abort';
+            break;
+        }
+    }
+
+    return result;
 }
 
 /**
@@ -157,6 +369,10 @@ export async function executeEventHook(
  *
  * Returns results for each hook that was executed.
  * Hooks are executed sequentially (not in parallel) to avoid race conditions.
+ *
+ * If a hook with blocking or interactive mode signals abort, execution stops
+ * and the aborted result is included. Check result.aborted on the last item
+ * to determine if the workflow should be aborted.
  *
  * @param event - The event type to fire hooks for
  * @param payload - Event payload with template variables
@@ -173,9 +389,21 @@ export async function executeHooksForEvent(
     for (const hook of hooks) {
         const result = await executeEventHook(hook, payload, options);
         results.push(result);
+
+        // Stop processing if a hook signals abort
+        if (result.aborted) {
+            break;
+        }
     }
 
     return results;
+}
+
+/**
+ * Check if hook results indicate the workflow should abort
+ */
+export function shouldAbort(results: HookResult[]): boolean {
+    return results.some((r) => r.aborted);
 }
 
 /**

--- a/packages/core/src/plugins/index.ts
+++ b/packages/core/src/plugins/index.ts
@@ -5,6 +5,9 @@
 // Types
 export type {
     EventType,
+    HookMode,
+    HookExitCodes,
+    HookOutcome,
     EventHook,
     EventHooksConfig,
     BaseEventPayload,
@@ -33,6 +36,7 @@ export {
     enableEventHook,
     disableEventHook,
     getValidEventTypes,
+    getValidModes,
 } from './registry.js';
 
 // Executor
@@ -41,6 +45,7 @@ export {
     executeEventHook,
     executeHooksForEvent,
     hasHooksForEvent,
+    shouldAbort,
 } from './executor.js';
 
 export type { HookExecutionOptions } from './executor.js';


### PR DESCRIPTION
## Summary

- Adds execution modes to event hooks that control behavior on completion
- `fire-and-forget` (default): Silent execution, logged only, never aborts workflow
- `blocking`: Shows output on failure, non-zero exit aborts workflow
- `interactive`: Always shows output, prompts user to continue/abort/view full output

## Changes

### Core Package
- Added `HookMode`, `HookExitCodes`, `HookOutcome` types
- Extended `EventHook` with `mode`, `exitCodes`, `continuePrompt` fields
- Extended `HookResult` with `exitCode`, `stderr`, `outcome`, `aborted` fields
- Replaced `exec` with `spawn` for proper exit code capture
- Added interactive prompting with y/N/v options and pager support

### CLI Package  
- Added `--mode` and `--continue-prompt` options to `ghp hooks add`
- Updated hook display to show mode badges

## Test plan

- [ ] Add a fire-and-forget hook and verify it runs silently
- [ ] Add a blocking hook that exits non-zero and verify workflow aborts
- [ ] Add an interactive hook and verify y/N/v prompt works
- [ ] Verify 'v' opens output in $PAGER then re-prompts

Relates to #212

🤖 Generated with [Claude Code](https://claude.com/claude-code)