### PR TITLE
Add configurable hook failure behavior (fail-fast vs continue)

### DIFF
--- a/.ragtime/branches/bretwardjames-237-make-hook-failures-configurable-fail-fast/context.md
+++ b/.ragtime/branches/bretwardjames-237-make-hook-failures-configurable-fail-fast/context.md
@@ -1,0 +1,93 @@
+---
+type: context
+branch: bretwardjames/237-make-hook-failures-configurable-fail-fast
+issue: 237
+status: complete
+created: '2026-02-02'
+author: bretwardjames
+---
+
+## Issue
+
+**#237**: Make hook failures configurable (fail-fast vs continue)
+
+## Description
+
+Currently, hook execution stops on the first failure (fail-fast behavior). This feature allows users to configure whether hooks should continue running after failures and collect all errors.
+
+## Plan
+
+- [x] Add `OnFailureBehavior` type to core plugins types
+- [x] Add `EventHookSettings` interface for per-event settings
+- [x] Update `EventHooksConfig` to include `eventDefaults` map
+- [x] Implement `getEventSettings()` in registry
+- [x] Update executor to support `onFailure` option with precedence chain
+- [x] Add `HooksConfig` to CLI config with `getHooksConfig()` helper
+- [x] Update all workflows to accept and pass `onFailure` option
+- [x] Update all CLI commands to pass `onFailure` from config
+- [x] Add `loadHooksConfig()` to MCP package
+- [x] Update MCP tools to use hooks config
+- [x] Write tests for executor onFailure behavior
+- [x] Fix existing workflow tests for new executeHooksForEvent signature
+
+## Implementation Summary
+
+### Configuration Precedence
+
+1. **Per-event settings** (in `~/.config/ghp-cli/event-hooks.json`):
+   ```json
+   {
+     "hooks": [...],
+     "eventDefaults": {
+       "pre-pr": { "onFailure": "fail-fast" },
+       "issue-created": { "onFailure": "continue" }
+     }
+   }
+   ```
+
+2. **Global default** (in `~/.config/ghp-cli/config.json`):
+   ```json
+   {
+     "hooks": {
+       "onFailure": "continue"
+     }
+   }
+   ```
+
+3. **Hard default**: `fail-fast` (preserves existing behavior)
+
+### Key Changes
+
+- **packages/core/src/plugins/types.ts**: Added `OnFailureBehavior`, `EventHookSettings`, updated `EventHooksConfig`
+- **packages/core/src/plugins/registry.ts**: Added `getEventSettings()`, `getValidOnFailureBehaviors()`
+- **packages/core/src/plugins/executor.ts**: Added `onFailure` to `HookExecutionOptions`, implemented continue behavior
+- **packages/cli/src/config.ts**: Added `HooksConfig` interface and `getHooksConfig()` helper
+- **packages/mcp/src/tool-registry.ts**: Added `loadHooksConfig()` for MCP context
+- **packages/core/src/workflows/*.ts**: All workflows now accept and pass `onFailure` option
+- **packages/cli/src/commands/*.ts**: All commands now use `getHooksConfig()` to pass `onFailure`
+
+### Test Coverage
+
+Added 7 new tests in `packages/core/src/plugins/executor.test.ts`:
+- fail-fast behavior (default)
+- fail-fast behavior (explicit option)
+- continue behavior (runs all hooks)
+- continue behavior (collects all failures)
+- per-event override (continue over fail-fast)
+- per-event override (fail-fast over continue)
+- fire-and-forget hooks (never abort)
+
+## Acceptance Criteria
+
+- [x] Users can set global default in CLI config
+- [x] Users can override per-event in event-hooks config
+- [x] fail-fast stops on first failure (existing behavior)
+- [x] continue runs all hooks and collects failures
+- [x] All existing tests pass
+- [x] New tests cover onFailure behavior
+
+## Notes
+
+- Fire-and-forget hooks never set `aborted=true` regardless of exit code, so they're unaffected by the onFailure setting
+- The MCP package has its own config loading since it can't import from CLI package
+- Precedence chain ensures maximum flexibility: per-event > global > default

--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -494,6 +494,15 @@
           "default": true,
           "description": "Automatically run setup command in new worktrees"
         },
+        "ghProjects.hooksOnFailure": {
+          "type": "string",
+          "enum": [
+            "fail-fast",
+            "continue"
+          ],
+          "default": "fail-fast",
+          "description": "Behavior when a hook fails: 'fail-fast' stops on first failure, 'continue' runs all hooks and collects failures"
+        },
         "ghProjects.worktree.defaultBaseBranch": {
           "type": "string",
           "enum": [

--- a/packages/cli/src/commands/add-issue.ts
+++ b/packages/cli/src/commands/add-issue.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk';
 import { api } from '../github-api.js';
 import { detectRepository } from '../git-utils.js';
-import { getAddIssueDefaults, getClaudeConfig } from '../config.js';
+import { getAddIssueDefaults, getClaudeConfig, getHooksConfig } from '../config.js';
 import { spawn, exec } from 'child_process';
 import { promisify } from 'util';
 import { writeFileSync, readFileSync, unlinkSync, existsSync, readdirSync } from 'fs';
@@ -492,7 +492,10 @@ export async function addIssueCommand(title: string, options: AddIssueOptions): 
             },
         };
 
-        const results = await executeHooksForEvent('issue-created', payload);
+        const hooksConfig = getHooksConfig();
+        const results = await executeHooksForEvent('issue-created', payload, {
+            onFailure: hooksConfig.onFailure,
+        });
 
         for (const result of results) {
             if (result.success) {

--- a/packages/cli/src/commands/pr.ts
+++ b/packages/cli/src/commands/pr.ts
@@ -4,7 +4,7 @@ import { promisify } from 'util';
 import { api } from '../github-api.js';
 import { detectRepository, getCurrentBranch, type RepoInfo } from '../git-utils.js';
 import { getIssueForBranch } from '../branch-linker.js';
-import { getConfig, getClaudeConfig } from '../config.js';
+import { getConfig, getClaudeConfig, getHooksConfig } from '../config.js';
 import { loadProjectConventions, buildConventionsContext } from '../conventions.js';
 import { runFeedbackLoop, UserCancelledError } from '../ai-feedback.js';
 import { generateWithClaude } from '../claude-runner.js';
@@ -103,6 +103,7 @@ async function createPr(
 
         // Use the workflow to handle PR creation and all hooks
         const baseBranch = getConfig('mainBranch') || 'main';
+        const hooksConfig = getHooksConfig();
 
         const result = await createPRWorkflow({
             repo,
@@ -115,6 +116,7 @@ async function createPr(
             openInBrowser: false, // We'll handle browser opening ourselves
             skipHooks: noHooks,
             force,
+            onFailure: hooksConfig.onFailure,
         });
 
         // Handle abort by hook

--- a/packages/cli/src/commands/start.test.ts
+++ b/packages/cli/src/commands/start.test.ts
@@ -51,6 +51,7 @@ vi.mock('../git-utils.js', () => ({
 vi.mock('../config.js', () => ({
     getConfig: vi.fn(),
     getParallelWorkConfig: vi.fn(() => ({ openTerminal: false })),
+    getHooksConfig: vi.fn(() => ({ onFailure: 'fail-fast' })),
 }));
 
 // Mock branch-linker

--- a/packages/cli/src/commands/worktree.ts
+++ b/packages/cli/src/commands/worktree.ts
@@ -15,6 +15,7 @@ import {
     type HookResult,
 } from '@bretwardjames/ghp-core';
 import { exit } from '../exit.js';
+import { getHooksConfig } from '../config.js';
 
 interface WorktreeRemoveOptions {
     force?: boolean;
@@ -111,12 +112,14 @@ export async function worktreeRemoveCommand(
     }
 
     // Use the workflow to remove worktree and fire hooks
+    const hooksConfig = getHooksConfig();
     const result = await removeWorktreeWorkflow({
         repo,
         issueNumber,
         branch: branchName,
         worktreePath: worktree.path,
         force: options.force,
+        onFailure: hooksConfig.onFailure,
     });
 
     if (!result.success) {

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -109,6 +109,22 @@ export interface ClaudeConfig {
     maxTokens?: number;
 }
 
+// Re-export OnFailureBehavior from core for convenience
+export { type OnFailureBehavior } from '@bretwardjames/ghp-core';
+import { type OnFailureBehavior } from '@bretwardjames/ghp-core';
+
+/**
+ * Event hooks configuration
+ */
+export interface HooksConfig {
+    /**
+     * Default behavior when a hook fails.
+     * Can be overridden per-event in event-hooks.json.
+     * Default: 'fail-fast'
+     */
+    onFailure?: OnFailureBehavior;
+}
+
 /**
  * Behavior when an issue is not in any project
  * - 'auto-add': Automatically add the issue to the first/default project
@@ -145,6 +161,9 @@ export interface Config {
 
     // Claude AI configuration
     claude?: ClaudeConfig;
+
+    // Event hooks configuration
+    hooks?: HooksConfig;
 
     // Command defaults
     defaults?: {
@@ -188,6 +207,10 @@ const DEFAULT_CONFIG: Config = {
             action: true,
         },
         disabledTools: [],
+    },
+    // Hooks defaults
+    hooks: {
+        onFailure: 'fail-fast',
     },
 };
 
@@ -519,6 +542,26 @@ export function getClaudeConfig(): ResolvedClaudeConfig {
         apiKey: process.env.ANTHROPIC_API_KEY || claudeConfig.apiKey,
         model: claudeConfig.model || DEFAULT_CLAUDE_MODEL,
         maxTokens: claudeConfig.maxTokens || DEFAULT_CLAUDE_MAX_TOKENS,
+    };
+}
+
+/**
+ * Resolved hooks configuration with defaults
+ */
+export interface ResolvedHooksConfig {
+    /** Behavior when a hook fails */
+    onFailure: OnFailureBehavior;
+}
+
+/**
+ * Get the hooks configuration with defaults applied.
+ */
+export function getHooksConfig(): ResolvedHooksConfig {
+    const config = loadConfig();
+    const hooksConfig = config.hooks || {};
+
+    return {
+        onFailure: hooksConfig.onFailure || 'fail-fast',
     };
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -418,6 +418,8 @@ export {
     disableEventHook,
     getValidEventTypes,
     getValidModes,
+    getValidOnFailureBehaviors,
+    getEventSettings,
     // Executor
     substituteTemplateVariables,
     executeEventHook,
@@ -431,6 +433,8 @@ export type {
     HookMode,
     HookExitCodes,
     HookOutcome,
+    OnFailureBehavior,
+    EventHookSettings,
     EventHook,
     EventHooksConfig,
     BaseEventPayload,

--- a/packages/core/src/plugins/executor.test.ts
+++ b/packages/core/src/plugins/executor.test.ts
@@ -1,0 +1,333 @@
+/**
+ * Tests for hook executor, specifically the onFailure behavior
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { executeHooksForEvent, executeEventHook } from './executor.js';
+import type { EventHook, IssueCreatedPayload, EventHookSettings } from './types.js';
+
+// Mock the registry module
+vi.mock('./registry.js', () => ({
+    getHooksForEvent: vi.fn(),
+    getEventSettings: vi.fn(),
+}));
+
+import { getHooksForEvent, getEventSettings } from './registry.js';
+
+const mockPayload: IssueCreatedPayload = {
+    repo: 'owner/repo',
+    issue: {
+        number: 123,
+        title: 'Test Issue',
+        body: 'Test body',
+        url: 'https://github.com/owner/repo/issues/123',
+    },
+};
+
+// Mock child_process.spawn
+vi.mock('child_process', async () => {
+    const actual = await vi.importActual<typeof import('child_process')>('child_process');
+    return {
+        ...actual,
+        spawn: vi.fn(),
+    };
+});
+
+import { spawn } from 'child_process';
+
+/**
+ * Create a mock spawn that simulates a command execution
+ */
+function mockSpawnWithExitCode(exitCode: number, stdout = '', stderr = '') {
+    vi.mocked(spawn).mockImplementation(() => {
+        const mockChild = {
+            stdout: {
+                on: vi.fn((event, cb) => {
+                    if (event === 'data' && stdout) {
+                        cb(Buffer.from(stdout));
+                    }
+                }),
+            },
+            stderr: {
+                on: vi.fn((event, cb) => {
+                    if (event === 'data' && stderr) {
+                        cb(Buffer.from(stderr));
+                    }
+                }),
+            },
+            stdin: { write: vi.fn(), end: vi.fn() },
+            on: vi.fn((event, cb) => {
+                if (event === 'close') {
+                    // Simulate async completion
+                    setTimeout(() => cb(exitCode), 0);
+                }
+            }),
+            kill: vi.fn(),
+        };
+        return mockChild as any;
+    });
+}
+
+describe('executeHooksForEvent', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.mocked(getEventSettings).mockReturnValue(undefined);
+    });
+
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    describe('fail-fast behavior (default)', () => {
+        it('should stop on first hook failure with default fail-fast', async () => {
+            const hooks: EventHook[] = [
+                { name: 'hook1', event: 'issue-created', command: 'echo hook1', enabled: true, mode: 'blocking' },
+                { name: 'hook2', event: 'issue-created', command: 'echo hook2', enabled: true, mode: 'blocking' },
+                { name: 'hook3', event: 'issue-created', command: 'echo hook3', enabled: true, mode: 'blocking' },
+            ];
+
+            vi.mocked(getHooksForEvent).mockReturnValue(hooks);
+
+            // First hook succeeds, second fails, third should not run
+            let callCount = 0;
+            vi.mocked(spawn).mockImplementation(() => {
+                callCount++;
+                const exitCode = callCount === 2 ? 1 : 0; // Second hook fails
+                const mockChild = {
+                    stdout: { on: vi.fn() },
+                    stderr: { on: vi.fn() },
+                    stdin: { write: vi.fn(), end: vi.fn() },
+                    on: vi.fn((event, cb) => {
+                        if (event === 'close') setTimeout(() => cb(exitCode), 0);
+                    }),
+                    kill: vi.fn(),
+                };
+                return mockChild as any;
+            });
+
+            const results = await executeHooksForEvent('issue-created', mockPayload);
+
+            // With fail-fast, should stop after second hook
+            expect(results).toHaveLength(2);
+            expect(results[0].hookName).toBe('hook1');
+            expect(results[0].aborted).toBe(false);
+            expect(results[1].hookName).toBe('hook2');
+            expect(results[1].aborted).toBe(true);
+        });
+
+        it('should stop on first hook failure with explicit fail-fast option', async () => {
+            const hooks: EventHook[] = [
+                { name: 'hook1', event: 'issue-created', command: 'echo hook1', enabled: true, mode: 'blocking' },
+                { name: 'hook2', event: 'issue-created', command: 'echo hook2', enabled: true, mode: 'blocking' },
+            ];
+
+            vi.mocked(getHooksForEvent).mockReturnValue(hooks);
+
+            let callCount = 0;
+            vi.mocked(spawn).mockImplementation(() => {
+                callCount++;
+                const exitCode = callCount === 1 ? 1 : 0; // First hook fails
+                const mockChild = {
+                    stdout: { on: vi.fn() },
+                    stderr: { on: vi.fn() },
+                    stdin: { write: vi.fn(), end: vi.fn() },
+                    on: vi.fn((event, cb) => {
+                        if (event === 'close') setTimeout(() => cb(exitCode), 0);
+                    }),
+                    kill: vi.fn(),
+                };
+                return mockChild as any;
+            });
+
+            const results = await executeHooksForEvent('issue-created', mockPayload, {
+                onFailure: 'fail-fast',
+            });
+
+            // Should stop after first hook
+            expect(results).toHaveLength(1);
+            expect(results[0].aborted).toBe(true);
+        });
+    });
+
+    describe('continue behavior', () => {
+        it('should run all hooks when onFailure is continue', async () => {
+            const hooks: EventHook[] = [
+                { name: 'hook1', event: 'issue-created', command: 'exit 1', enabled: true, mode: 'blocking' },
+                { name: 'hook2', event: 'issue-created', command: 'exit 1', enabled: true, mode: 'blocking' },
+                { name: 'hook3', event: 'issue-created', command: 'exit 0', enabled: true, mode: 'blocking' },
+            ];
+
+            vi.mocked(getHooksForEvent).mockReturnValue(hooks);
+
+            let callCount = 0;
+            vi.mocked(spawn).mockImplementation(() => {
+                callCount++;
+                // First two fail, third succeeds
+                const exitCode = callCount <= 2 ? 1 : 0;
+                const mockChild = {
+                    stdout: { on: vi.fn() },
+                    stderr: { on: vi.fn() },
+                    stdin: { write: vi.fn(), end: vi.fn() },
+                    on: vi.fn((event, cb) => {
+                        if (event === 'close') setTimeout(() => cb(exitCode), 0);
+                    }),
+                    kill: vi.fn(),
+                };
+                return mockChild as any;
+            });
+
+            const results = await executeHooksForEvent('issue-created', mockPayload, {
+                onFailure: 'continue',
+            });
+
+            // All hooks should run with continue mode
+            expect(results).toHaveLength(3);
+            expect(results[0].hookName).toBe('hook1');
+            expect(results[0].aborted).toBe(true); // First hook signaled abort
+            expect(results[1].hookName).toBe('hook2');
+            expect(results[1].aborted).toBe(true); // Second hook signaled abort
+            expect(results[2].hookName).toBe('hook3');
+            expect(results[2].aborted).toBe(false); // Third hook succeeded
+        });
+
+        it('should collect all failures when onFailure is continue', async () => {
+            const hooks: EventHook[] = [
+                { name: 'failing1', event: 'issue-created', command: 'exit 1', enabled: true, mode: 'blocking' },
+                { name: 'failing2', event: 'issue-created', command: 'exit 1', enabled: true, mode: 'blocking' },
+            ];
+
+            vi.mocked(getHooksForEvent).mockReturnValue(hooks);
+
+            vi.mocked(spawn).mockImplementation(() => {
+                const mockChild = {
+                    stdout: { on: vi.fn() },
+                    stderr: { on: vi.fn() },
+                    stdin: { write: vi.fn(), end: vi.fn() },
+                    on: vi.fn((event, cb) => {
+                        if (event === 'close') setTimeout(() => cb(1), 0); // All fail
+                    }),
+                    kill: vi.fn(),
+                };
+                return mockChild as any;
+            });
+
+            const results = await executeHooksForEvent('issue-created', mockPayload, {
+                onFailure: 'continue',
+            });
+
+            // Both hooks should run and report failure
+            expect(results).toHaveLength(2);
+            expect(results.filter(r => r.aborted)).toHaveLength(2);
+        });
+    });
+
+    describe('per-event override', () => {
+        it('should use per-event setting over options', async () => {
+            const hooks: EventHook[] = [
+                { name: 'hook1', event: 'issue-created', command: 'exit 1', enabled: true, mode: 'blocking' },
+                { name: 'hook2', event: 'issue-created', command: 'exit 0', enabled: true, mode: 'blocking' },
+            ];
+
+            vi.mocked(getHooksForEvent).mockReturnValue(hooks);
+            // Per-event setting says continue
+            vi.mocked(getEventSettings).mockReturnValue({ onFailure: 'continue' });
+
+            let callCount = 0;
+            vi.mocked(spawn).mockImplementation(() => {
+                callCount++;
+                const exitCode = callCount === 1 ? 1 : 0;
+                const mockChild = {
+                    stdout: { on: vi.fn() },
+                    stderr: { on: vi.fn() },
+                    stdin: { write: vi.fn(), end: vi.fn() },
+                    on: vi.fn((event, cb) => {
+                        if (event === 'close') setTimeout(() => cb(exitCode), 0);
+                    }),
+                    kill: vi.fn(),
+                };
+                return mockChild as any;
+            });
+
+            // Even though options say fail-fast, per-event says continue
+            const results = await executeHooksForEvent('issue-created', mockPayload, {
+                onFailure: 'fail-fast',
+            });
+
+            // Per-event override should take precedence - both hooks should run
+            expect(results).toHaveLength(2);
+        });
+
+        it('should use per-event fail-fast over options continue', async () => {
+            const hooks: EventHook[] = [
+                { name: 'hook1', event: 'issue-created', command: 'exit 1', enabled: true, mode: 'blocking' },
+                { name: 'hook2', event: 'issue-created', command: 'exit 0', enabled: true, mode: 'blocking' },
+            ];
+
+            vi.mocked(getHooksForEvent).mockReturnValue(hooks);
+            // Per-event setting says fail-fast
+            vi.mocked(getEventSettings).mockReturnValue({ onFailure: 'fail-fast' });
+
+            let callCount = 0;
+            vi.mocked(spawn).mockImplementation(() => {
+                callCount++;
+                const exitCode = callCount === 1 ? 1 : 0;
+                const mockChild = {
+                    stdout: { on: vi.fn() },
+                    stderr: { on: vi.fn() },
+                    stdin: { write: vi.fn(), end: vi.fn() },
+                    on: vi.fn((event, cb) => {
+                        if (event === 'close') setTimeout(() => cb(exitCode), 0);
+                    }),
+                    kill: vi.fn(),
+                };
+                return mockChild as any;
+            });
+
+            // Options say continue, but per-event says fail-fast
+            const results = await executeHooksForEvent('issue-created', mockPayload, {
+                onFailure: 'continue',
+            });
+
+            // Per-event override should take precedence - should stop after first
+            expect(results).toHaveLength(1);
+            expect(results[0].aborted).toBe(true);
+        });
+    });
+
+    describe('fire-and-forget hooks', () => {
+        it('should never abort for fire-and-forget hooks', async () => {
+            const hooks: EventHook[] = [
+                { name: 'hook1', event: 'issue-created', command: 'exit 1', enabled: true, mode: 'fire-and-forget' },
+                { name: 'hook2', event: 'issue-created', command: 'exit 0', enabled: true, mode: 'fire-and-forget' },
+            ];
+
+            vi.mocked(getHooksForEvent).mockReturnValue(hooks);
+
+            let callCount = 0;
+            vi.mocked(spawn).mockImplementation(() => {
+                callCount++;
+                const exitCode = callCount === 1 ? 1 : 0;
+                const mockChild = {
+                    stdout: { on: vi.fn() },
+                    stderr: { on: vi.fn() },
+                    stdin: { write: vi.fn(), end: vi.fn() },
+                    on: vi.fn((event, cb) => {
+                        if (event === 'close') setTimeout(() => cb(exitCode), 0);
+                    }),
+                    kill: vi.fn(),
+                };
+                return mockChild as any;
+            });
+
+            // Even with fail-fast, fire-and-forget hooks don't abort
+            const results = await executeHooksForEvent('issue-created', mockPayload, {
+                onFailure: 'fail-fast',
+            });
+
+            // Both hooks should run because fire-and-forget never sets aborted=true
+            expect(results).toHaveLength(2);
+            expect(results[0].aborted).toBe(false);
+            expect(results[1].aborted).toBe(false);
+        });
+    });
+});

