### PR TITLE
feat(core): centralize hook firing in workflow layer

### DIFF
--- a/.changeset/centralize-hook-firing.md
+++ b/.changeset/centralize-hook-firing.md
@@ -1,0 +1,37 @@
+---
+"@bretwardjames/ghp-core": minor
+"@bretwardjames/ghp-cli": patch
+"@bretwardjames/ghp-mcp": patch
+"gh-projects": patch
+---
+
+Centralize hook firing in core workflows
+
+## @bretwardjames/ghp-core (minor)
+
+- Add workflow layer with functions that combine operations + hook firing:
+  - `createIssueWorkflow` - Create issue and fire `issue-created` hook
+  - `startIssueWorkflow` - Start working on issue and fire `issue-started` hook
+  - `createPRWorkflow` - Create PR and fire `pr-created` hook
+  - `createWorktreeWorkflow` - Create worktree and fire `worktree-created` hook
+  - `removeWorktreeWorkflow` - Remove worktree and fire `worktree-removed` hook
+
+- Add `cwd` option to hook executor for firing hooks from inside worktrees
+- Add tests for all workflow functions (24 tests)
+- Add vitest test runner
+
+## @bretwardjames/ghp-cli (patch)
+
+- Hook firing order improved: `worktree-created` fires before `issue-started` in parallel mode
+- Hooks now fire from inside the worktree directory when using `--parallel`
+
+## @bretwardjames/ghp-mcp (patch)
+
+- MCP `start` tool now fires `issue-started` hook
+- MCP `add-issue` tool now fires `issue-created` hook
+
+## gh-projects (patch)
+
+- VS Code extension now fires `issue-started` hook when starting work
+- VS Code extension now fires `worktree-created` and `issue-started` hooks when creating worktrees
+- Hooks fire from inside the worktree directory for correct file placement

--- a/.ragtime/branches/bretwardjames-219-centralize-hook-firing-in-core-workflows/.CONTEXT.md
+++ b/.ragtime/branches/bretwardjames-219-centralize-hook-firing-in-core-workflows/.CONTEXT.md
@@ -1,0 +1,239 @@
+# Issue #219: Centralize Hook Firing in Core Workflows
+
+## Author: bretwardjames
+## Updated: 2026-02-01
+## Branch: bretwardjames/219-centralize-hook-firing-in-core-workflows
+
+---
+
+## Summary
+
+Hook firing is currently scattered across CLI commands. MCP, VS Code extension, and nvim plugin should all fire the same hooks when performing operations. This refactoring creates a workflow layer in `@bretwardjames/ghp-core` that encapsulates both operations AND hook firing.
+
+---
+
+## IMPLEMENTATION PLAN
+
+### Architecture: Fat Workflows (Option B)
+
+Workflows encapsulate **operations + hook firing**. Entry points (CLI, MCP, VS Code, nvim) just call the workflow and handle UI/output.
+
+```
+CLI ─────────────▶ startIssueWorkflow() ──▶ does work + fires hooks
+MCP ─────────────▶ startIssueWorkflow() ──▶ does work + fires hooks
+VSCode ──────────▶ startIssueWorkflow() ──▶ does work + fires hooks
+nvim ────────────▶ startIssueWorkflow() ──▶ does work + fires hooks
+```
+
+### All 6 Hook Events (from types.ts)
+
+| Event | When Fired | Current Status |
+|-------|------------|----------------|
+| `issue-created` | After `ghp add` creates an issue | CLI only |
+| `issue-started` | After `ghp start` creates/switches to branch | CLI only |
+| `pr-created` | After `ghp pr --create` | NOT IMPLEMENTED |
+| `pr-merged` | After PR merge detected | NOT IMPLEMENTED |
+| `worktree-created` | After `ghp start --parallel` creates worktree | CLI only |
+| `worktree-removed` | After `ghp worktree remove` | CLI only |
+
+---
+
+### Phase 1: Create Workflow Layer in Core
+
+Create `packages/core/src/workflows/` with fat workflow functions:
+
+#### 1.1 `packages/core/src/workflows/types.ts`
+- Common types for workflow options and results
+- Re-export hook-related types
+
+#### 1.2 `packages/core/src/workflows/issue.ts`
+
+```typescript
+export interface StartIssueOptions {
+  repo: string;
+  issueNumber: number;
+  parallel?: boolean;
+  review?: boolean;
+  forceDefaults?: boolean;
+  // ... other options from CLI
+}
+
+export interface StartIssueResult {
+  success: boolean;
+  branch: string;
+  worktree?: { path: string; name: string };
+  hookResults: HookResult[];
+}
+
+export async function startIssueWorkflow(options: StartIssueOptions): Promise<StartIssueResult>
+export async function createIssueWorkflow(options: CreateIssueOptions): Promise<CreateIssueResult>
+```
+
+#### 1.3 `packages/core/src/workflows/pr.ts`
+
+```typescript
+export async function createPRWorkflow(options: CreatePROptions): Promise<CreatePRResult>
+// pr-merged is typically detected, not triggered by user action
+```
+
+#### 1.4 `packages/core/src/workflows/worktree.ts`
+
+```typescript
+export async function createWorktreeWorkflow(options: CreateWorktreeOptions): Promise<CreateWorktreeResult>
+export async function removeWorktreeWorkflow(options: RemoveWorktreeOptions): Promise<RemoveWorktreeResult>
+```
+
+#### 1.5 `packages/core/src/workflows/index.ts`
+- Re-export all workflow functions and types
+
+---
+
+### Phase 2: Refactor CLI to Use Workflows
+
+| CLI Command | Current File | Workflow to Use |
+|-------------|--------------|-----------------|
+| `ghp start` | `packages/cli/src/commands/start.ts` | `startIssueWorkflow()` |
+| `ghp add` | `packages/cli/src/commands/add-issue.ts` | `createIssueWorkflow()` |
+| `ghp pr --create` | `packages/cli/src/commands/pr.ts` | `createPRWorkflow()` |
+| `ghp worktree remove` | `packages/cli/src/commands/worktree.ts` | `removeWorktreeWorkflow()` |
+
+**Key refactoring pattern:**
+1. Extract operation logic from CLI command into workflow
+2. CLI handles: argument parsing, interactive prompts, output formatting
+3. Workflow handles: GitHub API calls, git operations, hook firing
+
+---
+
+### Phase 3: Integrate MCP
+
+| MCP Tool | Current File | Integration |
+|----------|--------------|-------------|
+| `start` | `packages/mcp/src/tools/start.ts` | Use `startIssueWorkflow()` |
+| `add-issue` | `packages/mcp/src/tools/add-issue.ts` | Use `createIssueWorkflow()` |
+| `worktree` | `packages/mcp/src/tools/worktree.ts` | Use worktree workflows |
+
+MCP tools currently have their own implementations - they need to be updated to use core workflows.
+
+---
+
+### Phase 4: Integrate VS Code Extension
+
+| Extension Feature | Current File | Integration |
+|-------------------|--------------|-------------|
+| Start Working | `apps/vscode/src/start-working.ts` | Use `startIssueWorkflow()` |
+| Create Issue | Various | Use `createIssueWorkflow()` |
+| PR Workflow | `apps/vscode/src/pr-workflow.ts` | Use `createPRWorkflow()` |
+
+VS Code extension has its own `github-api.ts` wrapper - needs to use core workflows.
+
+---
+
+### Phase 5: Integrate nvim Plugin
+
+The nvim plugin currently shells out to CLI (`run_ghp_sync`), so it already gets hooks. Two options:
+
+**Option A: Keep shelling out (simpler)**
+- No changes needed - already works
+- Hooks fire via CLI
+
+**Option B: Direct workflow calls (better performance)**
+- Would require Node.js bridge or Lua FFI
+- Out of scope for this issue - nvim continues using CLI
+
+**Decision: Option A** - nvim plugin continues shelling out to CLI, which uses the new workflows internally. Hooks fire correctly.
+
+---
+
+## CURRENT STATE
+
+- Branch created with initial commit
+- Codebase analysis complete
+- Implementation plan approved
+- **Phase 1 COMPLETE** - Workflow layer created in core:
+  - `packages/core/src/workflows/types.ts` - All workflow types
+  - `packages/core/src/workflows/issue.ts` - createIssueWorkflow, startIssueWorkflow
+  - `packages/core/src/workflows/pr.ts` - createPRWorkflow
+  - `packages/core/src/workflows/worktree.ts` - createWorktreeWorkflow, removeWorktreeWorkflow
+  - `packages/core/src/workflows/index.ts` - Exports
+  - `packages/core/src/index.ts` - Updated with workflow exports
+- **Phase 2 PARTIAL** - CLI refactoring:
+  - `packages/cli/src/commands/worktree.ts` - Now uses `removeWorktreeWorkflow`
+  - `packages/cli/src/commands/start.ts` - Hooks now fire from inside worktree
+    - Order changed: `worktree-created` fires before `issue-started`
+    - Both hooks fire with `cwd: worktreePath` when worktree created
+  - `packages/cli/src/commands/pr.ts` - Already fires `pr-created` hook
+- **Phase 3 PARTIAL** - MCP integration:
+  - `packages/mcp/src/tools/start.ts` - Now fires `issue-started` hook
+  - `packages/mcp/src/tools/add-issue.ts` - Now fires `issue-created` hook
+  - Note: `worktree.ts` delegates to CLI via `execSync`, so hooks fire through CLI
+- **Phase 4 COMPLETE** - VS Code extension:
+  - `apps/vscode/src/start-working.ts` - Now fires `issue-started` hook
+  - `apps/vscode/src/worktree.ts` - Now fires `worktree-created` and `issue-started` hooks
+    - Hooks fire from inside worktree with `cwd: worktreePath`
+  - Note: `pr-workflow.ts` doesn't create PRs (only tracks status), so no hooks needed
+- **Hook Execution Enhancement**:
+  - Added `HookExecutionOptions` with `cwd` parameter to `executor.ts`
+  - Workflows now fire hooks from inside worktree directory
+  - Plugins (like Ragtime) will create files in the correct location
+- All packages build successfully
+
+---
+
+## WHAT'S LEFT TO DO
+
+- [x] **Phase 1.1**: Create `workflows/types.ts` with common types
+- [x] **Phase 1.2**: Create `workflows/issue.ts` with `startIssueWorkflow()`, `createIssueWorkflow()`
+- [x] **Phase 1.3**: Create `workflows/pr.ts` with `createPRWorkflow()`
+- [x] **Phase 1.4**: Create `workflows/worktree.ts` with worktree workflows
+- [x] **Phase 1.5**: Create `workflows/index.ts` exports
+- [x] **Phase 2.1**: Refactor `start.ts` CLI command - hooks fire from inside worktree
+- [x] **Phase 2.2**: CLI `add-issue.ts` - already fires hooks correctly (workflow not needed due to complex interactive features)
+- [x] **Phase 2.3**: Refactor `pr.ts` CLI command - already fires pr-created hook
+- [x] **Phase 2.4**: Refactor `worktree.ts` CLI command - uses removeWorktreeWorkflow
+- [x] **Phase 3**: Update MCP tools - start.ts and add-issue.ts now fire hooks
+- [x] **Phase 4**: Update VS Code extension - start-working.ts and worktree.ts now fire hooks
+- [x] **Phase 5**: Verify nvim plugin works (no changes needed - shells out to CLI)
+- [x] Update package exports in `packages/core/src/index.ts`
+- [x] Write tests for workflow functions (24 tests passing)
+- [x] CLI commands reviewed - hooks fire correctly, workflows available for MCP/VS Code
+
+## IMPLEMENTATION COMPLETE
+
+All entry points now fire hooks consistently. Tests added for workflow functions.
+
+---
+
+## KEY FILES
+
+### To Create
+- `packages/core/src/workflows/types.ts`
+- `packages/core/src/workflows/issue.ts`
+- `packages/core/src/workflows/pr.ts`
+- `packages/core/src/workflows/worktree.ts`
+- `packages/core/src/workflows/index.ts`
+
+### To Modify
+- `packages/core/src/index.ts` (add workflow exports)
+- `packages/cli/src/commands/start.ts`
+- `packages/cli/src/commands/add-issue.ts`
+- `packages/cli/src/commands/pr.ts`
+- `packages/cli/src/commands/worktree.ts`
+- `packages/mcp/src/tools/start.ts`
+- `packages/mcp/src/tools/add-issue.ts`
+- `packages/mcp/src/tools/worktree.ts`
+- `apps/vscode/src/start-working.ts`
+- `apps/vscode/src/pr-workflow.ts`
+
+### Reference (don't modify)
+- `packages/core/src/plugins/executor.ts` - Hook execution logic
+- `packages/core/src/plugins/types.ts` - Event types and payloads
+- `apps/nvim/lua/ghp/commands.lua` - nvim plugin (shells out to CLI)
+
+---
+
+## NOTES
+
+- nvim plugin already works because it shells out to CLI
+- MCP and VS Code are the primary beneficiaries of this refactoring
+- Keep backward compatibility - CLI behavior should not change
+- Hook firing moves from CLI commands into core workflows

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -32,6 +32,38 @@ const linker = new BranchLinker(api);
 await linker.linkBranch(issueNumber, branchName);
 ```
 
+### Workflows
+
+High-level workflow functions that combine operations with automatic hook firing. These are used by CLI, MCP, and VS Code extension to ensure consistent behavior.
+
+```typescript
+import {
+  createIssueWorkflow,
+  startIssueWorkflow,
+  createPRWorkflow,
+  createWorktreeWorkflow,
+  removeWorktreeWorkflow,
+} from '@bretwardjames/ghp-core';
+
+// Start working on an issue (creates branch, fires hooks)
+const result = await startIssueWorkflow(api, {
+  repo: { owner: 'user', name: 'repo', fullName: 'user/repo' },
+  issueNumber: 123,
+  issueTitle: 'Add new feature',
+  branchPattern: '{user}/{number}-{title}',
+  username: 'developer',
+  parallel: true,
+  worktreePath: '/path/to/worktree',
+});
+
+if (result.success) {
+  console.log(`Working on branch ${result.branch}`);
+  if (result.worktree) {
+    console.log(`Worktree at ${result.worktree.path}`);
+  }
+}
+```
+
 ### Event Hooks
 
 Register and execute lifecycle event hooks:
@@ -56,10 +88,20 @@ const payload: IssueStartedPayload = {
   issue: { number: 123, title: 'Fix bug', body: 'Issue description here...', url: '...' },
   branch: 'feature/123-fix-bug',
 };
-const results = await executeHooksForEvent('issue-started', payload);
+
+// Hooks can execute in a specific directory (e.g., inside a worktree)
+const results = await executeHooksForEvent('issue-started', payload, {
+  cwd: '/path/to/worktree',
+});
 ```
 
