### PR TITLE
Fire PR lifecycle hooks in ghp pr command

### DIFF
--- a/.changeset/pr-lifecycle-hooks.md
+++ b/.changeset/pr-lifecycle-hooks.md
@@ -1,0 +1,13 @@
+---
+"@bretwardjames/ghp-core": minor
+"@bretwardjames/ghp-cli": minor
+---
+
+Fire PR lifecycle hooks in ghp pr command
+
+- Fire `pre-pr` hooks before PR creation (with changed files, diff stats)
+- Fire `pr-creating` hooks just before GitHub API call (with proposed title/body)
+- Fire `pr-created` hooks after successful creation
+- Add `--force` flag to bypass blocking hook failures
+- Add `--no-hooks` flag to skip all hooks
+- Hooks now fire from core workflow layer (available to MCP, VS Code, nvim)

--- a/.ragtime/branches/bretwardjames-215-fire-pr-lifecycle-hooks-in-ghp-pr-command/context.md
+++ b/.ragtime/branches/bretwardjames-215-fire-pr-lifecycle-hooks-in-ghp-pr-command/context.md
@@ -1,0 +1,63 @@
+# Issue #215: Fire PR lifecycle hooks in ghp pr command
+
+## Summary
+Integrated full PR lifecycle hook firing (`pre-pr` → `pr-creating` → `pr-created`) into the core workflow layer, with proper abort handling and new CLI flags.
+
+## What Was Done
+
+### Core Workflow Changes (`packages/core/src/workflows/pr.ts`)
+- Fire `pre-pr` hooks before PR creation with payload containing:
+  - `changed_files`: List of modified file paths
+  - `diff_stat`: { additions, deletions, files_changed }
+  - `branch`, `base`, `repo`
+- Fire `pr-creating` hooks just before GitHub API call with payload:
+  - `title`, `body` (proposed values)
+  - `branch`, `base`, `repo`
+- Fire `pr-created` hooks after successful creation (fire-and-forget)
+- Handle abort signals from blocking/interactive hooks
+- Respect `skipHooks` and `force` options
+
+### Type Updates (`packages/core/src/workflows/types.ts`)
+- Added to `CreatePROptions`:
+  - `skipHooks?: boolean` - Skip all hooks
+  - `force?: boolean` - Ignore blocking hook failures
+  - `issueTitle?: string` - For hook payloads
+- Added to `CreatePRResult`:
+  - `abortedByHook?: string` - Hook name that caused abort
+  - `abortedAtEvent?: 'pre-pr' | 'pr-creating'` - Which event aborted
+
+### CLI Updates (`packages/cli/src/commands/pr.ts`, `packages/cli/src/index.ts`)
+- Added `-f, --force` flag to bypass blocking hook failures
+- Added `--no-hooks` flag to skip all hooks
+- Refactored to use `createPRWorkflow` instead of direct implementation
+- Removed duplicate hook firing code (now centralized in workflow)
+
+### Tests (`packages/core/src/workflows/pr.test.ts`)
+- Updated existing tests for new hook firing sequence
+- Added tests for abort behavior
+- Added tests for `force` and `skipHooks` options
+
+## Hook Flow
+
+```
+ghp pr --create
+    │
+    ├── Fire pre-pr hooks (blocking/interactive)
+    │   └── Abort if hook fails (unless --force)
+    │
+    ├── Fire pr-creating hooks (blocking/interactive)
+    │   └── Abort if hook fails (unless --force)
+    │
+    ├── Create PR via GitHub API
+    │
+    └── Fire pr-created hooks (fire-and-forget)
+```
+
+## Acceptance Criteria Status
+- [x] pre-pr hooks fire before PR creation
+- [x] Blocking pre-pr hook failure aborts PR creation
+- [x] --force flag bypasses blocking failures
+- [x] --no-hooks flag skips all hooks
+- [x] pr-creating hooks fire with title/body
+- [x] pr-created hooks fire after successful creation
+- [x] pr-created payload includes PR number, URL

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -316,9 +316,11 @@ program
 program
     .command('pr [issue]')
     .description('Create or view PR for an issue')
-    .option('--create', 'Create a new PR')
-    .option('--open', 'Open PR in browser')
+    .option('-c, --create', 'Create a new PR')
+    .option('-o, --open', 'Open PR in browser')
     .option('--ai-description', 'Generate PR description using AI (follows CLAUDE.md conventions)')
+    .option('-f, --force', 'Force PR creation even if blocking hooks fail')
+    .option('--no-hooks', 'Skip all hooks (pre-pr, pr-creating, pr-created)')
     .action(prCommand);
 
 program