--- a/packages/core/src/plugins/index.ts
+++ b/packages/core/src/plugins/index.ts
@@ -8,6 +8,8 @@ export type {
     HookMode,
     HookExitCodes,
     HookOutcome,
+    OnFailureBehavior,
+    EventHookSettings,
     EventHook,
     EventHooksConfig,
     BaseEventPayload,
@@ -39,6 +41,8 @@ export {
     disableEventHook,
     getValidEventTypes,
     getValidModes,
+    getValidOnFailureBehaviors,
+    getEventSettings,
 } from './registry.js';
 
 // Executor

--- a/packages/core/src/plugins/types.ts
+++ b/packages/core/src/plugins/types.ts
@@ -106,6 +106,8 @@ export interface EventHook {
  */
 export interface EventHooksConfig {
     hooks: EventHook[];
+    /** Per-event execution settings (overrides global defaults) */
+    eventDefaults?: Partial<Record<EventType, EventHookSettings>>;
 }
 
 // =============================================================================
@@ -279,6 +281,21 @@ export type EventPayload =
  * Outcome of hook execution based on mode and exit code
  */
 export type HookOutcome = 'success' | 'warn' | 'abort' | 'continue';
+
+/**
+ * Behavior when a hook fails (aborts)
+ * - 'fail-fast': Stop executing hooks on first failure (default)
+ * - 'continue': Run all hooks, collect all failures
+ */
+export type OnFailureBehavior = 'fail-fast' | 'continue';
+
+/**
+ * Per-event hook execution settings
+ */
+export interface EventHookSettings {
+    /** Behavior when a hook fails for this event */
+    onFailure?: OnFailureBehavior;
+}
 
 /**
  * Result of executing an event hook

--- a/packages/core/src/workflows/issue.test.ts
+++ b/packages/core/src/workflows/issue.test.ts
@@ -89,7 +89,8 @@ describe('createIssueWorkflow', () => {
                     title: 'Test Issue',
                     body: 'Issue body',
                 }),
-            })
+            }),
+            expect.objectContaining({})
         );
     });
 
@@ -213,7 +214,7 @@ describe('startIssueWorkflow', () => {
                 }),
                 branch: 'testuser/123-test-issue',
             }),
-            { cwd: undefined }
+            expect.objectContaining({ cwd: undefined })
         );
     });
 
@@ -276,7 +277,7 @@ describe('startIssueWorkflow', () => {
         expect(executeHooksForEvent).toHaveBeenCalledWith(
             'issue-started',
             expect.any(Object),
-            { cwd: '/worktrees/testrepo/123-test-issue' }
+            expect.objectContaining({ cwd: '/worktrees/testrepo/123-test-issue' })
         );
     });
 

--- a/packages/core/src/workflows/issue.ts
+++ b/packages/core/src/workflows/issue.ts
@@ -18,6 +18,7 @@ import type {
     IssueCreatedPayload,
     IssueStartedPayload,
     HookResult,
+    OnFailureBehavior,
 } from '../plugins/types.js';
 import type { RepoInfo } from '../types.js';
 import type {
@@ -73,6 +74,7 @@ export async function createIssueWorkflow(
         labels = [],
         assignees = [],
         parentIssueNumber,
+        onFailure,
     } = options;
 
     const hookResults: HookResult[] = [];
@@ -148,7 +150,7 @@ export async function createIssueWorkflow(
                 },
             };
 
-            const results = await executeHooksForEvent('issue-created', payload);
+            const results = await executeHooksForEvent('issue-created', payload, { onFailure });
             hookResults.push(...results);
         }
 
@@ -223,6 +225,7 @@ export async function startIssueWorkflow(
         projectId,
         statusFieldId,
         statusOptionId,
+        onFailure,
     } = options;
 
     const hookResults: HookResult[] = [];
@@ -264,6 +267,7 @@ export async function startIssueWorkflow(
                 issueTitle,
                 branch,
                 path: worktreePath,
+                onFailure,
             });
 
             if (!worktreeResult.success) {
@@ -311,6 +315,7 @@ export async function startIssueWorkflow(
             const hookCwd = worktreeInfo?.path;
             const results = await executeHooksForEvent('issue-started', payload, {
                 cwd: hookCwd,
+                onFailure,
             });
             hookResults.push(...results);
         }

--- a/packages/core/src/workflows/pr.test.ts
+++ b/packages/core/src/workflows/pr.test.ts
@@ -97,7 +97,8 @@ describe('createPRWorkflow', () => {
                     deletions: 50,
                     files_changed: 3,
                 }),
-            })
+            }),
+            expect.objectContaining({})
         );
 
         // Verify pr-creating hooks were called with title/body
@@ -107,7 +108,8 @@ describe('createPRWorkflow', () => {
                 repo: 'testowner/testrepo',
                 title: 'Add new feature',
                 body: 'This PR adds a new feature',
-            })
+            }),
+            expect.objectContaining({})
         );
 
         // Verify pr-created hooks were called
@@ -120,7 +122,8 @@ describe('createPRWorkflow', () => {
                     title: 'Add new feature',
                 }),
                 branch: 'feature/test-branch',
-            })
+            }),
+            expect.objectContaining({})
         );
     });
 
@@ -150,7 +153,8 @@ describe('createPRWorkflow', () => {
                 issue: expect.objectContaining({
                     number: 123,
                 }),
-            })
+            }),
+            expect.objectContaining({})
         );
     });
 

--- a/packages/core/src/workflows/pr.ts
+++ b/packages/core/src/workflows/pr.ts
@@ -14,6 +14,7 @@ import type {
     PrCreatingPayload,
     PrCreatedPayload,
     HookResult,
+    OnFailureBehavior,
 } from '../plugins/types.js';
 import { getDiffStats, getChangedFiles } from '../dashboard/index.js';
 import type {
@@ -79,6 +80,7 @@ export async function createPRWorkflow(
         openInBrowser = false,
         skipHooks = false,
         force = false,
+        onFailure,
     } = options;
 
     const hookResults: HookResult[] = [];
@@ -117,7 +119,7 @@ export async function createPRWorkflow(
                 },
             };
 
-            const prePrResults = await executeHooksForEvent('pre-pr', prePrPayload);
+            const prePrResults = await executeHooksForEvent('pre-pr', prePrPayload, { onFailure });
             hookResults.push(...prePrResults);
 
             // Check if any hook signaled abort (unless --force)
@@ -147,7 +149,7 @@ export async function createPRWorkflow(
                 body: bodyContent,
             };
 
-            const prCreatingResults = await executeHooksForEvent('pr-creating', prCreatingPayload);
+            const prCreatingResults = await executeHooksForEvent('pr-creating', prCreatingPayload, { onFailure });
             hookResults.push(...prCreatingResults);
 
             // Check if any hook signaled abort (unless --force)
@@ -257,7 +259,7 @@ export async function createPRWorkflow(
                 };
             }
 
-            const results = await executeHooksForEvent('pr-created', payload);
+            const results = await executeHooksForEvent('pr-created', payload, { onFailure });
             hookResults.push(...results);
             // Note: pr-created hooks are typically fire-and-forget, so we don't
             // check for abort here - the PR has already been created

--- a/packages/core/src/workflows/types.ts
+++ b/packages/core/src/workflows/types.ts
@@ -5,7 +5,7 @@
  * Workflows are used by CLI, MCP, VS Code extension, and nvim plugin.
  */
 
-import type { HookResult } from '../plugins/types.js';
+import type { HookResult, OnFailureBehavior } from '../plugins/types.js';
 import type { RepoInfo } from '../types.js';
 
 // =============================================================================
@@ -68,6 +68,8 @@ export interface CreateIssueOptions {
     assignees?: string[];
     /** Parent issue number for sub-issues (optional) */
     parentIssueNumber?: number;
+    /** Hook failure behavior (default: 'fail-fast') */
+    onFailure?: OnFailureBehavior;
 }
 
 /**
@@ -114,6 +116,8 @@ export interface StartIssueOptions {
     statusFieldId?: string;
     /** Status option ID (if known) */
     statusOptionId?: string;
+    /** Hook failure behavior (default: 'fail-fast') */
+    onFailure?: OnFailureBehavior;
 }
 
 /**
@@ -160,6 +164,8 @@ export interface CreatePROptions {
     skipHooks?: boolean;
     /** Force PR creation even if blocking hooks fail (--force flag) */
     force?: boolean;
+    /** Hook failure behavior (default: 'fail-fast') */
+    onFailure?: OnFailureBehavior;
 }
 
 /**
@@ -204,6 +210,8 @@ export interface CreateWorktreeOptions {
     branch: string;
     /** Full path for the worktree (required - caller determines path based on config) */
     path: string;
