### PR TITLE
Update create-pr command to clarify branch context should be committed

### DIFF
--- a/.ragtime/branches/bretwardjames-245-update-create-pr-command-to-clarify-ragtim/context.md
+++ b/.ragtime/branches/bretwardjames-245-update-create-pr-command-to-clarify-ragtim/context.md
@@ -1,0 +1,37 @@
+---
+type: context
+branch: bretwardjames/245-update-create-pr-command-to-clarify-ragtim
+issue: 245
+status: complete
+created: '2026-02-02'
+author: bretwardjames
+---
+
+## Issue
+
+**#245**: Update create-pr command to clarify ragtime branch context should be committed
+
+## Description
+
+The `/create-pr` command didn't explicitly mention that the branch context file (`.ragtime/branches/{slug}/context.md`) should be committed as part of the PR. This context contains the implementation plan and decisions, which is valuable for reviewers.
+
+## Changes Made
+
+1. **Updated `packages/cli/slash-commands/claude/create-pr.md`**
+   - Added "Before Creating the PR" section with bash script to check/stage context
+   - Added "Important" section emphasizing branch context should be committed
+   - Kept the original PR content requirements
+
+2. **Updated `~/.claude/commands/create-pr.md`** (user's personal command)
+   - Step 1: Added check for branch context.md with warning if missing
+   - Step 5b: New step to stage branch context file
+   - Step 6: Updated to commit both branch context and graduated knowledge
+   - Step 7: Added "Branch Context" section to PR body template
+   - Step 8: Updated summary to show branch context was committed
+   - Notes: Added note explaining branch context is committed with PR
+
+## Testing
+
+- The updated command now explicitly checks for and stages the branch context file
+- Warning message displayed if context.md is missing
+- PR body template includes section for branch context

--- a/packages/cli/slash-commands/claude/create-pr.md
+++ b/packages/cli/slash-commands/claude/create-pr.md
@@ -2,10 +2,34 @@
 
 Create a pull request for the current branch using `gh pr create`.
 
-Include in the PR:
+## Before Creating the PR
+
+1. **Check for branch context** - Ensure `.ragtime/branches/{branch}/context.md` exists
+2. **Stage ragtime files** - Branch context should be committed with the PR
+
+```bash
+BRANCH=$(git branch --show-current)
+BRANCH_SLUG=$(echo "$BRANCH" | tr '/' '-')
+
+# Check for branch context
+CONTEXT_FILE=".ragtime/branches/$BRANCH_SLUG/context.md"
+if [ -f "$CONTEXT_FILE" ]; then
+  echo "✓ Found branch context: $CONTEXT_FILE"
+  git add "$CONTEXT_FILE"
+else
+  echo "⚠ No branch context found (consider running /handoff first)"
+fi
+```
+
+## Include in the PR
+
 - A clear title summarizing the changes
 - Link to the related issue
 - Summary of what was changed and why
 - Any notes for reviewers
+
+## Important
+
+**Commit the branch context with your PR.** The `.ragtime/branches/{branch}/context.md` file contains the implementation plan and decisions - reviewers benefit from seeing this alongside the code changes.
 
 $ARGUMENTS


### PR DESCRIPTION
## Summary

- Updated `/create-pr` slash command to explicitly mention that branch context should be committed
- Added bash script to check for and stage `.ragtime/branches/{slug}/context.md`
- Added "Important" section emphasizing this is part of the PR workflow

## Branch Context

This PR includes the branch context from `.ragtime/branches/bretwardjames-245-update-create-pr-command-to-clarify-ragtim/context.md`:
- Implementation plan and decisions
- Session state for continuity

## Test Plan

- [x] Command file updated with clear instructions
- [x] Branch context committed as example of the workflow

---
🤖 Generated with [Claude Code](https://claude.ai/code)