--- a/packages/core/src/workflows/pr.test.ts
+++ b/packages/core/src/workflows/pr.test.ts
@@ -14,6 +14,21 @@ vi.mock('../git-utils.js', () => ({
 vi.mock('../plugins/executor.js', () => ({
     executeHooksForEvent: vi.fn(),
     hasHooksForEvent: vi.fn(),
+    shouldAbort: vi.fn().mockReturnValue(false),
+}));
+
+// Mock dashboard (for pre-pr hook payload)
+vi.mock('../dashboard/index.js', () => ({
+    getDiffStats: vi.fn().mockResolvedValue({
+        filesChanged: 3,
+        insertions: 100,
+        deletions: 50,
+        files: [],
+    }),
+    getChangedFiles: vi.fn().mockResolvedValue([
+        { path: 'src/file1.ts', status: 'modified' },
+        { path: 'src/file2.ts', status: 'added' },
+    ]),
 }));
 
 // Create a mock for execAsync that we can control
@@ -29,7 +44,7 @@ vi.mock('util', () => ({
 }));
 
 import { getCurrentBranch } from '../git-utils.js';
-import { executeHooksForEvent, hasHooksForEvent } from '../plugins/executor.js';
+import { executeHooksForEvent, hasHooksForEvent, shouldAbort } from '../plugins/executor.js';
 
 // Import after mocks are set up
 const { createPRWorkflow } = await import('./pr.js');
@@ -52,8 +67,9 @@ describe('createPRWorkflow', () => {
             stderr: '',
         });
         vi.mocked(hasHooksForEvent).mockReturnValue(true);
+        vi.mocked(shouldAbort).mockReturnValue(false);
         vi.mocked(executeHooksForEvent).mockResolvedValue([
-            { hookName: 'pr-notify', success: true },
+            { hookName: 'test-hook', success: true },
         ]);
 
         const result = await createPRWorkflow({
@@ -65,8 +81,36 @@ describe('createPRWorkflow', () => {
         expect(result.success).toBe(true);
         expect(result.pr?.number).toBe(42);
         expect(result.pr?.url).toBe('https://github.com/testowner/testrepo/pull/42');
-        expect(result.hookResults).toHaveLength(1);
+        // Now fires 3 hook events: pre-pr, pr-creating, pr-created
+        expect(result.hookResults).toHaveLength(3);
 
+        // Verify pre-pr hooks were called with diff stats
+        expect(executeHooksForEvent).toHaveBeenCalledWith(
+            'pre-pr',
+            expect.objectContaining({
+                repo: 'testowner/testrepo',
+                branch: 'feature/test-branch',
+                base: 'main',
+                changed_files: expect.any(Array),
+                diff_stat: expect.objectContaining({
+                    additions: 100,
+                    deletions: 50,
+                    files_changed: 3,
+                }),
+            })
+        );
+
+        // Verify pr-creating hooks were called with title/body
+        expect(executeHooksForEvent).toHaveBeenCalledWith(
+            'pr-creating',
+            expect.objectContaining({
+                repo: 'testowner/testrepo',
+                title: 'Add new feature',
+                body: 'This PR adds a new feature',
+            })
+        );
+
+        // Verify pr-created hooks were called
         expect(executeHooksForEvent).toHaveBeenCalledWith(
             'pr-created',
             expect.objectContaining({
@@ -87,6 +131,7 @@ describe('createPRWorkflow', () => {
             stderr: '',
         });
         vi.mocked(hasHooksForEvent).mockReturnValue(true);
+        vi.mocked(shouldAbort).mockReturnValue(false);
         vi.mocked(executeHooksForEvent).mockResolvedValue([]);
 
         const result = await createPRWorkflow({
@@ -111,6 +156,8 @@ describe('createPRWorkflow', () => {
 
     it('should handle PR already exists error', async () => {
         vi.mocked(getCurrentBranch).mockResolvedValue('existing-branch');
+        // No hooks for this test - we want to test the error handling
+        vi.mocked(hasHooksForEvent).mockReturnValue(false);
         mockExecAsync.mockRejectedValue({
             stderr: 'a pull request already exists for this branch',
         });
@@ -171,6 +218,67 @@ describe('createPRWorkflow', () => {
 
         expect(result.success).toBe(true);
         expect(result.hookResults).toHaveLength(0);
+        expect(executeHooksForEvent).not.toHaveBeenCalled();
+    });
+
+    it('should abort when pre-pr hook signals abort', async () => {
+        vi.mocked(getCurrentBranch).mockResolvedValue('test-branch');
+        vi.mocked(hasHooksForEvent).mockImplementation((event) => event === 'pre-pr');
+        vi.mocked(executeHooksForEvent).mockResolvedValue([
+            { hookName: 'lint-check', success: false, aborted: true },
+        ]);
+        vi.mocked(shouldAbort).mockReturnValue(true);
+
+        const result = await createPRWorkflow({
+            repo: mockRepo,
+            title: 'Will be aborted',
+        });
+
+        expect(result.success).toBe(false);
+        expect(result.abortedByHook).toBe('lint-check');
+        expect(result.abortedAtEvent).toBe('pre-pr');
+        expect(mockExecAsync).not.toHaveBeenCalled(); // PR should not be created
+    });
+
+    it('should continue with --force even when hook signals abort', async () => {
+        vi.mocked(getCurrentBranch).mockResolvedValue('test-branch');
+        mockExecAsync.mockResolvedValue({
+            stdout: 'https://github.com/testowner/testrepo/pull/70\n',
+            stderr: '',
+        });
+        vi.mocked(hasHooksForEvent).mockImplementation((event) => event === 'pre-pr');
+        vi.mocked(executeHooksForEvent).mockResolvedValue([
+            { hookName: 'lint-check', success: false, aborted: true },
+        ]);
+        vi.mocked(shouldAbort).mockReturnValue(true);
+
+        const result = await createPRWorkflow({
+            repo: mockRepo,
+            title: 'Forced through',
+            force: true,
+        });
+
+        expect(result.success).toBe(true);
+        expect(result.pr?.number).toBe(70);
+        expect(result.abortedByHook).toBeUndefined();
+    });
+
+    it('should skip all hooks with skipHooks option', async () => {
+        vi.mocked(getCurrentBranch).mockResolvedValue('test-branch');
+        mockExecAsync.mockResolvedValue({
+            stdout: 'https://github.com/testowner/testrepo/pull/80\n',
+            stderr: '',
+        });
+
+        const result = await createPRWorkflow({
+            repo: mockRepo,
+            title: 'Skip hooks',
+            skipHooks: true,
+        });
+
+        expect(result.success).toBe(true);
+        expect(result.hookResults).toHaveLength(0);
+        expect(hasHooksForEvent).not.toHaveBeenCalled();
         expect(executeHooksForEvent).not.toHaveBeenCalled();
     });
 });

--- a/packages/core/src/workflows/types.ts
+++ b/packages/core/src/workflows/types.ts
@@ -152,8 +152,14 @@ export interface CreatePROptions {
     headBranch?: string;
     /** Linked issue number (optional) */
     issueNumber?: number;
+    /** Linked issue title (optional, for hooks) */
+    issueTitle?: string;
     /** Whether to open in browser after creation */
     openInBrowser?: boolean;
+    /** Skip all hooks (--no-hooks flag) */
+    skipHooks?: boolean;
+    /** Force PR creation even if blocking hooks fail (--force flag) */
+    force?: boolean;
 }
 
 /**
@@ -174,6 +180,10 @@ export interface CreatePRResult extends WorkflowResult {
     pr?: PRInfo;
     /** Linked issue info (if any) */
     issue?: IssueInfo;
+    /** Hook name that aborted the workflow (if any) */
+    abortedByHook?: string;
+    /** Hook event that caused the abort (pre-pr or pr-creating) */
+    abortedAtEvent?: 'pre-pr' | 'pr-creating';
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary
Integrates full PR lifecycle hook firing (`pre-pr` → `pr-creating` → `pr-created`) into the core workflow layer, with proper abort handling and new CLI flags.

## Changes

### Core Workflow (`packages/core/src/workflows/pr.ts`)
- Fire `pre-pr` hooks before PR creation with payload:
  - `changed_files`: List of modified file paths
  - `diff_stat`: { additions, deletions, files_changed }
- Fire `pr-creating` hooks just before GitHub API call with payload:
  - `title`, `body` (proposed values)
- Fire `pr-created` hooks after successful creation (fire-and-forget)
- Handle abort signals from blocking/interactive hooks
- Respect `skipHooks` and `force` options

### Type Updates (`packages/core/src/workflows/types.ts`)
- Added `skipHooks`, `force`, `issueTitle` to `CreatePROptions`
- Added `abortedByHook`, `abortedAtEvent` to `CreatePRResult`

### CLI Updates
- Added `-f, --force` flag to bypass blocking hook failures
- Added `--no-hooks` flag to skip all hooks
- Refactored to use `createPRWorkflow` from core (removes duplicate code)

### Tests
- Updated existing tests for new hook firing sequence
- Added tests for abort and skipHooks behavior

## Hook Flow

```
ghp pr --create
    │
    ├── Fire pre-pr hooks (blocking/interactive)
    │   └── Abort if hook fails (unless --force)
    │
    ├── Fire pr-creating hooks (blocking/interactive)
    │   └── Abort if hook fails (unless --force)
    │
    ├── Create PR via GitHub API
    │
    └── Fire pr-created hooks (fire-and-forget)
```

## Test plan
- [x] Build passes
- [x] All tests pass (27 tests)
- [ ] Manual test: `ghp pr --create` fires hooks correctly
- [ ] Manual test: `ghp pr --create --no-hooks` skips all hooks
- [ ] Manual test: `ghp pr --create --force` bypasses blocking failures

Relates to #215

🤖 Generated with [Claude Code](https://claude.com/claude-code)