+    /** Hook failure behavior (default: 'fail-fast') */
+    onFailure?: OnFailureBehavior;
 }
 
 /**
@@ -234,6 +242,8 @@ export interface RemoveWorktreeOptions {
     worktreePath?: string;
     /** Force removal even with uncommitted changes */
     force?: boolean;
+    /** Hook failure behavior (default: 'fail-fast') */
+    onFailure?: OnFailureBehavior;
 }
 
 /**

--- a/packages/core/src/workflows/worktree.test.ts
+++ b/packages/core/src/workflows/worktree.test.ts
@@ -79,7 +79,7 @@ describe('createWorktreeWorkflow', () => {
                     url: 'https://github.com/testowner/testrepo/issues/123',
                 },
             }),
-            { cwd: '/tmp/worktrees/testrepo/123-test-issue' }
+            expect.objectContaining({ cwd: '/tmp/worktrees/testrepo/123-test-issue' })
         );
     });
 
@@ -203,7 +203,8 @@ describe('removeWorktreeWorkflow', () => {
             expect.objectContaining({
                 repo: 'testowner/testrepo',
                 branch: 'testowner/123-test',
-            })
+            }),
+            expect.objectContaining({})
         );
     });
 

--- a/packages/core/src/workflows/worktree.ts
+++ b/packages/core/src/workflows/worktree.ts
@@ -19,6 +19,7 @@ import type {
     WorktreeCreatedPayload,
     WorktreeRemovedPayload,
     HookResult,
+    OnFailureBehavior,
 } from '../plugins/types.js';
 import type {
     CreateWorktreeOptions,
@@ -56,7 +57,7 @@ import type {
 export async function createWorktreeWorkflow(
     options: CreateWorktreeOptions
 ): Promise<CreateWorktreeResult> {
-    const { repo, issueNumber, issueTitle, branch, path } = options;
+    const { repo, issueNumber, issueTitle, branch, path, onFailure } = options;
     const hookResults: HookResult[] = [];
 
     try {
@@ -106,6 +107,7 @@ export async function createWorktreeWorkflow(
             // Fire hook from inside the worktree so plugins create files there
             const results = await executeHooksForEvent('worktree-created', payload, {
                 cwd: worktreePath,
+                onFailure,
             });
             hookResults.push(...results);
         }
@@ -161,7 +163,7 @@ export async function createWorktreeWorkflow(
 export async function removeWorktreeWorkflow(
     options: RemoveWorktreeOptions
 ): Promise<RemoveWorktreeResult> {
-    const { repo, issueNumber, issueTitle, branch, worktreePath, force } = options;
+    const { repo, issueNumber, issueTitle, branch, worktreePath, force, onFailure } = options;
     const hookResults: HookResult[] = [];
 
     try {
@@ -230,7 +232,7 @@ export async function removeWorktreeWorkflow(
                 };
             }
 
-            const results = await executeHooksForEvent('worktree-removed', payload);
+            const results = await executeHooksForEvent('worktree-removed', payload, { onFailure });
             hookResults.push(...results);
         }
 

--- a/packages/mcp/src/tools/add-issue.ts
+++ b/packages/mcp/src/tools/add-issue.ts
@@ -2,6 +2,7 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import * as z from 'zod';
 import type { ServerContext } from '../server.js';
 import type { ToolMeta } from '../types.js';
+import { loadHooksConfig } from '../tool-registry.js';
 import {
     executeHooksForEvent,
     hasHooksForEvent,
@@ -132,7 +133,10 @@ export function register(server: McpServer, context: ServerContext): void {
                         },
                     };
 
-                    const hookResults = await executeHooksForEvent('issue-created', payload);
+                    const hooksConfig = loadHooksConfig();
+                    const hookResults = await executeHooksForEvent('issue-created', payload, {
+                        onFailure: hooksConfig.onFailure,
+                    });
                     const successCount = hookResults.filter(r => r.success).length;
                     const failCount = hookResults.length - successCount;
 

--- a/packages/mcp/src/tools/start.ts
+++ b/packages/mcp/src/tools/start.ts
@@ -2,6 +2,7 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import * as z from 'zod';
 import type { ServerContext } from '../server.js';
 import type { ToolMeta } from '../types.js';
+import { loadHooksConfig } from '../tool-registry.js';
 import {
     getCurrentBranch,
     executeHooksForEvent,
@@ -162,7 +163,10 @@ export function register(server: McpServer, context: ServerContext): void {
                         branch,
                     };
 
-                    const hookResults = await executeHooksForEvent('issue-started', payload);
+                    const hooksConfig = loadHooksConfig();
+                    const hookResults = await executeHooksForEvent('issue-started', payload, {
+                        onFailure: hooksConfig.onFailure,
+                    });
                     const successCount = hookResults.filter(r => r.success).length;
                     const failCount = hookResults.length - successCount;
 


### PR DESCRIPTION
## Summary

- Add `OnFailureBehavior` type (`'fail-fast' | 'continue'`) to control hook execution behavior
- Allow per-event overrides via `eventDefaults` in event-hooks.json
- Add global default via `hooks.onFailure` in CLI/MCP config
- Update VS Code extension with `ghProjects.hooksOnFailure` setting
- Preserve backward compatibility (default remains fail-fast)

## Configuration

**Global default** (~/.config/ghp-cli/config.json):
```json
{
  "hooks": {
    "onFailure": "continue"
  }
}
```

**Per-event override** (~/.config/ghp-cli/event-hooks.json):
```json
{
  "hooks": [...],
  "eventDefaults": {
    "pre-pr": { "onFailure": "fail-fast" },
    "issue-created": { "onFailure": "continue" }
  }
}
```

## Test plan

- [x] All 186 existing tests pass
- [x] 7 new tests for onFailure behavior in executor.test.ts
- [ ] Manual test: Configure `continue` and verify all hooks run even when one fails
- [ ] Manual test: Verify per-event override takes precedence over global

Relates to #237

🤖 Generated with [Claude Code](https://claude.ai/code)