-Available events: `issue-created`, `issue-started`, `pr-created`, `pr-merged`
+Available events:
+- `issue-created` - Fired when a new issue is created
+- `issue-started` - Fired when starting work on an issue
+- `pr-created` - Fired when a pull request is created
+- `pr-merged` - Fired when a pull request is merged
+- `worktree-created` - Fired when a worktree is created
+- `worktree-removed` - Fired when a worktree is removed
 
 ## License
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,6 +20,8 @@
     "build": "tsup src/index.ts --format cjs,esm --dts",
     "dev": "tsup src/index.ts --format cjs,esm --dts --watch",
     "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "prepublishOnly": "npm run build"
   },
   "keywords": [
@@ -44,6 +46,7 @@
   "devDependencies": {
     "@types/node": "^20.10.0",
     "tsup": "^8.0.0",
-    "typescript": "^5.3.2"
+    "typescript": "^5.3.2",
+    "vitest": "^3.0.5"
   }
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -340,6 +340,42 @@ export type {
 } from './dashboard/hooks.js';
 
 // =============================================================================
+// Workflows (Centralized Operations + Hook Firing)
+// =============================================================================
+
+export {
+    // Issue workflows
+    createIssueWorkflow,
+    startIssueWorkflow,
+    // PR workflows
+    createPRWorkflow,
+    // Worktree workflows
+    createWorktreeWorkflow,
+    removeWorktreeWorkflow,
+} from './workflows/index.js';
+
+export type {
+    // Common types
+    WorkflowResult,
+    IssueInfo as WorkflowIssueInfo,
+    WorktreeInfo as WorkflowWorktreeInfo,
+    // Issue workflow types
+    CreateIssueOptions,
+    CreateIssueResult,
+    StartIssueOptions,
+    StartIssueResult,
+    // PR workflow types
+    CreatePROptions,
+    CreatePRResult,
+    PRInfo,
+    // Worktree workflow types
+    CreateWorktreeOptions,
+    CreateWorktreeResult,
+    RemoveWorktreeOptions,
+    RemoveWorktreeResult,
+} from './workflows/index.js';
+
+// =============================================================================
 // Event Hooks System
 // =============================================================================
 
@@ -378,4 +414,5 @@ export type {
     WorktreeRemovedPayload,
     EventPayload,
     HookResult,
+    HookExecutionOptions,
 } from './plugins/index.js';

--- a/packages/core/src/plugins/index.ts
+++ b/packages/core/src/plugins/index.ts
@@ -42,3 +42,5 @@ export {
     executeHooksForEvent,
     hasHooksForEvent,
 } from './executor.js';
+
+export type { HookExecutionOptions } from './executor.js';

--- a/packages/core/src/workflows/index.ts
+++ b/packages/core/src/workflows/index.ts
@@ -1,0 +1,66 @@
+/**
+ * Workflows - Centralized Operations with Hook Firing
+ *
+ * This module provides workflow functions that combine operations with
+ * automatic hook firing. All entry points (CLI, MCP, VS Code, nvim)
+ * should use these workflows to ensure consistent hook behavior.
+ *
+ * @example
+ * ```typescript
+ * import {
+ *   createIssueWorkflow,
+ *   startIssueWorkflow,
+ *   createPRWorkflow,
+ *   createWorktreeWorkflow,
+ *   removeWorktreeWorkflow,
+ * } from '@bretwardjames/ghp-core';
+ *
+ * // Create an issue with hooks
+ * const result = await createIssueWorkflow(api, {
+ *   repo,
+ *   title: 'New feature',
+ *   projectId: 'PVT_xxx',
+ * });
+ *
+ * // Hook results are included in the response
+ * for (const hookResult of result.hookResults) {
+ *   console.log(`Hook ${hookResult.hookName}: ${hookResult.success ? 'OK' : 'FAILED'}`);
+ * }
+ * ```
+ */
+
+// =============================================================================
+// Workflow Functions
+// =============================================================================
+
+export { createIssueWorkflow, startIssueWorkflow } from './issue.js';
+export { createPRWorkflow } from './pr.js';
+export { createWorktreeWorkflow, removeWorktreeWorkflow } from './worktree.js';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export type {
+    // Common types
+    WorkflowResult,
+    IssueInfo,
+    WorktreeInfo,
+
+    // Issue workflow types
+    CreateIssueOptions,
+    CreateIssueResult,
+    StartIssueOptions,
+    StartIssueResult,
+
+    // PR workflow types
+    CreatePROptions,
+    CreatePRResult,
+    PRInfo,
+
+    // Worktree workflow types
+    CreateWorktreeOptions,
+    CreateWorktreeResult,
+    RemoveWorktreeOptions,
+    RemoveWorktreeResult,
+} from './types.js';

--- a/packages/core/src/workflows/issue.test.ts
+++ b/packages/core/src/workflows/issue.test.ts
@@ -1,0 +1,315 @@
+/**
+ * Tests for issue workflows
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createIssueWorkflow, startIssueWorkflow } from './issue.js';
+import type { RepoInfo } from '../types.js';
+import type { GitHubAPI } from '../github-api.js';
+
+// Mock git-utils
+vi.mock('../git-utils.js', () => ({
+    createBranch: vi.fn(),
+    checkoutBranch: vi.fn(),
+    branchExists: vi.fn(),
+    generateBranchName: vi.fn(),
+    getCurrentBranch: vi.fn(),
+}));
+
+// Mock hook executor
+vi.mock('../plugins/executor.js', () => ({
+    executeHooksForEvent: vi.fn(),
+    hasHooksForEvent: vi.fn(),
+}));
+
+// Mock worktree workflow
+vi.mock('./worktree.js', () => ({
+    createWorktreeWorkflow: vi.fn(),
+}));
+
+import { createBranch, checkoutBranch, branchExists, generateBranchName } from '../git-utils.js';
+import { executeHooksForEvent, hasHooksForEvent } from '../plugins/executor.js';
+import { createWorktreeWorkflow } from './worktree.js';
+
+const mockRepo: RepoInfo = {
+    owner: 'testowner',
+    name: 'testrepo',
+    fullName: 'testowner/testrepo',
+};
+
+// Create a mock API object
+function createMockApi(): Partial<GitHubAPI> {
+    return {
+        createIssue: vi.fn(),
+        addToProject: vi.fn(),
+        getStatusField: vi.fn(),
+        updateItemStatus: vi.fn(),
+        addLabelToIssue: vi.fn(),
+        updateAssignees: vi.fn(),
+        addSubIssue: vi.fn(),
+        findItemByNumber: vi.fn(),
+    };
+}
+
+describe('createIssueWorkflow', () => {
+    let mockApi: ReturnType<typeof createMockApi>;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockApi = createMockApi();
+    });
+
+    it('should create an issue and fire hooks', async () => {
+        vi.mocked(mockApi.createIssue).mockResolvedValue({ number: 123, id: 'issue-id' });
+        vi.mocked(mockApi.addToProject).mockResolvedValue('item-id');
+        vi.mocked(hasHooksForEvent).mockReturnValue(true);
+        vi.mocked(executeHooksForEvent).mockResolvedValue([
+            { hookName: 'notify-hook', success: true },
+        ]);
+
+        const result = await createIssueWorkflow(mockApi as GitHubAPI, {
+            repo: mockRepo,
+            title: 'Test Issue',
+            body: 'Issue body',
+            projectId: 'project-123',
+        });
+
+        expect(result.success).toBe(true);
+        expect(result.issue?.number).toBe(123);
+        expect(result.issue?.title).toBe('Test Issue');
+        expect(result.projectItemId).toBe('item-id');
+        expect(result.hookResults).toHaveLength(1);
+
+        expect(executeHooksForEvent).toHaveBeenCalledWith(
+            'issue-created',
+            expect.objectContaining({
+                repo: 'testowner/testrepo',
+                issue: expect.objectContaining({
+                    number: 123,
+                    title: 'Test Issue',
+                    body: 'Issue body',
+                }),
+            })
+        );
+    });
+
+    it('should set initial status when provided', async () => {
+        vi.mocked(mockApi.createIssue).mockResolvedValue({ number: 123, id: 'issue-id' });
+        vi.mocked(mockApi.addToProject).mockResolvedValue('item-id');
+        vi.mocked(mockApi.getStatusField).mockResolvedValue({
+            fieldId: 'field-123',
+            options: [
+                { id: 'opt-1', name: 'Todo' },
+                { id: 'opt-2', name: 'In Progress' },
+            ],
+        });
+        vi.mocked(mockApi.updateItemStatus).mockResolvedValue(true);
+        vi.mocked(hasHooksForEvent).mockReturnValue(false);
+
+        const result = await createIssueWorkflow(mockApi as GitHubAPI, {
+            repo: mockRepo,
+            title: 'Test Issue',
+            projectId: 'project-123',
+            status: 'In Progress',
+        });
+
+        expect(result.success).toBe(true);
+        expect(mockApi.updateItemStatus).toHaveBeenCalledWith(
+            'project-123',
+            'item-id',
+            'field-123',
+            'opt-2'
+        );
+    });
+
+    it('should apply labels when provided', async () => {
+        vi.mocked(mockApi.createIssue).mockResolvedValue({ number: 123, id: 'issue-id' });
+        vi.mocked(mockApi.addToProject).mockResolvedValue('item-id');
+        vi.mocked(mockApi.addLabelToIssue).mockResolvedValue(true);
+        vi.mocked(hasHooksForEvent).mockReturnValue(false);
+
+        const result = await createIssueWorkflow(mockApi as GitHubAPI, {
+            repo: mockRepo,
+            title: 'Test Issue',
+            projectId: 'project-123',
+            labels: ['bug', 'high-priority'],
+        });
+
+        expect(result.success).toBe(true);
+        expect(mockApi.addLabelToIssue).toHaveBeenCalledTimes(2);
+        expect(mockApi.addLabelToIssue).toHaveBeenCalledWith(mockRepo, 123, 'bug');
+        expect(mockApi.addLabelToIssue).toHaveBeenCalledWith(mockRepo, 123, 'high-priority');
+    });
+
+    it('should link to parent issue when provided', async () => {
+        vi.mocked(mockApi.createIssue).mockResolvedValue({ number: 123, id: 'issue-id' });
+        vi.mocked(mockApi.addToProject).mockResolvedValue('item-id');
+        vi.mocked(mockApi.addSubIssue).mockResolvedValue(true);
+        vi.mocked(hasHooksForEvent).mockReturnValue(false);
+
+        const result = await createIssueWorkflow(mockApi as GitHubAPI, {
+            repo: mockRepo,
+            title: 'Sub-issue',
+            projectId: 'project-123',
+            parentIssueNumber: 100,
+        });
+
+        expect(result.success).toBe(true);
+        expect(mockApi.addSubIssue).toHaveBeenCalledWith(mockRepo, 100, 123);
+    });
+
+    it('should handle API errors gracefully', async () => {
+        vi.mocked(mockApi.createIssue).mockResolvedValue(null);
+
+        const result = await createIssueWorkflow(mockApi as GitHubAPI, {
+            repo: mockRepo,
+            title: 'Test Issue',
+            projectId: 'project-123',
+        });
+
+        expect(result.success).toBe(false);
+        expect(result.error).toBe('Failed to create issue');
+    });
+});
+
+describe('startIssueWorkflow', () => {
+    let mockApi: ReturnType<typeof createMockApi>;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockApi = createMockApi();
+    });
+
+    it('should create branch and fire hooks in normal mode', async () => {
+        vi.mocked(branchExists).mockResolvedValue(false);
+        vi.mocked(createBranch).mockResolvedValue(undefined);
+        vi.mocked(checkoutBranch).mockResolvedValue(undefined);
+        vi.mocked(generateBranchName).mockReturnValue('testuser/123-test-issue');
+        vi.mocked(hasHooksForEvent).mockReturnValue(true);
+        vi.mocked(executeHooksForEvent).mockResolvedValue([
+            { hookName: 'setup-hook', success: true },
+        ]);
+
+        const result = await startIssueWorkflow(mockApi as GitHubAPI, {
+            repo: mockRepo,
+            issueNumber: 123,
+            issueTitle: 'Test Issue',
+            branchPattern: '{user}/{number}-{title}',
+            username: 'testuser',
+        });
+
+        expect(result.success).toBe(true);
+        expect(result.branch).toBe('testuser/123-test-issue');
+        expect(result.branchCreated).toBe(true);
+        expect(result.hookResults).toHaveLength(1);
+
+        expect(executeHooksForEvent).toHaveBeenCalledWith(
+            'issue-started',
+            expect.objectContaining({
+                repo: 'testowner/testrepo',
+                issue: expect.objectContaining({
+                    number: 123,
+                    title: 'Test Issue',
+                }),
+                branch: 'testuser/123-test-issue',
+            }),
+            { cwd: undefined }
+        );
+    });
+
+    it('should use linked branch when provided', async () => {
+        vi.mocked(checkoutBranch).mockResolvedValue(undefined);
+        vi.mocked(hasHooksForEvent).mockReturnValue(false);
+
+        const result = await startIssueWorkflow(mockApi as GitHubAPI, {
+            repo: mockRepo,
+            issueNumber: 123,
+            issueTitle: 'Test Issue',
+            linkedBranch: 'existing-branch',
+        });
+
+        expect(result.success).toBe(true);
+        expect(result.branch).toBe('existing-branch');
+        expect(result.branchCreated).toBe(false);
+        expect(generateBranchName).not.toHaveBeenCalled();
+    });
+
+    it('should create worktree in parallel mode and fire hooks from inside', async () => {
+        vi.mocked(branchExists).mockResolvedValue(false);
+        vi.mocked(createBranch).mockResolvedValue(undefined);
+        vi.mocked(generateBranchName).mockReturnValue('testuser/123-test-issue');
+        vi.mocked(createWorktreeWorkflow).mockResolvedValue({
+            success: true,
+            worktree: {
+                path: '/worktrees/testrepo/123-test-issue',
+                name: '123-test-issue',
+            },
+            alreadyExisted: false,
+            branch: 'testuser/123-test-issue',
+            hookResults: [{ hookName: 'worktree-hook', success: true }],
+        });
+        vi.mocked(hasHooksForEvent).mockReturnValue(true);
+        vi.mocked(executeHooksForEvent).mockResolvedValue([
+            { hookName: 'issue-hook', success: true },
+        ]);
+
+        const result = await startIssueWorkflow(mockApi as GitHubAPI, {
+            repo: mockRepo,
+            issueNumber: 123,
+            issueTitle: 'Test Issue',
+            parallel: true,
+            worktreePath: '/worktrees/testrepo/123-test-issue',
+            branchPattern: '{user}/{number}-{title}',
+            username: 'testuser',
+        });
+
+        expect(result.success).toBe(true);
+        expect(result.worktree?.path).toBe('/worktrees/testrepo/123-test-issue');
+        expect(result.worktreeCreated).toBe(true);
+
+        // Should have hooks from both worktree and issue-started
+        expect(result.hookResults).toHaveLength(2);
+        expect(result.hookResults[0].hookName).toBe('worktree-hook');
+        expect(result.hookResults[1].hookName).toBe('issue-hook');
+
+        // issue-started hook should fire from inside the worktree
+        expect(executeHooksForEvent).toHaveBeenCalledWith(
+            'issue-started',
+            expect.any(Object),
+            { cwd: '/worktrees/testrepo/123-test-issue' }
+        );
+    });
+
+    it('should require worktreePath in parallel mode', async () => {
+        vi.mocked(branchExists).mockResolvedValue(false);
+        vi.mocked(createBranch).mockResolvedValue(undefined);
+        vi.mocked(generateBranchName).mockReturnValue('testuser/123-test-issue');
+
+        const result = await startIssueWorkflow(mockApi as GitHubAPI, {
+            repo: mockRepo,
+            issueNumber: 123,
+            issueTitle: 'Test Issue',
+            parallel: true,
+            // worktreePath missing
+        });
+
+        expect(result.success).toBe(false);
+        expect(result.error).toContain('worktreePath is required');
+    });
+
+    it('should skip hooks in review mode', async () => {
+        vi.mocked(checkoutBranch).mockResolvedValue(undefined);
+        vi.mocked(hasHooksForEvent).mockReturnValue(true);
+
+        const result = await startIssueWorkflow(mockApi as GitHubAPI, {
+            repo: mockRepo,
+            issueNumber: 123,
+            issueTitle: 'Test Issue',
+            linkedBranch: 'existing-branch',
+            review: true,
+        });
+
+        expect(result.success).toBe(true);
+        expect(executeHooksForEvent).not.toHaveBeenCalled();
+    });
+});

--- a/packages/core/src/workflows/issue.ts
+++ b/packages/core/src/workflows/issue.ts
@@ -1,0 +1,338 @@
+/**
+ * Issue Workflows
+ *
+ * Centralized issue operations with hook firing.
+ * Used by CLI, MCP, VS Code extension, and nvim plugin.
+ */
+
+import { GitHubAPI } from '../github-api.js';
+import {
+    createBranch,
+    checkoutBranch,
+    branchExists,
+    generateBranchName,
+    getCurrentBranch,
+} from '../git-utils.js';
+import { executeHooksForEvent, hasHooksForEvent } from '../plugins/executor.js';
+import type {
+    IssueCreatedPayload,
+    IssueStartedPayload,
+    HookResult,
+} from '../plugins/types.js';
+import type { RepoInfo } from '../types.js';
+import type {
+    CreateIssueOptions,
+    CreateIssueResult,
+    StartIssueOptions,
+    StartIssueResult,
+    IssueInfo,
+} from './types.js';
+import { createWorktreeWorkflow } from './worktree.js';
+
+// =============================================================================
+// Create Issue Workflow
+// =============================================================================
+
+/**
+ * Create an issue, add it to a project, and fire the issue-created hook.
+ *
+ * This workflow:
+ * 1. Creates the issue in GitHub
+ * 2. Adds it to the specified project
+ * 3. Sets initial status (if provided)
+ * 4. Applies labels (if provided)
+ * 5. Links to parent issue (if provided)
+ * 6. Fires the issue-created hook
+ *
+ * @example
+ * ```typescript
+ * const result = await createIssueWorkflow(api, {
+ *   repo: { owner: 'user', name: 'repo', fullName: 'user/repo' },
+ *   title: 'Add new feature',
+ *   body: 'Description of the feature',
+ *   projectId: 'PVT_xxx',
+ *   status: 'Todo',
+ *   labels: ['enhancement'],
+ * });
+ *
+ * if (result.success) {
+ *   console.log(`Created issue #${result.issue.number}`);
+ * }
+ * ```
+ */
+export async function createIssueWorkflow(
+    api: GitHubAPI,
+    options: CreateIssueOptions
+): Promise<CreateIssueResult> {
+    const {
+        repo,
+        title,
+        body = '',
+        projectId,
+        status,
+        labels = [],
+        assignees = [],
+        parentIssueNumber,
+    } = options;
+
+    const hookResults: HookResult[] = [];
+
+    try {
+        // 1. Create the issue
+        const issue = await api.createIssue(repo, title, body);
+        if (!issue) {
+            return {
+                success: false,
+                error: 'Failed to create issue',
+                hookResults,
+            };
+        }
+
+        const issueInfo: IssueInfo = {
+            number: issue.number,
+            title,
+            body,
+            url: `https://github.com/${repo.owner}/${repo.name}/issues/${issue.number}`,
+        };
+
+        // 2. Add to project
+        const itemId = await api.addToProject(projectId, issue.id);
+        if (!itemId) {
+            // Issue created but failed to add to project
+            // Still return success since the issue exists
+            return {
+                success: true,
+                issue: issueInfo,
+                error: 'Issue created but failed to add to project',
+                hookResults,
+            };
+        }
+
+        // 3. Set initial status
+        if (status) {
+            const statusField = await api.getStatusField(projectId);
+            if (statusField) {
+                const option = statusField.options.find(
+                    o => o.name.toLowerCase() === status.toLowerCase()
+                );
+                if (option) {
+                    await api.updateItemStatus(projectId, itemId, statusField.fieldId, option.id);
+                }
+            }
+        }
+
+        // 4. Apply labels
+        for (const label of labels) {
+            await api.addLabelToIssue(repo, issue.number, label);
+        }
+
+        // 5. Set assignees
+        if (assignees.length > 0) {
+            await api.updateAssignees(repo, issue.number, assignees);
+        }
+
+        // 6. Link to parent issue
+        if (parentIssueNumber) {
+            await api.addSubIssue(repo, parentIssueNumber, issue.number);
+        }
+
+        // 7. Fire issue-created hook
+        if (hasHooksForEvent('issue-created')) {
+            const payload: IssueCreatedPayload = {
+                repo: `${repo.owner}/${repo.name}`,
+                issue: {
+                    number: issue.number,
+                    title,
+                    body,
+                    url: issueInfo.url,
+                },
+            };
+
+            const results = await executeHooksForEvent('issue-created', payload);
+            hookResults.push(...results);
+        }
+
+        return {
+            success: true,
+            issue: issueInfo,
+            projectItemId: itemId,
+            hookResults,
+        };
+    } catch (error) {
+        return {
+            success: false,
+            error: error instanceof Error ? error.message : String(error),
+            hookResults,
+        };
+    }
+}
+
+// =============================================================================
+// Start Issue Workflow
+// =============================================================================
+
+/**
+ * Start working on an issue: create/checkout branch, optionally create worktree,
+ * and fire the issue-started hook.
+ *
+ * This workflow handles the core "start working" logic:
+ * 1. Creates a new branch (if no linked branch exists)
+ * 2. Checks out the branch (or creates a worktree in parallel mode)
+ * 3. Updates issue status (if not in review mode)
+ * 4. Fires the issue-started hook (if not in review mode)
+ * 5. Fires the worktree-created hook (if worktree was created)
+ *
+ * Note: This workflow does NOT handle interactive prompts or UI.
+ * The calling code (CLI, MCP, etc.) should handle user interaction
+ * and pass the resolved options to this workflow.
+ *
+ * @example
+ * ```typescript
+ * const result = await startIssueWorkflow(api, {
+ *   repo: { owner: 'user', name: 'repo', fullName: 'user/repo' },
+ *   issueNumber: 123,
+ *   issueTitle: 'Add new feature',
+ *   branchPattern: '{user}/{number}-{title}',
+ *   username: 'developer',
+ *   parallel: true,
+ * });
+ *
+ * if (result.success) {
+ *   console.log(`Working on branch ${result.branch}`);
+ *   if (result.worktree) {
+ *     console.log(`Worktree at ${result.worktree.path}`);
+ *   }
+ * }
+ * ```
+ */
+export async function startIssueWorkflow(
+    api: GitHubAPI,
+    options: StartIssueOptions
+): Promise<StartIssueResult> {
+    const {
+        repo,
+        issueNumber,
+        issueTitle = '',
+        linkedBranch,
+        parallel = false,
+        worktreePath,
+        review = false,
+        branchPattern = '{user}/{number}-{title}',
+        username = 'user',
+        targetStatus,
+        projectId,
+        statusFieldId,
+        statusOptionId,
+    } = options;
+
+    const hookResults: HookResult[] = [];
+    let branch = linkedBranch;
+    let branchCreated = false;
+    let worktreeCreated = false;
+    let worktreeInfo: { path: string; name: string } | undefined;
+
+    try {
+        // 1. Create branch if no linked branch exists
+        if (!branch) {
+            branch = generateBranchName(branchPattern, {
+                user: username,
+                number: issueNumber,
+                title: issueTitle,
+                repo: repo.name,
+            });
+
+            // Check if branch already exists
+            if (!(await branchExists(branch))) {
+                await createBranch(branch);
+                branchCreated = true;
+            }
+        }
+
+        // 2. Either create worktree (parallel mode) or checkout branch
+        if (parallel) {
+            if (!worktreePath) {
+                return {
+                    success: false,
+                    error: 'worktreePath is required when parallel mode is enabled',
+                    hookResults,
+                };
+            }
+
+            const worktreeResult = await createWorktreeWorkflow({
+                repo,
+                issueNumber,
+                issueTitle,
+                branch,
+                path: worktreePath,
+            });
+
+            if (!worktreeResult.success) {
+                return {
+                    success: false,
+                    error: worktreeResult.error,
+                    hookResults,
+                };
+            }
+
+            worktreeInfo = worktreeResult.worktree;
+            worktreeCreated = !worktreeResult.alreadyExisted;
+
+            // Add worktree hook results
+            hookResults.push(...worktreeResult.hookResults);
+        } else {
+            // Checkout the branch
+            await checkoutBranch(branch);
+        }
+
+        // 3. Update issue status (if not review mode and status info provided)
+        if (!review && projectId && statusFieldId && statusOptionId) {
+            // Get the project item ID for this issue
+            const item = await api.findItemByNumber(repo, issueNumber);
+            if (item) {
+                await api.updateItemStatus(projectId, item.id, statusFieldId, statusOptionId);
+            }
+        }
+
+        // 4. Fire issue-started hook (if not review mode)
+        // If worktree was created, fire from inside the worktree so plugins create files there
+        if (!review && hasHooksForEvent('issue-started')) {
+            const payload: IssueStartedPayload = {
+                repo: `${repo.owner}/${repo.name}`,
+                issue: {
+                    number: issueNumber,
+                    title: issueTitle,
+                    body: '', // Body not typically available at this point
+                    url: `https://github.com/${repo.owner}/${repo.name}/issues/${issueNumber}`,
+                },
+                branch,
+            };
+
+            // Fire hook from inside the worktree if one was created
+            const hookCwd = worktreeInfo?.path;
+            const results = await executeHooksForEvent('issue-started', payload, {
+                cwd: hookCwd,
+            });
+            hookResults.push(...results);
+        }
+
+        return {
+            success: true,
+            branch,
+            branchCreated,
+            worktree: worktreeInfo,
+            worktreeCreated,
+            issue: {
+                number: issueNumber,
+                title: issueTitle,
+                url: `https://github.com/${repo.owner}/${repo.name}/issues/${issueNumber}`,
+            },
+            hookResults,
+        };
+    } catch (error) {
+        return {
+            success: false,
+            error: error instanceof Error ? error.message : String(error),
+            hookResults,
+        };
+    }
+}

--- a/packages/core/src/workflows/pr.test.ts
+++ b/packages/core/src/workflows/pr.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Tests for PR workflows
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { RepoInfo } from '../types.js';
+
+// Mock git-utils
+vi.mock('../git-utils.js', () => ({
+    getCurrentBranch: vi.fn(),
+}));
+
+// Mock hook executor
+vi.mock('../plugins/executor.js', () => ({
+    executeHooksForEvent: vi.fn(),
+    hasHooksForEvent: vi.fn(),
+}));
+
+// Create a mock for execAsync that we can control
+const mockExecAsync = vi.fn();
+
+// Mock child_process.exec and util.promisify at module level
+vi.mock('child_process', () => ({
+    exec: vi.fn(),
+}));
+
+vi.mock('util', () => ({
+    promisify: () => mockExecAsync,
+}));
+
+import { getCurrentBranch } from '../git-utils.js';
+import { executeHooksForEvent, hasHooksForEvent } from '../plugins/executor.js';
+
+// Import after mocks are set up
+const { createPRWorkflow } = await import('./pr.js');
+
+const mockRepo: RepoInfo = {
+    owner: 'testowner',
+    name: 'testrepo',
+    fullName: 'testowner/testrepo',
+};
+
+describe('createPRWorkflow', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('should create a PR and fire hooks', async () => {
+        vi.mocked(getCurrentBranch).mockResolvedValue('feature/test-branch');
+        mockExecAsync.mockResolvedValue({
+            stdout: 'https://github.com/testowner/testrepo/pull/42\n',
+            stderr: '',
+        });
+        vi.mocked(hasHooksForEvent).mockReturnValue(true);
+        vi.mocked(executeHooksForEvent).mockResolvedValue([
+            { hookName: 'pr-notify', success: true },
+        ]);
+
+        const result = await createPRWorkflow({
+            repo: mockRepo,
+            title: 'Add new feature',
+            body: 'This PR adds a new feature',
+        });
+
+        expect(result.success).toBe(true);
+        expect(result.pr?.number).toBe(42);
+        expect(result.pr?.url).toBe('https://github.com/testowner/testrepo/pull/42');
+        expect(result.hookResults).toHaveLength(1);
+
+        expect(executeHooksForEvent).toHaveBeenCalledWith(
+            'pr-created',
+            expect.objectContaining({
+                repo: 'testowner/testrepo',
+                pr: expect.objectContaining({
+                    number: 42,
+                    title: 'Add new feature',
+                }),
+                branch: 'feature/test-branch',
+            })
+        );
+    });
+
+    it('should include issue reference when linked', async () => {
+        vi.mocked(getCurrentBranch).mockResolvedValue('testuser/123-feature');
+        mockExecAsync.mockResolvedValue({
+            stdout: 'https://github.com/testowner/testrepo/pull/50\n',
+            stderr: '',
+        });
+        vi.mocked(hasHooksForEvent).mockReturnValue(true);
+        vi.mocked(executeHooksForEvent).mockResolvedValue([]);
+
+        const result = await createPRWorkflow({
+            repo: mockRepo,
+            title: 'Fix issue #123',
+            issueNumber: 123,
+        });
+
+        expect(result.success).toBe(true);
+        expect(result.issue?.number).toBe(123);
+        expect(result.pr?.body).toContain('Relates to #123');
+
+        expect(executeHooksForEvent).toHaveBeenCalledWith(
+            'pr-created',
+            expect.objectContaining({
+                issue: expect.objectContaining({
+                    number: 123,
+                }),
+            })
+        );
+    });
+
+    it('should handle PR already exists error', async () => {
+        vi.mocked(getCurrentBranch).mockResolvedValue('existing-branch');
+        mockExecAsync.mockRejectedValue({
+            stderr: 'a pull request already exists for this branch',
+        });
+
+        const result = await createPRWorkflow({
+            repo: mockRepo,
+            title: 'Duplicate PR',
+        });
+
+        expect(result.success).toBe(false);
+        expect(result.error).toContain('already exists');
+    });
+
+    it('should handle missing current branch', async () => {
+        vi.mocked(getCurrentBranch).mockResolvedValue(null);
+
+        const result = await createPRWorkflow({
+            repo: mockRepo,
+            title: 'No branch',
+        });
+
+        expect(result.success).toBe(false);
+        expect(result.error).toBe('Could not determine current branch');
+    });
+
+    it('should use provided head branch instead of current', async () => {
+        mockExecAsync.mockImplementation((cmd: string) => {
+            expect(cmd).toContain('--head custom-branch');
+            return Promise.resolve({
+                stdout: 'https://github.com/testowner/testrepo/pull/55\n',
+                stderr: '',
+            });
+        });
+        vi.mocked(hasHooksForEvent).mockReturnValue(false);
+
+        const result = await createPRWorkflow({
+            repo: mockRepo,
+            title: 'From custom branch',
+            headBranch: 'custom-branch',
+        });
+
+        expect(result.success).toBe(true);
+        expect(getCurrentBranch).not.toHaveBeenCalled();
+    });
+
+    it('should not fire hooks when none registered', async () => {
+        vi.mocked(getCurrentBranch).mockResolvedValue('test-branch');
+        mockExecAsync.mockResolvedValue({
+            stdout: 'https://github.com/testowner/testrepo/pull/60\n',
+            stderr: '',
+        });
+        vi.mocked(hasHooksForEvent).mockReturnValue(false);
+
+        const result = await createPRWorkflow({
+            repo: mockRepo,
+            title: 'No hooks',
+        });
+
+        expect(result.success).toBe(true);
+        expect(result.hookResults).toHaveLength(0);
+        expect(executeHooksForEvent).not.toHaveBeenCalled();
+    });
+});

--- a/packages/core/src/workflows/pr.ts
+++ b/packages/core/src/workflows/pr.ts
@@ -1,0 +1,192 @@
+/**
+ * PR Workflows
+ *
+ * Centralized pull request operations with hook firing.
+ * Used by CLI, MCP, VS Code extension, and nvim plugin.
+ */
+
+import { exec } from 'child_process';
+import { promisify } from 'util';
+import { getCurrentBranch } from '../git-utils.js';
+import { executeHooksForEvent, hasHooksForEvent } from '../plugins/executor.js';
+import type { PrCreatedPayload, HookResult } from '../plugins/types.js';
+import type {
+    CreatePROptions,
+    CreatePRResult,
+    PRInfo,
+    IssueInfo,
+} from './types.js';
+
+const execAsync = promisify(exec);
+
+// =============================================================================
+// Create PR Workflow
+// =============================================================================
+
+/**
+ * Create a pull request and fire the pr-created hook.
+ *
+ * This workflow:
+ * 1. Creates the PR using gh CLI
+ * 2. Fires the pr-created hook
+ *
+ * Note: This workflow uses the `gh` CLI for PR creation since the GitHub
+ * GraphQL API for PR creation is more complex and gh handles edge cases well.
+ *
+ * @example
+ * ```typescript
+ * const result = await createPRWorkflow({
+ *   repo: { owner: 'user', name: 'repo', fullName: 'user/repo' },
+ *   title: 'Add new feature',
+ *   body: 'Description of changes',
+ *   issueNumber: 123,
+ * });
+ *
+ * if (result.success) {
+ *   console.log(`Created PR #${result.pr.number}: ${result.pr.url}`);
+ * }
+ * ```
+ */
+export async function createPRWorkflow(
+    options: CreatePROptions
+): Promise<CreatePRResult> {
+    const {
+        repo,
+        title,
+        body = '',
+        baseBranch = 'main',
+        headBranch,
+        issueNumber,
+        openInBrowser = false,
+    } = options;
+
+    const hookResults: HookResult[] = [];
+
+    try {
+        // Get current branch if head branch not specified
+        const head = headBranch || await getCurrentBranch();
+        if (!head) {
+            return {
+                success: false,
+                error: 'Could not determine current branch',
+                hookResults,
+            };
+        }
+
+        // Build gh pr create command
+        const args: string[] = ['gh', 'pr', 'create'];
+
+        // Escape shell special characters in strings
+        const escapeShell = (str: string) => str.replace(/([`$\\"])/g, '\\$1');
+
+        args.push('--title', `"${escapeShell(title)}"`);
+
+        // Use heredoc for body to handle multi-line content safely
+        const bodyContent = body || (issueNumber ? `Relates to #${issueNumber}` : '');
+
+        args.push('--base', baseBranch);
+        args.push('--head', head);
+
+        if (openInBrowser) {
+            args.push('--web');
+        }
+
+        // Build the command with heredoc for body
+        const command = bodyContent
+            ? `${args.join(' ')} --body "$(cat <<'EOF'\n${bodyContent}\nEOF\n)"`
+            : args.join(' ');
+
+        // Create the PR
+        const { stdout, stderr } = await execAsync(command);
+
+        // Parse PR URL from output to get PR number
+        // gh pr create outputs the PR URL
+        const prUrlMatch = stdout.match(/https:\/\/github\.com\/[^\/]+\/[^\/]+\/pull\/(\d+)/);
+        let prNumber = 0;
+        let prUrl = '';
+
+        if (prUrlMatch) {
+            prNumber = parseInt(prUrlMatch[1], 10);
+            prUrl = prUrlMatch[0];
+        } else {
+            // Try to get PR info from gh pr view
+            try {
+                const { stdout: viewOutput } = await execAsync('gh pr view --json number,url');
+                const prData = JSON.parse(viewOutput);
+                prNumber = prData.number;
+                prUrl = prData.url;
+            } catch {
+                // PR was created but we couldn't get details
+                // Return success with partial info
+            }
+        }
+
+        const prInfo: PRInfo = {
+            number: prNumber,
+            title,
+            body: bodyContent,
+            url: prUrl || `https://github.com/${repo.owner}/${repo.name}/pull/${prNumber}`,
+        };
+
+        // Build issue info if linked
+        let issueInfo: IssueInfo | undefined;
+        if (issueNumber) {
+            issueInfo = {
+                number: issueNumber,
+                title: '', // We don't have the issue title here
+                url: `https://github.com/${repo.owner}/${repo.name}/issues/${issueNumber}`,
+            };
+        }
+
+        // Fire pr-created hook
+        if (hasHooksForEvent('pr-created')) {
+            const payload: PrCreatedPayload = {
+                repo: `${repo.owner}/${repo.name}`,
+                pr: {
+                    number: prNumber,
+                    title,
+                    body: bodyContent,
+                    url: prInfo.url,
+                },
+                branch: head,
+            };
+
+            // Add issue info if linked
+            if (issueNumber) {
+                payload.issue = {
+                    number: issueNumber,
+                    title: '', // Not available without additional API call
+                    body: '',
+                    url: `https://github.com/${repo.owner}/${repo.name}/issues/${issueNumber}`,
+                };
+            }
+
+            const results = await executeHooksForEvent('pr-created', payload);
+            hookResults.push(...results);
+        }
+
+        return {
+            success: true,
+            pr: prInfo,
+            issue: issueInfo,
+            hookResults,
+        };
+    } catch (error) {
+        const err = error as { stderr?: string; message?: string };
+
+        // Check if PR already exists
+        if (err.stderr?.includes('already exists')) {
+            return {
+                success: false,
+                error: 'A pull request already exists for this branch',
+                hookResults,
+            };
+        }
+
+        return {
+            success: false,
+            error: err.stderr || err.message || String(error),
+            hookResults,
+        };
+    }
+}

--- a/packages/core/src/workflows/types.ts
+++ b/packages/core/src/workflows/types.ts
@@ -1,0 +1,237 @@
+/**
+ * Workflow Types
+ *
+ * Types for the workflow layer that encapsulates operations + hook firing.
+ * Workflows are used by CLI, MCP, VS Code extension, and nvim plugin.
+ */
+
+import type { HookResult } from '../plugins/types.js';
+import type { RepoInfo } from '../types.js';
+
+// =============================================================================
+// Common Types
+// =============================================================================
+
+/**
+ * Base result for all workflows
+ */
+export interface WorkflowResult {
+    /** Whether the workflow completed successfully */
+    success: boolean;
+    /** Error message if success is false */
+    error?: string;
+    /** Results from any hooks that were fired */
+    hookResults: HookResult[];
+}
+
+/**
+ * Issue information used across workflows
+ */
+export interface IssueInfo {
+    number: number;
+    title: string;
+    body?: string;
+    url: string;
+}
+
+/**
+ * Worktree information
+ */
+export interface WorktreeInfo {
+    /** Absolute path to the worktree */
+    path: string;
+    /** Directory name of the worktree */
+    name: string;
+}
+
+// =============================================================================
+// Create Issue Workflow
+// =============================================================================
+
+/**
+ * Options for creating an issue
+ */
+export interface CreateIssueOptions {
+    /** Repository info */
+    repo: RepoInfo;
+    /** Issue title */
+    title: string;
+    /** Issue body/description */
+    body?: string;
+    /** Project ID to add the issue to */
+    projectId: string;
+    /** Initial status name (optional) */
+    status?: string;
+    /** Labels to apply (optional) */
+    labels?: string[];
+    /** Users to assign (optional) */
+    assignees?: string[];
+    /** Parent issue number for sub-issues (optional) */
+    parentIssueNumber?: number;
+}
+
+/**
+ * Result of creating an issue
+ */
+export interface CreateIssueResult extends WorkflowResult {
+    /** Created issue info (if successful) */
+    issue?: IssueInfo;
+    /** Project item ID (if added to project) */
+    projectItemId?: string;
+}
+
+// =============================================================================
+// Start Issue Workflow
+// =============================================================================
+
+/**
+ * Options for starting work on an issue
+ */
+export interface StartIssueOptions {
+    /** Repository info */
+    repo: RepoInfo;
+    /** Issue number to start working on */
+    issueNumber: number;
+    /** Issue title (if known, avoids API call) */
+    issueTitle?: string;
+    /** Branch to work on (if already known/linked) */
+    linkedBranch?: string;
+    /** Whether to create a parallel worktree */
+    parallel?: boolean;
+    /** Custom path for worktree (only used with parallel) */
+    worktreePath?: string;
+    /** Whether this is review mode (skip status/label changes) */
+    review?: boolean;
+    /** Branch pattern for new branches */
+    branchPattern?: string;
+    /** Username for branch naming */
+    username?: string;
+    /** Target status to set */
+    targetStatus?: string;
+    /** Project ID (if known) */
+    projectId?: string;
+    /** Status field ID (if known) */
+    statusFieldId?: string;
+    /** Status option ID (if known) */
+    statusOptionId?: string;
+}
+
+/**
+ * Result of starting work on an issue
+ */
+export interface StartIssueResult extends WorkflowResult {
+    /** The branch being worked on */
+    branch?: string;
+    /** Whether a new branch was created */
+    branchCreated?: boolean;
+    /** Worktree info if parallel mode was used */
+    worktree?: WorktreeInfo;
+    /** Whether a new worktree was created */
+    worktreeCreated?: boolean;
+    /** Issue info */
+    issue?: IssueInfo;
+}
+
+// =============================================================================
+// Create PR Workflow
+// =============================================================================
+
+/**
+ * Options for creating a pull request
+ */
+export interface CreatePROptions {
+    /** Repository info */
+    repo: RepoInfo;
+    /** PR title */
+    title: string;
+    /** PR body/description */
+    body?: string;
+    /** Base branch (default: main) */
+    baseBranch?: string;
+    /** Head branch (default: current branch) */
+    headBranch?: string;
+    /** Linked issue number (optional) */
+    issueNumber?: number;
+    /** Whether to open in browser after creation */
+    openInBrowser?: boolean;
+}
+
+/**
+ * PR information
+ */
+export interface PRInfo {
+    number: number;
+    title: string;
+    body?: string;
+    url: string;
+}
+
+/**
+ * Result of creating a pull request
+ */
+export interface CreatePRResult extends WorkflowResult {
+    /** Created PR info (if successful) */
+    pr?: PRInfo;
+    /** Linked issue info (if any) */
+    issue?: IssueInfo;
+}
+
+// =============================================================================
+// Worktree Workflows
+// =============================================================================
+
+/**
+ * Options for creating a worktree
+ */
+export interface CreateWorktreeOptions {
+    /** Repository info */
+    repo: RepoInfo;
+    /** Issue number (for hooks) */
+    issueNumber?: number;
+    /** Issue title (for hooks) */
+    issueTitle?: string;
+    /** Branch to checkout in the worktree */
+    branch: string;
+    /** Full path for the worktree (required - caller determines path based on config) */
+    path: string;
+}
+
+/**
+ * Result of creating a worktree
+ */
+export interface CreateWorktreeResult extends WorkflowResult {
+    /** Worktree info */
+    worktree?: WorktreeInfo;
+    /** Whether the worktree already existed */
+    alreadyExisted?: boolean;
+    /** Branch name */
+    branch?: string;
+}
+
+/**
+ * Options for removing a worktree
+ */
+export interface RemoveWorktreeOptions {
+    /** Repository info */
+    repo: RepoInfo;
+    /** Issue number (for finding worktree and hooks) */
+    issueNumber: number;
+    /** Issue title (for hooks, optional) */
+    issueTitle?: string;
+    /** Branch name (if known, avoids lookup) */
+    branch?: string;
+    /** Worktree path (if known, avoids lookup) */
+    worktreePath?: string;
+    /** Force removal even with uncommitted changes */
+    force?: boolean;
+}
+
+/**
+ * Result of removing a worktree
+ */
+export interface RemoveWorktreeResult extends WorkflowResult {
+    /** Removed worktree info */
+    worktree?: WorktreeInfo;
+    /** Branch that was in the worktree */
+    branch?: string;
+}

--- a/packages/core/src/workflows/worktree.test.ts
+++ b/packages/core/src/workflows/worktree.test.ts
@@ -1,0 +1,231 @@
+/**
+ * Tests for worktree workflows
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createWorktreeWorkflow, removeWorktreeWorkflow } from './worktree.js';
+import type { RepoInfo } from '../types.js';
+
+// Mock git-utils
+vi.mock('../git-utils.js', () => ({
+    createWorktree: vi.fn(),
+    removeWorktree: vi.fn(),
+    listWorktrees: vi.fn(),
+}));
+
+// Mock hook executor
+vi.mock('../plugins/executor.js', () => ({
+    executeHooksForEvent: vi.fn(),
+    hasHooksForEvent: vi.fn(),
+}));
+
+import { createWorktree, removeWorktree, listWorktrees } from '../git-utils.js';
+import { executeHooksForEvent, hasHooksForEvent } from '../plugins/executor.js';
+
+const mockRepo: RepoInfo = {
+    owner: 'testowner',
+    name: 'testrepo',
+    fullName: 'testowner/testrepo',
+};
+
+describe('createWorktreeWorkflow', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('should create a worktree and fire hooks', async () => {
+        vi.mocked(listWorktrees).mockResolvedValue([]);
+        vi.mocked(createWorktree).mockResolvedValue(undefined);
+        vi.mocked(hasHooksForEvent).mockReturnValue(true);
+        vi.mocked(executeHooksForEvent).mockResolvedValue([
+            { hookName: 'test-hook', success: true },
+        ]);
+
+        const result = await createWorktreeWorkflow({
+            repo: mockRepo,
+            issueNumber: 123,
+            issueTitle: 'Test Issue',
+            branch: 'testowner/123-test-issue',
+            path: '/tmp/worktrees/testrepo/123-test-issue',
+        });
+
+        expect(result.success).toBe(true);
+        expect(result.worktree?.path).toBe('/tmp/worktrees/testrepo/123-test-issue');
+        expect(result.worktree?.name).toBe('123-test-issue');
+        expect(result.alreadyExisted).toBe(false);
+        expect(result.hookResults).toHaveLength(1);
+        expect(result.hookResults[0].hookName).toBe('test-hook');
+
+        // Verify hook was called with correct cwd
+        expect(executeHooksForEvent).toHaveBeenCalledWith(
+            'worktree-created',
+            expect.objectContaining({
+                repo: 'testowner/testrepo',
+                branch: 'testowner/123-test-issue',
+                worktree: {
+                    path: '/tmp/worktrees/testrepo/123-test-issue',
+                    name: '123-test-issue',
+                },
+                issue: {
+                    number: 123,
+                    title: 'Test Issue',
+                    url: 'https://github.com/testowner/testrepo/issues/123',
+                },
+            }),
+            { cwd: '/tmp/worktrees/testrepo/123-test-issue' }
+        );
+    });
+
+    it('should return existing worktree without creating', async () => {
+        vi.mocked(listWorktrees).mockResolvedValue([
+            {
+                path: '/existing/worktree/path',
+                branch: 'testowner/123-test-issue',
+                isMain: false,
+            },
+        ]);
+
+        const result = await createWorktreeWorkflow({
+            repo: mockRepo,
+            issueNumber: 123,
+            issueTitle: 'Test Issue',
+            branch: 'testowner/123-test-issue',
+            path: '/tmp/worktrees/testrepo/123-test-issue',
+        });
+
+        expect(result.success).toBe(true);
+        expect(result.alreadyExisted).toBe(true);
+        expect(result.hookResults).toHaveLength(0);
+        expect(createWorktree).not.toHaveBeenCalled();
+    });
+
+    it('should not fire hooks when none are registered', async () => {
+        vi.mocked(listWorktrees).mockResolvedValue([]);
+        vi.mocked(createWorktree).mockResolvedValue(undefined);
+        vi.mocked(hasHooksForEvent).mockReturnValue(false);
+
+        const result = await createWorktreeWorkflow({
+            repo: mockRepo,
+            issueNumber: 123,
+            issueTitle: 'Test Issue',
+            branch: 'testowner/123-test-issue',
+            path: '/tmp/worktrees/testrepo/123-test-issue',
+        });
+
+        expect(result.success).toBe(true);
+        expect(result.hookResults).toHaveLength(0);
+        expect(executeHooksForEvent).not.toHaveBeenCalled();
+    });
+
+    it('should handle git errors gracefully', async () => {
+        vi.mocked(listWorktrees).mockResolvedValue([]);
+        vi.mocked(createWorktree).mockRejectedValue(new Error('Git error'));
+
+        const result = await createWorktreeWorkflow({
+            repo: mockRepo,
+            issueNumber: 123,
+            issueTitle: 'Test Issue',
+            branch: 'testowner/123-test-issue',
+            path: '/tmp/worktrees/testrepo/123-test-issue',
+        });
+
+        expect(result.success).toBe(false);
+        expect(result.error).toBe('Git error');
+    });
+});
+
+describe('removeWorktreeWorkflow', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('should remove worktree by branch and fire hooks', async () => {
+        vi.mocked(listWorktrees).mockResolvedValue([
+            {
+                path: '/worktrees/testrepo/123-test',
+                branch: 'testowner/123-test',
+                isMain: false,
+            },
+        ]);
+        vi.mocked(removeWorktree).mockResolvedValue(undefined);
+        vi.mocked(hasHooksForEvent).mockReturnValue(true);
+        vi.mocked(executeHooksForEvent).mockResolvedValue([
+            { hookName: 'cleanup-hook', success: true },
+        ]);
+
+        const result = await removeWorktreeWorkflow({
+            repo: mockRepo,
+            issueNumber: 123,
+            issueTitle: 'Test Issue',
+            branch: 'testowner/123-test',
+        });
+
+        expect(result.success).toBe(true);
+        expect(result.worktree?.path).toBe('/worktrees/testrepo/123-test');
+        expect(result.hookResults).toHaveLength(1);
+
+        expect(executeHooksForEvent).toHaveBeenCalledWith(
+            'worktree-removed',
+            expect.objectContaining({
+                repo: 'testowner/testrepo',
+                branch: 'testowner/123-test',
+            })
+        );
+    });
+
+    it('should find worktree by issue number in branch name', async () => {
+        vi.mocked(listWorktrees).mockResolvedValue([
+            {
+                path: '/worktrees/testrepo/456-other',
+                branch: 'user/456-other-feature',
+                isMain: false,
+            },
+            {
+                path: '/worktrees/testrepo/123-test',
+                branch: 'user/123-test-feature',
+                isMain: false,
+            },
+        ]);
+        vi.mocked(removeWorktree).mockResolvedValue(undefined);
+        vi.mocked(hasHooksForEvent).mockReturnValue(false);
+
+        const result = await removeWorktreeWorkflow({
+            repo: mockRepo,
+            issueNumber: 123,
+        });
+
+        expect(result.success).toBe(true);
+        expect(result.worktree?.path).toBe('/worktrees/testrepo/123-test');
+    });
+
+    it('should return error when worktree not found', async () => {
+        vi.mocked(listWorktrees).mockResolvedValue([]);
+
+        const result = await removeWorktreeWorkflow({
+            repo: mockRepo,
+            issueNumber: 999,
+        });
+
+        expect(result.success).toBe(false);
+        expect(result.error).toContain('No worktree found');
+    });
+
+    it('should handle removal errors', async () => {
+        vi.mocked(listWorktrees).mockResolvedValue([
+            {
+                path: '/worktrees/testrepo/123-test',
+                branch: 'user/123-test',
+                isMain: false,
+            },
+        ]);
+        vi.mocked(removeWorktree).mockRejectedValue(new Error('Uncommitted changes'));
+
+        const result = await removeWorktreeWorkflow({
+            repo: mockRepo,
+            issueNumber: 123,
+        });
+
+        expect(result.success).toBe(false);
+        expect(result.error).toBe('Uncommitted changes');
+    });
+});

--- a/packages/core/src/workflows/worktree.ts
+++ b/packages/core/src/workflows/worktree.ts
@@ -1,0 +1,248 @@
+/**
+ * Worktree Workflows
+ *
+ * Centralized worktree operations with hook firing.
+ * Used by CLI, MCP, VS Code extension, and nvim plugin.
+ *
+ * IMPORTANT: Hooks are fired from INSIDE the worktree directory so that
+ * plugins (like Ragtime) create files in the correct location.
+ */
+
+import {
+    createWorktree as gitCreateWorktree,
+    removeWorktree as gitRemoveWorktree,
+    listWorktrees,
+} from '../git-utils.js';
+import { executeHooksForEvent, hasHooksForEvent } from '../plugins/executor.js';
+import type {
+    WorktreeCreatedPayload,
+    WorktreeRemovedPayload,
+    HookResult,
+} from '../plugins/types.js';
+import type {
+    CreateWorktreeOptions,
+    CreateWorktreeResult,
+    RemoveWorktreeOptions,
+    RemoveWorktreeResult,
+} from './types.js';
+
+// =============================================================================
+// Create Worktree Workflow
+// =============================================================================
+
+/**
+ * Create a worktree and fire the worktree-created hook.
+ *
+ * This workflow:
+ * 1. Checks if worktree already exists
+ * 2. Creates the worktree with the specified branch
+ * 3. Fires the worktree-created hook FROM INSIDE the worktree
+ *
+ * @example
+ * ```typescript
+ * const result = await createWorktreeWorkflow({
+ *   repo: { owner: 'user', name: 'repo', fullName: 'user/repo' },
+ *   issueNumber: 123,
+ *   issueTitle: 'Add new feature',
+ *   branch: 'user/123-add-new-feature',
+ * });
+ *
+ * if (result.success) {
+ *   console.log(`Worktree created at ${result.worktree.path}`);
+ * }
+ * ```
+ */
+export async function createWorktreeWorkflow(
+    options: CreateWorktreeOptions
+): Promise<CreateWorktreeResult> {
+    const { repo, issueNumber, issueTitle, branch, path } = options;
+    const hookResults: HookResult[] = [];
+
+    try {
+        // Check if worktree already exists for this branch
+        const existingWorktrees = await listWorktrees();
+        const existing = existingWorktrees.find(wt => wt.branch === branch && !wt.isMain);
+
+        if (existing) {
+            return {
+                success: true,
+                worktree: {
+                    path: existing.path,
+                    name: existing.path.split('/').pop() || '',
+                },
+                alreadyExisted: true,
+                branch,
+                hookResults: [], // No hooks fired for existing worktrees
+            };
+        }
+
+        const worktreePath = path;
+        const worktreeName = worktreePath.split('/').pop() || '';
+
+        // Create the worktree
+        await gitCreateWorktree(worktreePath, branch, {});
+
+        // Fire worktree-created hook
+        if (hasHooksForEvent('worktree-created')) {
+            const payload: WorktreeCreatedPayload = {
+                repo: `${repo.owner}/${repo.name}`,
+                branch,
+                worktree: {
+                    path: worktreePath,
+                    name: worktreeName,
+                },
+            };
+
+            // Add issue info if available
+            if (issueNumber) {
+                payload.issue = {
+                    number: issueNumber,
+                    title: issueTitle || '',
+                    url: `https://github.com/${repo.owner}/${repo.name}/issues/${issueNumber}`,
+                };
+            }
+
+            // Fire hook from inside the worktree so plugins create files there
+            const results = await executeHooksForEvent('worktree-created', payload, {
+                cwd: worktreePath,
+            });
+            hookResults.push(...results);
+        }
+
+        return {
+            success: true,
+            worktree: {
+                path: worktreePath,
+                name: worktreeName,
+            },
+            alreadyExisted: false,
+            branch,
+            hookResults,
+        };
+    } catch (error) {
+        return {
+            success: false,
+            error: error instanceof Error ? error.message : String(error),
+            hookResults,
+        };
+    }
+}
+
+// =============================================================================
+// Remove Worktree Workflow
+// =============================================================================
+
+/**
+ * Remove a worktree and fire the worktree-removed hook.
+ *
+ * This workflow:
+ * 1. Finds the worktree for the issue (if path not provided)
+ * 2. Removes the worktree
+ * 3. Fires the worktree-removed hook
+ *
+ * @example
+ * ```typescript
+ * const result = await removeWorktreeWorkflow({
+ *   repo: { owner: 'user', name: 'repo', fullName: 'user/repo' },
+ *   issueNumber: 123,
+ *   branch: 'user/123-add-feature',
+ * });
+ *
+ * if (result.success) {
+ *   console.log(`Worktree removed: ${result.worktree.path}`);
+ * }
+ * ```
+ */
+export async function removeWorktreeWorkflow(
+    options: RemoveWorktreeOptions
+): Promise<RemoveWorktreeResult> {
+    const { repo, issueNumber, issueTitle, branch, worktreePath, force } = options;
+    const hookResults: HookResult[] = [];
+
+    try {
+        // Find the worktree if path not provided
+        let targetPath = worktreePath;
+        let targetBranch = branch;
+
+        if (!targetPath) {
+            const worktrees = await listWorktrees();
+
+            // Find by branch if provided
+            if (targetBranch) {
+                const wt = worktrees.find(w => w.branch === targetBranch && !w.isMain);
+                if (wt) {
+                    targetPath = wt.path;
+                }
+            }
+
+            // If still not found, search by issue number in branch name
+            if (!targetPath) {
+                const wt = worktrees.find(w => {
+                    if (!w.branch || w.isMain) return false;
+                    // Match common patterns: user/123-title, 123-title, issue-123
+                    return w.branch.includes(`/${issueNumber}-`) ||
+                           w.branch.includes(`/${issueNumber}_`) ||
+                           w.branch.startsWith(`${issueNumber}-`) ||
+                           w.branch.includes(`issue-${issueNumber}`);
+                });
+                if (wt) {
+                    targetPath = wt.path;
+                    targetBranch = wt.branch || undefined;
+                }
+            }
+        }
+
+        if (!targetPath) {
+            return {
+                success: false,
+                error: `No worktree found for issue #${issueNumber}`,
+                hookResults,
+            };
+        }
+
+        const worktreeName = targetPath.split('/').pop() || '';
+
+        // Remove the worktree
+        await gitRemoveWorktree(targetPath, {}, force);
+
+        // Fire worktree-removed hook
+        if (hasHooksForEvent('worktree-removed')) {
+            const payload: WorktreeRemovedPayload = {
+                repo: `${repo.owner}/${repo.name}`,
+                branch: targetBranch || '',
+                worktree: {
+                    path: targetPath,
+                    name: worktreeName,
+                },
+            };
+
+            // Add issue info if available
+            if (issueNumber) {
+                payload.issue = {
+                    number: issueNumber,
+                    title: issueTitle || '',
+                    url: `https://github.com/${repo.owner}/${repo.name}/issues/${issueNumber}`,
+                };
+            }
+
+            const results = await executeHooksForEvent('worktree-removed', payload);
+            hookResults.push(...results);
+        }
+
+        return {
+            success: true,
+            worktree: {
+                path: targetPath,
+                name: worktreeName,
+            },
+            branch: targetBranch,
+            hookResults,
+        };
+    } catch (error) {
+        return {
+            success: false,
+            error: error instanceof Error ? error.message : String(error),
+            hookResults,
+        };
+    }
+}

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+    test: {
+        globals: true,
+        environment: 'node',
+        include: ['src/**/*.test.ts'],
+        coverage: {
+            provider: 'v8',
+            include: ['src/workflows/**/*.ts'],
+            exclude: ['src/**/*.test.ts'],
+        },
+    },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,6 +83,9 @@ importers:
       typescript:
         specifier: ^5.3.2
         version: 5.9.3
+      vitest:
+        specifier: ^3.0.5
+        version: 3.2.4(@types/node@20.19.30)
 
   packages/mcp:
     dependencies:
@@ -588,6 +591,12 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
@@ -667,6 +676,35 @@ packages:
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
 
+  '@vitest/expect@3.2.4':
+    resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
+
+  '@vitest/mocker@3.2.4':
+    resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@3.2.4':
+    resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
+
+  '@vitest/runner@3.2.4':
+    resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
+
+  '@vitest/snapshot@3.2.4':
+    resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
+
+  '@vitest/spy@3.2.4':
+    resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
+
+  '@vitest/utils@3.2.4':
+    resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
+
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
@@ -720,6 +758,10 @@ packages:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
     engines: {node: '>=8'}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
@@ -767,6 +809,10 @@ packages:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
 
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
@@ -777,6 +823,10 @@ packages:
 
   chardet@2.1.1:
     resolution: {integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
 
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
@@ -844,6 +894,10 @@ packages:
       supports-color:
         optional: true
 
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
@@ -888,6 +942,9 @@ packages:
   es-errors@1.3.0:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
+
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
 
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
@@ -940,6 +997,9 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
@@ -955,6 +1015,10 @@ packages:
   eventsource@3.0.7:
     resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
     engines: {node: '>=18.0.0'}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   express-rate-limit@7.5.1:
     resolution: {integrity: sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==}
@@ -1183,6 +1247,9 @@ packages:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
     engines: {node: '>=10'}
 
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
+
   js-yaml@3.14.2:
     resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
     hasBin: true
@@ -1244,6 +1311,9 @@ packages:
 
   lodash.startcase@4.4.0:
     resolution: {integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==}
+
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -1390,6 +1460,10 @@ packages:
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -1558,6 +1632,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
@@ -1580,9 +1657,15 @@ packages:
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
@@ -1595,6 +1678,9 @@ packages:
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
+
+  strip-literal@3.1.0:
+    resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
 
   sucrase@3.35.1:
     resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
@@ -1619,12 +1705,27 @@ packages:
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
   tinyexec@0.3.2:
     resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
 
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@4.0.4:
+    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
+    engines: {node: '>=14.0.0'}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -1747,9 +1848,87 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
+  vite-node@3.2.4:
+    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+
+  vite@7.3.1:
+    resolution: {integrity: sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@3.2.4:
+    resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.2.4
+      '@vitest/ui': 3.2.4
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   word-wrap@1.2.5:
@@ -2247,6 +2426,13 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.55.2':
     optional: true
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
   '@types/estree@1.0.8': {}
 
   '@types/json-schema@7.0.15': {}
@@ -2349,6 +2535,48 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
+  '@vitest/expect@3.2.4':
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@20.19.30))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.1(@types/node@20.19.30)
+
+  '@vitest/pretty-format@3.2.4':
+    dependencies:
+      tinyrainbow: 2.0.0
+
+  '@vitest/runner@3.2.4':
+    dependencies:
+      '@vitest/utils': 3.2.4
+      pathe: 2.0.3
+      strip-literal: 3.1.0
+
+  '@vitest/snapshot@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@3.2.4':
+    dependencies:
+      tinyspy: 4.0.4
+
+  '@vitest/utils@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      loupe: 3.2.1
+      tinyrainbow: 2.0.0
+
   accepts@2.0.0:
     dependencies:
       mime-types: 3.0.2
@@ -2395,6 +2623,8 @@ snapshots:
   argparse@2.0.1: {}
 
   array-union@2.1.0: {}
+
+  assertion-error@2.0.1: {}
 
   balanced-match@1.0.2: {}
 
@@ -2450,6 +2680,14 @@ snapshots:
 
   callsites@3.1.0: {}
 
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
@@ -2458,6 +2696,8 @@ snapshots:
   chalk@5.6.2: {}
 
   chardet@2.1.1: {}
+
+  check-error@2.1.3: {}
 
   chokidar@4.0.3:
     dependencies:
@@ -2504,6 +2744,8 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  deep-eql@5.0.2: {}
+
   deep-is@0.1.4: {}
 
   depd@2.0.0: {}
@@ -2538,6 +2780,8 @@ snapshots:
   es-define-property@1.0.1: {}
 
   es-errors@1.3.0: {}
+
+  es-module-lexer@1.7.0: {}
 
   es-object-atoms@1.1.1:
     dependencies:
@@ -2644,6 +2888,10 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   esutils@2.0.3: {}
 
   etag@1.8.1: {}
@@ -2653,6 +2901,8 @@ snapshots:
   eventsource@3.0.7:
     dependencies:
       eventsource-parser: 3.0.6
+
+  expect-type@1.3.0: {}
 
   express-rate-limit@7.5.1(express@5.2.1):
     dependencies:
@@ -2905,6 +3155,8 @@ snapshots:
 
   joycon@3.1.1: {}
 
+  js-tokens@9.0.1: {}
+
   js-yaml@3.14.2:
     dependencies:
       argparse: 1.0.10
@@ -2960,6 +3212,8 @@ snapshots:
 
   lodash.startcase@4.4.0: {}
 
+  loupe@3.2.1: {}
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -3008,8 +3262,7 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
-  nanoid@3.3.11:
-    optional: true
+  nanoid@3.3.11: {}
 
   natural-compare@1.4.0: {}
 
@@ -3084,6 +3337,8 @@ snapshots:
 
   pathe@2.0.3: {}
 
+  pathval@2.0.1: {}
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
@@ -3113,7 +3368,6 @@ snapshots:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
-    optional: true
 
   prelude-ls@1.2.1: {}
 
@@ -3274,12 +3528,13 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@4.1.0: {}
 
   slash@3.0.0: {}
 
-  source-map-js@1.2.1:
-    optional: true
+  source-map-js@1.2.1: {}
 
   source-map@0.7.6: {}
 
@@ -3290,7 +3545,11 @@ snapshots:
 
   sprintf-js@1.0.3: {}
 
+  stackback@0.0.2: {}
+
   statuses@2.0.2: {}
+
+  std-env@3.10.0: {}
 
   strip-ansi@6.0.1:
     dependencies:
@@ -3299,6 +3558,10 @@ snapshots:
   strip-bom@3.0.0: {}
 
   strip-json-comments@3.1.1: {}
+
+  strip-literal@3.1.0:
+    dependencies:
+      js-tokens: 9.0.1
 
   sucrase@3.35.1:
     dependencies:
@@ -3326,12 +3589,20 @@ snapshots:
     dependencies:
       any-promise: 1.3.0
 
+  tinybench@2.9.0: {}
+
   tinyexec@0.3.2: {}
 
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@2.0.0: {}
+
+  tinyspy@4.0.4: {}
 
   to-regex-range@5.0.1:
     dependencies:
@@ -3436,9 +3707,88 @@ snapshots:
 
   vary@1.1.2: {}
 
+  vite-node@3.2.4(@types/node@20.19.30):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 7.3.1(@types/node@20.19.30)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vite@7.3.1(@types/node@20.19.30):
+    dependencies:
+      esbuild: 0.27.2
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.6
+      rollup: 4.55.2
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 20.19.30
+      fsevents: 2.3.3
+
+  vitest@3.2.4(@types/node@20.19.30):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@20.19.30))
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.3.1(@types/node@20.19.30)
+      vite-node: 3.2.4(@types/node@20.19.30)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 20.19.30
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   word-wrap@1.2.5: {}
 


### PR DESCRIPTION
## Summary

- Add workflow layer in `@bretwardjames/ghp-core` that encapsulates operations + automatic hook firing
- All entry points (CLI, MCP, VS Code) now fire hooks consistently
- Hooks in parallel mode fire from inside the worktree directory

## Changes

### Core Package
- Add workflow functions: `createIssueWorkflow`, `startIssueWorkflow`, `createPRWorkflow`, `createWorktreeWorkflow`, `removeWorktreeWorkflow`
- Add `cwd` option to `executeHooksForEvent` for firing hooks from inside worktrees
- Add vitest and 24 tests for workflow functions
- Update README with workflow documentation

### CLI
- Hook firing order: `worktree-created` fires before `issue-started` in parallel mode
- Hooks fire from inside the worktree directory when using `--parallel`

### MCP
- `start` tool now fires `issue-started` hook
- `add-issue` tool now fires `issue-created` hook

### VS Code Extension
- `start-working.ts` now fires `issue-started` hook
- `worktree.ts` now fires `worktree-created` and `issue-started` hooks
- Hooks fire from inside the worktree directory

## Test plan

- [x] All 24 workflow tests pass (`pnpm test` in core package)
- [x] All packages build successfully
- [ ] Manual test: `ghp start 123 --parallel` creates worktree and fires hooks inside it
- [ ] Manual test: VS Code "Start Working" fires hooks correctly

Relates to #219

🤖 Generated with [Claude Code](https://claude.com/claude-code)