### PR TITLE
feat: worktree branch swapping, pipeline management, and MCP repo scoping

### DIFF
--- a/.ghp/config.json
+++ b/.ghp/config.json
@@ -13,7 +13,14 @@
     }
   },
   "parallelWork": {
-    "claudeCommand": "start"
+    "claudeCommand": "start",
+    "dashboard": {
+      "mode": "window",
+      "focusedAgent": {
+        "direction": "vertical",
+        "size": "60%"
+      }
+    }
   },
   "shortcuts": {
     "bugs": {
@@ -30,5 +37,13 @@
       "status": "Todo",
       "unassigned": true
     }
+  },
+  "pipeline": {
+    "stages": [
+      "planning",
+      "working",
+      "code_review",
+      "stopped"
+    ]
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ firebase-debug.log
 .env.local
 .env.*.local
 
+# Ragtime local context
+.ragtime/
+
 # Source repos (being migrated)
 ghp-cli/
 ghp-core/

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.18.0
+
+### Minor Changes
+
+- Add `--repo owner/name` flag to scope MCP server instances to a specific GitHub repo. The CLI's `ghp mcp --config --repo` generates per-repo config with unique server keys. Also includes pipeline dashboard enhancements, hook modes, and terminal utility improvements.
+
 ## 0.17.0
 
 ### Minor Changes

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.16.1
+
+### Patch Changes
+
+- Fix dashboard pane-pull to use worktree path lookup instead of window name matching, preventing breakage from emoji-prefixed window titles
+
 ## 0.13.0
 
 ### Minor Changes

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.16.2
+
+### Patch Changes
+
+- Fix pane-pull parsing to use tab separators, preventing emoji window names from breaking field splitting
+
 ## 0.16.1
 
 ### Patch Changes

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.17.0
+
+### Minor Changes
+
+- Add hook modes and hot-swap support to the pipeline dashboard
+
+  - Hook modes: configure workflow modes (e.g., planning, testing, review) that change which hook scripts run. Mode-specific hooks use a dot-suffix convention (`.ghp/hooks/agent-focused.testing`), falling back to the unsuffixed script.
+  - Dashboard `[m]` keystroke cycles through configured modes (including a "default" position for unsuffixed hooks).
+  - Hot-swap: switching between focused agents fires a single `agent-swapped` hook with both old and new agent payloads, avoiding port conflicts. Falls back to sequential unfocus→focus if no swap hook exists.
+  - New config fields: `pipeline.hookModes`, `pipeline.defaultHookMode`, `pipeline.hookModeSwapOrder`.
+  - New commands: `ghp pipeline agent-swapped`, `ghp pipeline mode`.
+  - `--mode` flag on `agent-focused` and `agent-unfocused` commands.
+  - Expanded setup wizard with all 13 hook questions (6 directory hooks, 7 event hooks) plus mode configuration. Adds flavor save option to interactive wizard.
+  - Dashboard now calls hook scripts directly instead of spawning `ghp` child processes.
+
 ## 0.16.3
 
 ### Patch Changes

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.13.0
+
+### Minor Changes
+
+- Add worktree swap commands, configurable pipeline stages, dashboard with pane-pull, and stage emoji indicators
+
+  - `ghp wt move-to/clean/status/ready/next` — swap worktree branches into main repo for integration testing
+  - `ghp pipeline dashboard` — interactive kanban dashboard with tmux pane-pull
+  - `ghp pipeline advance/set/stages` — agents self-report pipeline progress
+  - `ghp status` — unified pipeline + agent status view
+  - `--background` flag on `ghp start/switch --parallel` to open agent terminals without stealing focus
+  - Stage emojis in tmux window titles (e.g., 🔨 ghp-271) update automatically on transitions
+  - Configurable pipeline stages via `ghp config pipeline.stages`
+
 ## 0.12.0
 
 ### Minor Changes

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.16.3
+
+### Patch Changes
+
+- Always register worktrees in the pipeline dashboard when in parallel mode, even if the worktree already existed
+
 ## 0.16.2
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bretwardjames/ghp-cli",
-  "version": "0.16.3",
+  "version": "0.17.0",
   "description": "GitHub Projects CLI - manage project boards from your terminal",
   "main": "./dist/index.js",
   "bin": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bretwardjames/ghp-cli",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "GitHub Projects CLI - manage project boards from your terminal",
   "main": "./dist/index.js",
   "bin": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bretwardjames/ghp-cli",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "GitHub Projects CLI - manage project boards from your terminal",
   "main": "./dist/index.js",
   "bin": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bretwardjames/ghp-cli",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "GitHub Projects CLI - manage project boards from your terminal",
   "main": "./dist/index.js",
   "bin": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bretwardjames/ghp-cli",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "GitHub Projects CLI - manage project boards from your terminal",
   "main": "./dist/index.js",
   "bin": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bretwardjames/ghp-cli",
-  "version": "0.16.2",
+  "version": "0.16.3",
   "description": "GitHub Projects CLI - manage project boards from your terminal",
   "main": "./dist/index.js",
   "bin": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bretwardjames/ghp-cli",
-  "version": "0.12.0",
+  "version": "0.14.0",
   "description": "GitHub Projects CLI - manage project boards from your terminal",
   "main": "./dist/index.js",
   "bin": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bretwardjames/ghp-cli",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "description": "GitHub Projects CLI - manage project boards from your terminal",
   "main": "./dist/index.js",
   "bin": {

--- a/packages/cli/src/commands/agents.ts
+++ b/packages/cli/src/commands/agents.ts
@@ -18,7 +18,7 @@ import {
     type SessionWatcher,
 } from '@bretwardjames/ghp-core';
 import { confirmWithDefault, isInteractive } from '../prompts.js';
-import { killTmuxWindow, isInsideTmux } from '../terminal-utils.js';
+import { killTmuxWindow } from '../terminal-utils.js';
 import { exit, registerCleanupHandler } from '../exit.js';
 
 // Track active session watchers
@@ -196,17 +196,13 @@ async function stopAgent(agentId: string, issueNumber: number): Promise<void> {
 
     console.log(chalk.dim(`Stopping agent for #${issueNumber}...`));
 
-    // Try to kill the tmux window if we're in tmux
-    if (isInsideTmux()) {
-        const windowName = `ghp-${issueNumber}`;
-        const result = await killTmuxWindow(windowName);
-        if (result.success) {
-            console.log(chalk.dim(`Killed tmux window: ${windowName}`));
-        } else {
-            console.log(chalk.dim(`Tmux window not found: ${windowName}`));
-        }
+    // Try to kill the tmux window (works even if we're not inside tmux)
+    const windowName = `ghp-${issueNumber}`;
+    const result = await killTmuxWindow(windowName);
+    if (result.success) {
+        console.log(chalk.dim(`Killed tmux window: ${windowName}`));
     } else if (agent.pid > 0) {
-        // Fall back to PID-based kill if not in tmux
+        // Fall back to PID-based kill if tmux window wasn't found
         try {
             process.kill(agent.pid, 'SIGTERM');
             console.log(chalk.dim(`Sent SIGTERM to PID ${agent.pid}`));
@@ -248,11 +244,11 @@ async function stopAllAgents(force?: boolean): Promise<void> {
 
     let stopped = 0;
     for (const agent of agents) {
-        // Try to kill tmux window
-        if (isInsideTmux()) {
-            const windowName = `ghp-${agent.issueNumber}`;
-            await killTmuxWindow(windowName);
-        } else if (agent.pid > 0) {
+        // Try to kill tmux window (works even if we're not inside tmux)
+        const windowName = `ghp-${agent.issueNumber}`;
+        const result = await killTmuxWindow(windowName);
+        if (!result.success && agent.pid > 0) {
+            // Fall back to PID-based kill
             try {
                 process.kill(agent.pid, 'SIGTERM');
             } catch {

--- a/packages/cli/src/commands/agents.ts
+++ b/packages/cli/src/commands/agents.ts
@@ -18,7 +18,7 @@ import {
     type SessionWatcher,
 } from '@bretwardjames/ghp-core';
 import { confirmWithDefault, isInteractive } from '../prompts.js';
-import { killTmuxWindow } from '../terminal-utils.js';
+import { killTmuxWindow, killTmuxSession, agentWindowName, agentSessionName } from '../terminal-utils.js';
 import { exit, registerCleanupHandler } from '../exit.js';
 
 // Track active session watchers
@@ -196,11 +196,14 @@ async function stopAgent(agentId: string, issueNumber: number): Promise<void> {
 
     console.log(chalk.dim(`Stopping agent for #${issueNumber}...`));
 
-    // Try to kill the tmux window (works even if we're not inside tmux)
-    const windowName = `ghp-${issueNumber}`;
-    const result = await killTmuxWindow(windowName);
-    if (result.success) {
-        console.log(chalk.dim(`Killed tmux window: ${windowName}`));
+    // Try to kill the tmux window and/or session (works even if we're not inside tmux)
+    const windowName = agentWindowName(issueNumber);
+    const sessionName = agentSessionName(issueNumber);
+    const windowResult = await killTmuxWindow(windowName);
+    const sessionResult = await killTmuxSession(sessionName);
+    if (windowResult.success || sessionResult.success) {
+        const killed = [windowResult.success && 'window', sessionResult.success && 'session'].filter(Boolean).join(' + ');
+        console.log(chalk.dim(`Killed tmux ${killed}: ${windowName}`));
     } else if (agent.pid > 0) {
         // Fall back to PID-based kill if tmux window wasn't found
         try {
@@ -244,10 +247,12 @@ async function stopAllAgents(force?: boolean): Promise<void> {
 
     let stopped = 0;
     for (const agent of agents) {
-        // Try to kill tmux window (works even if we're not inside tmux)
-        const windowName = `ghp-${agent.issueNumber}`;
-        const result = await killTmuxWindow(windowName);
-        if (!result.success && agent.pid > 0) {
+        // Try to kill tmux window and/or session (works even if we're not inside tmux)
+        const windowName = agentWindowName(agent.issueNumber);
+        const sessionName = agentSessionName(agent.issueNumber);
+        const windowResult = await killTmuxWindow(windowName);
+        const sessionResult = await killTmuxSession(sessionName);
+        if (!windowResult.success && !sessionResult.success && agent.pid > 0) {
             // Fall back to PID-based kill
             try {
                 process.kill(agent.pid, 'SIGTERM');
@@ -278,7 +283,7 @@ async function startSessionWatchers(): Promise<void> {
 
         try {
             // Pass tmux window name for permission detection
-            const tmuxWindowName = `ghp-${agent.issueNumber}`;
+            const tmuxWindowName = agentWindowName(agent.issueNumber);
             const watcher = await createSessionWatcher(agent.worktreePath, tmuxWindowName);
             if (watcher) {
                 // Update registry when status changes

--- a/packages/cli/src/commands/dashboard-pipeline.ts
+++ b/packages/cli/src/commands/dashboard-pipeline.ts
@@ -226,11 +226,12 @@ function renderDashboard(
     process.stdout.write('\x1b[2J\x1b[H'); // clear
 
     const triggerStage = getIntegrationTriggerStage();
-    const waiting = entries.filter(e => e.agent?.waitingForInput);
+    const waiting = entries.filter(e => e.agent?.waitingForInput || e.pipeline.stage === 'needs_attention');
     const ready   = entries.filter(e => e.pipeline.stage === triggerStage && !e.inMainRepo);
     const testing = entries.filter(e => e.inMainRepo);
     const working = entries.filter(e =>
         !e.agent?.waitingForInput &&
+        e.pipeline.stage !== 'needs_attention' &&
         e.pipeline.stage !== triggerStage &&
         !e.inMainRepo
     );
@@ -370,9 +371,10 @@ export async function pipelineDashboardCommand(options: DashboardOptions = {}): 
 
     function getNumberedEntry(entries: DashboardEntry[], digit: number): DashboardEntry | undefined {
         const triggerStage = getIntegrationTriggerStage();
-        const waiting = entries.filter(e => e.agent?.waitingForInput);
+        const waiting = entries.filter(e => e.agent?.waitingForInput || e.pipeline.stage === 'needs_attention');
         const working = entries.filter(e =>
             !e.agent?.waitingForInput &&
+            e.pipeline.stage !== 'needs_attention' &&
             e.pipeline.stage !== triggerStage &&
             !e.inMainRepo
         );

--- a/packages/cli/src/commands/dashboard-pipeline.ts
+++ b/packages/cli/src/commands/dashboard-pipeline.ts
@@ -158,6 +158,19 @@ async function findCoordinatorPane(): Promise<string | null> {
 }
 
 // ---------------------------------------------------------------------------
+// Git helpers
+// ---------------------------------------------------------------------------
+
+async function isMainRepoDirty(repoRoot: string): Promise<boolean> {
+    try {
+        const { stdout } = await execFileAsync('git', ['-C', repoRoot, 'status', '--porcelain']);
+        return stdout.trim().length > 0;
+    } catch {
+        return false;
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Rendering
 // ---------------------------------------------------------------------------
 
@@ -205,7 +218,8 @@ function renderDashboard(
     entries: DashboardEntry[],
     tmuxMode: TmuxMode,
     attached: AttachedPane | null,
-    now: string
+    now: string,
+    mainDirty: boolean
 ): void {
     process.stdout.write('\x1b[2J\x1b[H'); // clear
 
@@ -240,7 +254,8 @@ function renderDashboard(
     }
 
     if (ready.length > 0) {
-        console.log(chalk.green.bold('  READY FOR INTEGRATION'));
+        const blocked = mainDirty ? chalk.red.bold('  BLOCKED') + chalk.red(' — main repo has uncommitted changes') : '';
+        console.log(chalk.green.bold('  READY FOR INTEGRATION') + blocked);
         for (const e of ready) {
             const age = formatAge(e.pipeline.stageEnteredAt);
             const active = isAttached(e, attached);
@@ -345,8 +360,10 @@ export async function pipelineDashboardCommand(options: DashboardOptions = {}): 
     }
 
     async function refresh(): Promise<void> {
+        const repoRoot = await getMainWorktreeRoot();
         const entries = await buildEntries();
-        renderDashboard(entries, tmuxMode, attached, new Date().toLocaleTimeString());
+        const dirty = repoRoot ? await isMainRepoDirty(repoRoot) : false;
+        renderDashboard(entries, tmuxMode, attached, new Date().toLocaleTimeString(), dirty);
     }
 
     function getNumberedEntry(entries: DashboardEntry[], digit: number): DashboardEntry | undefined {

--- a/packages/cli/src/commands/dashboard-pipeline.ts
+++ b/packages/cli/src/commands/dashboard-pipeline.ts
@@ -17,6 +17,7 @@ import { getAllPipelineEntries, getReadyWorktrees, getIntegrationTriggerStage, g
 import { readSwapState } from './worktree-swap-state.js';
 import { worktreeCleanCommand, worktreeNextCommand } from './worktree-swap.js';
 import { registerCleanupHandler, resetExitState } from '../exit.js';
+import { adminWindowName, agentSessionName, getTmuxPrefix, tmuxSessionExists } from '../terminal-utils.js';
 
 // Guard: when true, the dashboard cleanup handler is a no-op
 let suppressCleanup = false;
@@ -59,11 +60,16 @@ interface AttachedPane {
     sourceWindowName: string;
 }
 
+interface ViewportState {
+    paneId: string;
+    attachedIssue: number | null;
+}
+
 interface DashboardOptions {
     interval?: string;
 }
 
-type TmuxMode = 'pane' | 'window';
+type TmuxMode = 'pane' | 'window' | 'session';
 
 // ---------------------------------------------------------------------------
 // tmux helpers — window mode (join-pane pull/release)
@@ -153,6 +159,59 @@ async function selectPane(paneId: string): Promise<void> {
     } catch { /* ignore */ }
 }
 
+// ---------------------------------------------------------------------------
+// tmux helpers — session mode (viewport with nested attach)
+// ---------------------------------------------------------------------------
+
+/** Create the viewport pane next to the dashboard. Returns the pane ID. */
+async function createViewportPane(dashPaneId: string): Promise<string | null> {
+    const { dashboard: dbConfig } = getParallelWorkConfig();
+    const dirFlag = dbConfig.focusedAgent.direction === 'horizontal' ? '-h' : '-v';
+    const size = dbConfig.focusedAgent.size;
+
+    try {
+        const { stdout } = await execFileAsync('tmux', [
+            'split-window', dirFlag, '-l', size, '-t', dashPaneId, '-d',
+            '-P', '-F', '#{pane_id}',
+            'echo "Press [1-9] to view an agent"; read',
+        ]);
+        return stdout.trim() || null;
+    } catch {
+        return null;
+    }
+}
+
+/** Attach the viewport pane to an agent session via respawn-pane. */
+async function attachViewportToSession(viewportPaneId: string, sessionName: string): Promise<void> {
+    try {
+        // TMUX="" prevents nested-tmux errors; the respawn replaces the viewport process.
+        // The = prefix forces exact session name matching (prevents ghp-agent-8 matching ghp-agent-86).
+        // Session names are validated to [a-zA-Z0-9_-]+ via prefix validation + integer issue numbers.
+        const escaped = sessionName.replace(/'/g, "'\\''");
+        await execFileAsync('tmux', [
+            'respawn-pane', '-k', '-t', viewportPaneId,
+            `TMUX="" tmux attach-session -t '=${escaped}'`,
+        ]);
+    } catch { /* best effort */ }
+}
+
+/** Detach the viewport pane (show placeholder). */
+async function detachViewport(viewportPaneId: string): Promise<void> {
+    try {
+        await execFileAsync('tmux', [
+            'respawn-pane', '-k', '-t', viewportPaneId,
+            'echo "Press [1-9] to view an agent"; read',
+        ]);
+    } catch { /* best effort */ }
+}
+
+/** Kill the viewport pane. */
+async function killViewportPane(viewportPaneId: string): Promise<void> {
+    try {
+        await execFileAsync('tmux', ['kill-pane', '-t', viewportPaneId]);
+    } catch { /* best effort */ }
+}
+
 /** Get the pane ID of the dashboard itself (this process). */
 function getDashboardPaneId(): string | null {
     // TMUX_PANE is set by tmux for each pane's process — unlike display-message
@@ -177,7 +236,7 @@ async function fireDashboardOpenedHook(paneId: string, mode?: string | null): Pr
             stdio: ['pipe', 'ignore', 'ignore'],
             detached: true,
         });
-        child.stdin.write(JSON.stringify({ pane_id: paneId, window_name: 'ghp-admin' }));
+        child.stdin.write(JSON.stringify({ pane_id: paneId, window_name: adminWindowName() }));
         child.stdin.end();
         child.unref();
     } catch { /* silent */ }
@@ -188,7 +247,8 @@ async function fireDashboardOpenedHook(paneId: string, mode?: string | null): Pr
 // ---------------------------------------------------------------------------
 
 async function findCoordinatorPane(): Promise<string | null> {
-    const candidates = ['ghp-root', 'ghp-coordinator', 'ghp-main'];
+    const prefix = getTmuxPrefix();
+    const candidates = [`${prefix}-root`, `${prefix}-coordinator`, `${prefix}-main`];
     for (const name of candidates) {
         try {
             const { stdout } = await execFileAsync('tmux', ['display-message', '-t', name, '-p', '#{window_name}']);
@@ -369,6 +429,12 @@ function renderDashboard(
 
     if (tmuxMode === 'pane') {
         console.log(chalk.dim(`[1-9] focus agent${modeLabel}  [i] next integration  [x] clean  [q] quit`));
+    } else if (tmuxMode === 'session') {
+        if (attached) {
+            console.log(chalk.dim(`[1-9] swap  [esc] detach${modeLabel}  [i] next integration  [x] clean  [q] quit`));
+        } else {
+            console.log(chalk.dim(`[1-9] attach session${modeLabel}  [i] next integration  [x] clean  [q] quit`));
+        }
     } else {
         if (attached) {
             console.log(chalk.dim(`[1-9] swap  [esc] send back${modeLabel}  [c] coordinator  [q] quit`));
@@ -401,6 +467,9 @@ export async function pipelineDashboardCommand(options: DashboardOptions = {}): 
     let dashboardPaneId: string | null = null;
     let coordinatorWindow: string | null = null;
     let refreshTimer: ReturnType<typeof setInterval> | null = null;
+
+    // Session mode viewport state
+    let viewport: ViewportState | null = null;
 
     // Hook mode state — runtime only, initialized from config
     const pipelineConfig = getConfig('pipeline') as any;
@@ -438,6 +507,25 @@ export async function pipelineDashboardCommand(options: DashboardOptions = {}): 
     }
 
     async function refresh(): Promise<void> {
+        // Session mode: validate attached session still exists
+        if (tmuxMode === 'session' && viewport?.attachedIssue != null) {
+            const sessionName = agentSessionName(viewport.attachedIssue);
+            const exists = await tmuxSessionExists(sessionName);
+            if (!exists) {
+                // Fire agent-unfocused hook before clearing state (fire-and-forget)
+                const repoRoot = await getMainWorktreeRoot();
+                if (repoRoot) {
+                    const entry = getAllPipelineEntries(repoRoot).find(e => e.issueNumber === viewport!.attachedIssue);
+                    if (entry) {
+                        runUserHookScript('agent-unfocused', agentPayload(entry), entry.worktreePath, currentHookMode);
+                    }
+                }
+                viewport.attachedIssue = null;
+                attached = null;
+                await detachViewport(viewport.paneId);
+            }
+        }
+
         const repoRoot = await getMainWorktreeRoot();
         const entries = await buildEntries();
         const dirty = repoRoot ? await isMainRepoDirty(repoRoot) : false;
@@ -613,14 +701,94 @@ export async function pipelineDashboardCommand(options: DashboardOptions = {}): 
     }
 
     // ---------------------------------------------------------------------------
+    // Session mode: attach/detach via viewport
+    // ---------------------------------------------------------------------------
+
+    async function attachSessionToViewport(issueNumber: number): Promise<void> {
+        if (!viewport) return;
+        if (viewport.attachedIssue === issueNumber) return; // already attached
+
+        const sessionName = agentSessionName(issueNumber);
+        const exists = await tmuxSessionExists(sessionName);
+        if (!exists) return;
+
+        let previousEntry: PipelineEntry | null = null;
+
+        // Hot-swap: if already viewing a different agent
+        if (viewport.attachedIssue != null) {
+            const repoRoot = await getMainWorktreeRoot();
+            if (repoRoot) {
+                previousEntry = getAllPipelineEntries(repoRoot).find(e => e.issueNumber === viewport!.attachedIssue) ?? null;
+            }
+        }
+
+        await attachViewportToSession(viewport.paneId, sessionName);
+        viewport.attachedIssue = issueNumber;
+        attached = { issueNumber, paneId: viewport.paneId, sourceWindowName: '' };
+
+        // Set pane border title
+        try {
+            await execFileAsync('tmux', ['select-pane', '-t', viewport.paneId, '-T', `Agent #${issueNumber}`]);
+        } catch { /* best effort */ }
+
+        // Fire hooks
+        const repoRoot = await getMainWorktreeRoot();
+        if (repoRoot) {
+            const newEntry = getAllPipelineEntries(repoRoot).find(e => e.issueNumber === issueNumber);
+            if (newEntry) {
+                if (previousEntry) {
+                    fireSwapHook(previousEntry, newEntry);
+                } else {
+                    runUserHookScript('agent-focused', agentPayload(newEntry), newEntry.worktreePath, currentHookMode);
+                }
+            }
+        }
+
+        await refresh();
+    }
+
+    /** Fire agent-unfocused hook and kill the viewport pane. Fire-and-forget safe. */
+    function cleanupViewport(): void {
+        if (!viewport) return;
+        if (viewport.attachedIssue != null) {
+            getMainWorktreeRoot().then(repoRoot => {
+                if (!repoRoot) return;
+                const entry = getAllPipelineEntries(repoRoot).find(e => e.issueNumber === viewport!.attachedIssue);
+                if (entry) runUserHookScript('agent-unfocused', agentPayload(entry), entry.worktreePath, currentHookMode);
+            }).catch(() => {});
+        }
+        killViewportPane(viewport.paneId).catch(() => {});
+    }
+
+    async function detachSessionFromViewport(): Promise<void> {
+        if (!viewport || viewport.attachedIssue == null) return;
+
+        // Fire agent-unfocused hook
+        const repoRoot = await getMainWorktreeRoot();
+        if (repoRoot) {
+            const entry = getAllPipelineEntries(repoRoot).find(e => e.issueNumber === viewport!.attachedIssue);
+            if (entry) {
+                runUserHookScript('agent-unfocused', agentPayload(entry), entry.worktreePath, currentHookMode);
+            }
+        }
+
+        await detachViewport(viewport.paneId);
+        viewport.attachedIssue = null;
+        attached = null;
+        await refresh();
+    }
+
+    // ---------------------------------------------------------------------------
     // Keypress handler
     // ---------------------------------------------------------------------------
 
     async function handleKey(key: string): Promise<void> {
-        // esc — send pane back (window mode) or refocus dashboard (pane mode)
+        // esc — send pane back (window mode), detach (session mode), or refocus dashboard (pane mode)
         if (key === '\x1b') {
             if (tmuxMode === 'pane' && dashboardPaneId) {
                 await selectPane(dashboardPaneId);
+            } else if (tmuxMode === 'session') {
+                await detachSessionFromViewport();
             } else if (tmuxMode === 'window' && attached) {
                 await sendPaneBack();
             }
@@ -629,7 +797,11 @@ export async function pipelineDashboardCommand(options: DashboardOptions = {}): 
 
         // q — quit
         if (key === 'q' || key === 'Q') {
-            if (attached) await sendPaneBack();
+            if (tmuxMode === 'session' && viewport) {
+                cleanupViewport();
+            } else if (attached) {
+                await sendPaneBack();
+            }
             if (refreshTimer) clearInterval(refreshTimer);
             if (process.stdin.isTTY) {
                 process.stdin.setRawMode(false);
@@ -671,10 +843,17 @@ export async function pipelineDashboardCommand(options: DashboardOptions = {}): 
         // m — cycle hook modes (includes null/"default" as the last position)
         if (key === 'm' || key === 'M') {
             if (hookModes.length > 0) {
+                const oldMode = currentHookMode;
                 const currentIdx = currentHookMode ? hookModes.indexOf(currentHookMode) : -1;
                 const nextIdx = currentIdx + 1;
                 // After the last named mode, wrap to null (default/unsuffixed hooks)
                 currentHookMode = nextIdx < hookModes.length ? hookModes[nextIdx] : null;
+                // Fire mode-switched hook (fire-and-forget, never mode-suffixed)
+                const modePayload = JSON.stringify({ oldMode: oldMode ?? null, newMode: currentHookMode ?? null });
+                const modeRoot = await getMainWorktreeRoot();
+                if (modeRoot) {
+                    runUserHookScript('mode-switched', modePayload, modeRoot, null);
+                }
                 await refresh();
             }
             return;
@@ -687,7 +866,7 @@ export async function pipelineDashboardCommand(options: DashboardOptions = {}): 
             return;
         }
 
-        // 1-9 — zoom (pane mode) or pull (window mode)
+        // 1-9 — focus (pane mode), pull (window mode), or attach (session mode)
         const digit = parseInt(key, 10);
         if (!isNaN(digit) && digit >= 1 && digit <= 9) {
             const entries = await buildEntries();
@@ -696,6 +875,8 @@ export async function pipelineDashboardCommand(options: DashboardOptions = {}): 
 
             if (tmuxMode === 'pane') {
                 await focusAgent(entry.pipeline.issueNumber);
+            } else if (tmuxMode === 'session') {
+                await attachSessionToViewport(entry.pipeline.issueNumber);
             } else {
                 await pullAgentPane(entry.pipeline.issueNumber);
             }
@@ -706,6 +887,14 @@ export async function pipelineDashboardCommand(options: DashboardOptions = {}): 
     // ---------------------------------------------------------------------------
     // Start
     // ---------------------------------------------------------------------------
+
+    // Session mode: create viewport pane at startup
+    if (tmuxMode === 'session' && dashboardPaneId) {
+        const vpPaneId = await createViewportPane(dashboardPaneId);
+        if (vpPaneId) {
+            viewport = { paneId: vpPaneId, attachedIssue: null };
+        }
+    }
 
     await refresh();
 
@@ -721,7 +910,11 @@ export async function pipelineDashboardCommand(options: DashboardOptions = {}): 
     registerCleanupHandler(() => {
         if (suppressCleanup) return;
         if (refreshTimer) clearInterval(refreshTimer);
-        if (attached) releasePaneToWindow(attached).catch(() => {});
+        if (viewport) {
+            cleanupViewport();
+        } else if (attached) {
+            releasePaneToWindow(attached).catch(() => {});
+        }
         process.stdin.setRawMode?.(false);
         process.stdin.pause();
     });
@@ -732,7 +925,11 @@ export async function pipelineDashboardCommand(options: DashboardOptions = {}): 
         process.stdin.setEncoding('utf-8');
         process.stdin.on('data', (key: string) => {
             if (key === '\u0003') {
-                if (attached) releasePaneToWindow(attached).catch(() => {});
+                if (viewport) {
+                    cleanupViewport();
+                } else if (attached) {
+                    releasePaneToWindow(attached).catch(() => {});
+                }
                 if (refreshTimer) clearInterval(refreshTimer);
                 process.stdin.setRawMode(false);
                 process.stdin.pause();

--- a/packages/cli/src/commands/dashboard-pipeline.ts
+++ b/packages/cli/src/commands/dashboard-pipeline.ts
@@ -7,12 +7,13 @@
  */
 
 import chalk from 'chalk';
-import { execFile, execFileSync } from 'child_process';
+import { execFile, spawn } from 'child_process';
 import { promisify } from 'util';
 import { getAgentSummaries, type AgentSummary } from '@bretwardjames/ghp-core';
 import { getMainWorktreeRoot } from '../git-utils.js';
-import { getConfig } from '../config.js';
-import { getAllPipelineEntries, getReadyWorktrees, getIntegrationTriggerStage, getStageEmoji, type PipelineEntry } from '../pipeline-registry.js';
+import { getConfig, getParallelWorkConfig } from '../config.js';
+import { resolveHookScript, runUserHookScript } from './pipeline-commands.js';
+import { getAllPipelineEntries, getReadyWorktrees, getIntegrationTriggerStage, getPipelineStages, getStageEmoji, type PipelineEntry } from '../pipeline-registry.js';
 import { readSwapState } from './worktree-swap-state.js';
 import { worktreeCleanCommand, worktreeNextCommand } from './worktree-swap.js';
 import { registerCleanupHandler, resetExitState } from '../exit.js';
@@ -160,6 +161,29 @@ function getDashboardPaneId(): string | null {
 }
 
 // ---------------------------------------------------------------------------
+// Hook: dashboard-opened
+// ---------------------------------------------------------------------------
+
+async function fireDashboardOpenedHook(paneId: string, mode?: string | null): Promise<void> {
+    const repoRoot = await getMainWorktreeRoot();
+    if (!repoRoot) return;
+
+    const scriptPath = resolveHookScript(repoRoot, 'dashboard-opened', mode);
+    if (!scriptPath) return;
+
+    try {
+        const child = spawn(scriptPath, [], {
+            cwd: repoRoot,
+            stdio: ['pipe', 'ignore', 'ignore'],
+            detached: true,
+        });
+        child.stdin.write(JSON.stringify({ pane_id: paneId, window_name: 'ghp-admin' }));
+        child.stdin.end();
+        child.unref();
+    } catch { /* silent */ }
+}
+
+// ---------------------------------------------------------------------------
 // Coordinator pane detection
 // ---------------------------------------------------------------------------
 
@@ -238,23 +262,34 @@ function renderDashboard(
     tmuxMode: TmuxMode,
     attached: AttachedPane | null,
     now: string,
-    mainDirty: boolean
+    mainDirty: boolean,
+    hookMode?: string | null,
+    hookModes?: string[],
 ): void {
     process.stdout.write('\x1b[2J\x1b[H'); // clear
 
     const triggerStage = getIntegrationTriggerStage();
+    const stages = getPipelineStages();
+    const hasTriggerStage = stages.includes(triggerStage);
+
     const waiting = entries.filter(e => e.agent?.waitingForInput || e.pipeline.stage === 'needs_attention');
-    const ready   = entries.filter(e => e.pipeline.stage === triggerStage && !e.inMainRepo);
+    const ready   = hasTriggerStage ? entries.filter(e => e.pipeline.stage === triggerStage && !e.inMainRepo) : [];
     const testing = entries.filter(e => e.inMainRepo);
+    const stopped = entries.filter(e =>
+        e.pipeline.stage === 'stopped' &&
+        !e.agent?.waitingForInput &&
+        !e.inMainRepo
+    );
     const working = entries.filter(e =>
         !e.agent?.waitingForInput &&
         e.pipeline.stage !== 'needs_attention' &&
-        e.pipeline.stage !== triggerStage &&
+        e.pipeline.stage !== 'stopped' &&
+        (!hasTriggerStage || e.pipeline.stage !== triggerStage) &&
         !e.inMainRepo
     );
 
-    // Number all entries for keypress selection (attention first, then working)
-    const numbered = [...waiting, ...working];
+    // Number all entries for keypress selection (attention first, then stopped, then working)
+    const numbered = [...waiting, ...stopped, ...working];
     numbered.forEach((e, i) => { e.attentionIndex = i + 1; });
 
     const attachedLabel = attached
@@ -269,6 +304,15 @@ function renderDashboard(
         for (const e of waiting) {
             const key = chalk.yellow(`[${e.attentionIndex}]`);
             renderEntry(e, key, attached, true);
+        }
+        console.log();
+    }
+
+    if (stopped.length > 0) {
+        console.log(chalk.dim.bold('  STOPPED'));
+        for (const e of stopped) {
+            const key = e.attentionIndex ? chalk.dim(`[${e.attentionIndex}]`) : '   ';
+            renderEntry(e, `${key} ${chalk.dim('⏸')}`, attached, false);
         }
         console.log();
     }
@@ -319,13 +363,17 @@ function renderDashboard(
 
     console.log(chalk.dim('─'.repeat(70)));
 
+    const modeLabel = (hookModes && hookModes.length > 0)
+        ? `  [m] mode: ${hookMode ? chalk.cyan(hookMode) : chalk.dim('default')}`
+        : '';
+
     if (tmuxMode === 'pane') {
-        console.log(chalk.dim('[1-9] focus agent  [i] next integration  [x] clean  [q] quit'));
+        console.log(chalk.dim(`[1-9] focus agent${modeLabel}  [i] next integration  [x] clean  [q] quit`));
     } else {
         if (attached) {
-            console.log(chalk.dim('[1-9] swap  [esc] send back  [c] coordinator  [q] quit'));
+            console.log(chalk.dim(`[1-9] swap  [esc] send back${modeLabel}  [c] coordinator  [q] quit`));
         } else {
-            console.log(chalk.dim('[1-9] pull pane  [i] next integration  [x] clean  [c] coordinator  [q] quit'));
+            console.log(chalk.dim(`[1-9] pull pane${modeLabel}  [i] next integration  [x] clean  [c] coordinator  [q] quit`));
         }
     }
 }
@@ -353,6 +401,16 @@ export async function pipelineDashboardCommand(options: DashboardOptions = {}): 
     let dashboardPaneId: string | null = null;
     let coordinatorWindow: string | null = null;
     let refreshTimer: ReturnType<typeof setInterval> | null = null;
+
+    // Hook mode state — runtime only, initialized from config
+    const pipelineConfig = getConfig('pipeline') as any;
+    const hookModes: string[] = pipelineConfig?.hookModes ?? [];
+    let currentHookMode: string | null = pipelineConfig?.defaultHookMode ?? null;
+    // Validate that defaultHookMode is in the hookModes list
+    if (currentHookMode && hookModes.length > 0 && !hookModes.includes(currentHookMode)) {
+        currentHookMode = hookModes[0];
+    }
+    if (hookModes.length === 0) currentHookMode = null;
 
     if (process.env.TMUX) {
         dashboardPaneId = getDashboardPaneId();
@@ -383,19 +441,28 @@ export async function pipelineDashboardCommand(options: DashboardOptions = {}): 
         const repoRoot = await getMainWorktreeRoot();
         const entries = await buildEntries();
         const dirty = repoRoot ? await isMainRepoDirty(repoRoot) : false;
-        renderDashboard(entries, tmuxMode, attached, new Date().toLocaleTimeString(), dirty);
+        renderDashboard(entries, tmuxMode, attached, new Date().toLocaleTimeString(), dirty, currentHookMode, hookModes);
     }
 
     function getNumberedEntry(entries: DashboardEntry[], digit: number): DashboardEntry | undefined {
         const triggerStage = getIntegrationTriggerStage();
+        const stages = getPipelineStages();
+        const hasTriggerStage = stages.includes(triggerStage);
+
         const waiting = entries.filter(e => e.agent?.waitingForInput || e.pipeline.stage === 'needs_attention');
+        const stopped = entries.filter(e =>
+            e.pipeline.stage === 'stopped' &&
+            !e.agent?.waitingForInput &&
+            !e.inMainRepo
+        );
         const working = entries.filter(e =>
             !e.agent?.waitingForInput &&
             e.pipeline.stage !== 'needs_attention' &&
-            e.pipeline.stage !== triggerStage &&
+            e.pipeline.stage !== 'stopped' &&
+            (!hasTriggerStage || e.pipeline.stage !== triggerStage) &&
             !e.inMainRepo
         );
-        const numbered = [...waiting, ...working];
+        const numbered = [...waiting, ...stopped, ...working];
         return numbered[digit - 1];
     }
 
@@ -420,11 +487,70 @@ export async function pipelineDashboardCommand(options: DashboardOptions = {}): 
     // Window mode: pull/release
     // ---------------------------------------------------------------------------
 
+    /** Build the JSON payload for a focused/unfocused hook. */
+    function agentPayload(entry: PipelineEntry): string {
+        return JSON.stringify({
+            issueNumber: entry.issueNumber,
+            worktreePath: entry.worktreePath,
+            branch: entry.branch,
+        });
+    }
+
+    /** Fire the agent-swapped hook, or fall back to sequential unfocus→focus. */
+    async function fireSwapHook(oldEntry: PipelineEntry, newEntry: PipelineEntry): Promise<void> {
+        const repoRoot = await getMainWorktreeRoot();
+        if (!repoRoot) return;
+
+        const swapScript = resolveHookScript(repoRoot, 'agent-swapped', currentHookMode);
+
+        if (swapScript) {
+            // Atomic swap hook
+            const payload = JSON.stringify({
+                old: { issueNumber: oldEntry.issueNumber, worktreePath: oldEntry.worktreePath, branch: oldEntry.branch },
+                new: { issueNumber: newEntry.issueNumber, worktreePath: newEntry.worktreePath, branch: newEntry.branch },
+            });
+            try {
+                const child = spawn(swapScript, [], {
+                    cwd: newEntry.worktreePath,
+                    stdio: ['pipe', 'ignore', 'ignore'],
+                    detached: true,
+                });
+                child.stdin.write(payload);
+                child.stdin.end();
+                child.unref();
+            } catch { /* silent */ }
+        } else {
+            // Fallback: sequential unfocus→focus (respecting hookModeSwapOrder)
+            // Await the first to guarantee ordering; second is fire-and-forget
+            const swapOrder = pipelineConfig?.hookModeSwapOrder ?? 'unfocus-first';
+            if (swapOrder === 'focus-first') {
+                await runUserHookScript('agent-focused', agentPayload(newEntry), newEntry.worktreePath, currentHookMode);
+                runUserHookScript('agent-unfocused', agentPayload(oldEntry), oldEntry.worktreePath, currentHookMode);
+            } else {
+                await runUserHookScript('agent-unfocused', agentPayload(oldEntry), oldEntry.worktreePath, currentHookMode);
+                runUserHookScript('agent-focused', agentPayload(newEntry), newEntry.worktreePath, currentHookMode);
+            }
+        }
+    }
+
     async function pullAgentPane(issueNumber: number): Promise<void> {
-        // Hot-swap: release current pane before pulling the new one
+        let previousEntry: PipelineEntry | null = null;
+
+        // Hot-swap: if already viewing a different agent
         if (attached) {
             if (attached.issueNumber === issueNumber) return; // already showing this one
-            await sendPaneBack();
+
+            // Look up the old entry before releasing
+            if (attached.issueNumber > 0) {
+                const repoRoot = await getMainWorktreeRoot();
+                if (repoRoot) {
+                    previousEntry = getAllPipelineEntries(repoRoot).find(e => e.issueNumber === attached!.issueNumber) ?? null;
+                }
+            }
+
+            // Release the tmux pane
+            await releasePaneToWindow(attached);
+            attached = null;
         }
 
         if (!dashboardPaneId) return;
@@ -438,9 +564,14 @@ export async function pipelineDashboardCommand(options: DashboardOptions = {}): 
         const agent = await findAgentByWorktreePath(pipelineEntry.worktreePath);
         if (!agent) return;
 
+        // Read focused agent config for direction/size
+        const { dashboard: dbConfig } = getParallelWorkConfig();
+        const dirFlag = dbConfig.focusedAgent.direction === 'horizontal' ? '-h' : '-v';
+        const size = dbConfig.focusedAgent.size;
+
         // Pull the pane into dashboard
         try {
-            await execFileAsync('tmux', ['join-pane', '-v', '-l', '50%', '-t', dashboardPaneId, '-s', agent.paneId]);
+            await execFileAsync('tmux', ['join-pane', dirFlag, '-l', size, '-t', dashboardPaneId, '-s', agent.paneId]);
         } catch { return; }
 
         // Set pane border title so it's visually clear which agent is shown
@@ -449,11 +580,33 @@ export async function pipelineDashboardCommand(options: DashboardOptions = {}): 
         } catch { /* best effort */ }
 
         attached = { issueNumber, paneId: agent.paneId, sourceWindowName: agent.windowName };
+
+        // Fire hooks
+        if (previousEntry) {
+            // Hot-swap: atomic agent-swapped or sequential fallback
+            fireSwapHook(previousEntry, pipelineEntry);
+        } else {
+            // Fresh pull: agent-focused only
+            runUserHookScript('agent-focused', agentPayload(pipelineEntry), pipelineEntry.worktreePath, currentHookMode);
+        }
+
         await refresh();
     }
 
     async function sendPaneBack(): Promise<void> {
         if (!attached) return;
+
+        // Fire agent-unfocused hook before releasing (fire-and-forget)
+        if (attached.issueNumber > 0) {
+            const repoRoot = await getMainWorktreeRoot();
+            if (repoRoot) {
+                const entry = getAllPipelineEntries(repoRoot).find(e => e.issueNumber === attached!.issueNumber);
+                if (entry) {
+                    runUserHookScript('agent-unfocused', agentPayload(entry), entry.worktreePath, currentHookMode);
+                }
+            }
+        }
+
         await releasePaneToWindow(attached);
         attached = null;
         await refresh();
@@ -515,6 +668,18 @@ export async function pipelineDashboardCommand(options: DashboardOptions = {}): 
             return;
         }
 
+        // m — cycle hook modes (includes null/"default" as the last position)
+        if (key === 'm' || key === 'M') {
+            if (hookModes.length > 0) {
+                const currentIdx = currentHookMode ? hookModes.indexOf(currentHookMode) : -1;
+                const nextIdx = currentIdx + 1;
+                // After the last named mode, wrap to null (default/unsuffixed hooks)
+                currentHookMode = nextIdx < hookModes.length ? hookModes[nextIdx] : null;
+                await refresh();
+            }
+            return;
+        }
+
         // x — clean
         if (key === 'x' || key === 'X') {
             await safeExec(() => worktreeCleanCommand({}));
@@ -543,6 +708,12 @@ export async function pipelineDashboardCommand(options: DashboardOptions = {}): 
     // ---------------------------------------------------------------------------
 
     await refresh();
+
+    // Fire dashboard-opened hook (fire-and-forget)
+    if (dashboardPaneId) {
+        fireDashboardOpenedHook(dashboardPaneId, currentHookMode);
+    }
+
     refreshTimer = setInterval(() => {
         refresh().catch(() => {});
     }, intervalMs);

--- a/packages/cli/src/commands/dashboard-pipeline.ts
+++ b/packages/cli/src/commands/dashboard-pipeline.ts
@@ -131,15 +131,12 @@ async function findPaneForWorktree(worktreePath: string): Promise<string | null>
 /** Find pane + window info for a worktree path across all tmux windows. */
 async function findAgentByWorktreePath(worktreePath: string): Promise<{ paneId: string; windowName: string } | null> {
     try {
+        const sep = '\t';
         const { stdout } = await execFileAsync('tmux', [
-            'list-panes', '-a', '-F', '#{pane_id} #{window_name} #{pane_current_path}',
+            'list-panes', '-a', '-F', `#{pane_id}${sep}#{window_name}${sep}#{pane_current_path}`,
         ]);
         for (const line of stdout.trim().split('\n')) {
-            const parts = line.split(' ');
-            if (parts.length < 3) continue;
-            const paneId = parts[0];
-            const windowName = parts[1];
-            const panePath = parts.slice(2).join(' ');
+            const [paneId, windowName, panePath] = line.split(sep);
             if (panePath && panePath.startsWith(worktreePath)) {
                 return { paneId, windowName };
             }

--- a/packages/cli/src/commands/dashboard-pipeline.ts
+++ b/packages/cli/src/commands/dashboard-pipeline.ts
@@ -112,7 +112,7 @@ async function releasePaneToWindow(attached: AttachedPane): Promise<void> {
 // tmux helpers — pane mode (zoom/select)
 // ---------------------------------------------------------------------------
 
-/** Find the pane ID that contains a process whose cwd matches the worktree path. */
+/** Find the pane ID that contains a process whose cwd matches the worktree path (current window only). */
 async function findPaneForWorktree(worktreePath: string): Promise<string | null> {
     try {
         const { stdout } = await execFileAsync('tmux', [
@@ -122,6 +122,26 @@ async function findPaneForWorktree(worktreePath: string): Promise<string | null>
             const [paneId, panePath] = line.split(' ', 2);
             if (panePath && panePath.startsWith(worktreePath)) {
                 return paneId;
+            }
+        }
+    } catch { /* ignore */ }
+    return null;
+}
+
+/** Find pane + window info for a worktree path across all tmux windows. */
+async function findAgentByWorktreePath(worktreePath: string): Promise<{ paneId: string; windowName: string } | null> {
+    try {
+        const { stdout } = await execFileAsync('tmux', [
+            'list-panes', '-a', '-F', '#{pane_id} #{window_name} #{pane_current_path}',
+        ]);
+        for (const line of stdout.trim().split('\n')) {
+            const parts = line.split(' ');
+            if (parts.length < 3) continue;
+            const paneId = parts[0];
+            const windowName = parts[1];
+            const panePath = parts.slice(2).join(' ');
+            if (panePath && panePath.startsWith(worktreePath)) {
+                return { paneId, windowName };
             }
         }
     } catch { /* ignore */ }
@@ -410,17 +430,28 @@ export async function pipelineDashboardCommand(options: DashboardOptions = {}): 
             await sendPaneBack();
         }
 
-        const windowName = `ghp-${issueNumber}`;
         if (!dashboardPaneId) return;
-        const result = await pullPaneFromWindow(windowName, dashboardPaneId);
-        if (!result) return;
+
+        // Look up worktree path from pipeline registry, then find the pane by cwd
+        const repoRoot = await getMainWorktreeRoot();
+        if (!repoRoot) return;
+        const pipelineEntry = getAllPipelineEntries(repoRoot).find(e => e.issueNumber === issueNumber);
+        if (!pipelineEntry) return;
+
+        const agent = await findAgentByWorktreePath(pipelineEntry.worktreePath);
+        if (!agent) return;
+
+        // Pull the pane into dashboard
+        try {
+            await execFileAsync('tmux', ['join-pane', '-v', '-l', '50%', '-t', dashboardPaneId, '-s', agent.paneId]);
+        } catch { return; }
 
         // Set pane border title so it's visually clear which agent is shown
         try {
-            await execFileAsync('tmux', ['select-pane', '-t', result.paneId, '-T', `Agent #${issueNumber}`]);
+            await execFileAsync('tmux', ['select-pane', '-t', agent.paneId, '-T', `Agent #${issueNumber}`]);
         } catch { /* best effort */ }
 
-        attached = { issueNumber, paneId: result.paneId, sourceWindowName: result.sourceWindowName };
+        attached = { issueNumber, paneId: agent.paneId, sourceWindowName: agent.windowName };
         await refresh();
     }
 

--- a/packages/cli/src/commands/dashboard-pipeline.ts
+++ b/packages/cli/src/commands/dashboard-pipeline.ts
@@ -1,23 +1,9 @@
 /**
- * Pipeline dashboard — kanban view of all worktrees with pane-pull interaction.
+ * Pipeline dashboard — kanban view of all worktrees with interactive controls.
  *
- * Layout (no pane attached):
- *
- *   GHP Dashboard                    [14:22:03]
- *   ─────────────────────────────────────────────────────
- *   NEEDS ATTENTION      READY           IN TESTING
- *   ⚠ [1] #271 auth      ✓ [i] #269      ⟳ #268
- *     S1 · 23m             ready 8m         [x] clean
- *
- *   WORKING
- *   ● #273 export  S1 · 1h 4m
- *   ● #275 dark    S3 · 22m
- *   ─────────────────────────────────────────────────────
- *   [1-9] pull  [i] next  [x] clean  [c] coord  [q] quit
- *
- * Layout (pane attached, split right):
- *   The dashboard narrows and the agent pane fills the right side.
- *   tmux handles the visual split; we just move the pane in/out.
+ * Detects tmux layout mode at startup:
+ *   - pane mode:   agents are panes in the same window. [1-9] zooms the agent pane.
+ *   - window mode: agents are in separate windows. [1-9] pulls pane into dashboard window.
  */
 
 import chalk from 'chalk';
@@ -25,10 +11,33 @@ import { execFile, execFileSync } from 'child_process';
 import { promisify } from 'util';
 import { getAgentSummaries, type AgentSummary } from '@bretwardjames/ghp-core';
 import { getMainWorktreeRoot } from '../git-utils.js';
-import { getAllPipelineEntries, getReadyWorktrees, type PipelineEntry } from '../pipeline-registry.js';
+import { getConfig } from '../config.js';
+import { getAllPipelineEntries, getReadyWorktrees, getIntegrationTriggerStage, type PipelineEntry } from '../pipeline-registry.js';
 import { readSwapState } from './worktree-swap-state.js';
-import { worktreeMoveToCommand, worktreeCleanCommand, worktreeNextCommand } from './worktree-swap.js';
-import { registerCleanupHandler } from '../exit.js';
+import { worktreeCleanCommand, worktreeNextCommand } from './worktree-swap.js';
+import { registerCleanupHandler, resetExitState } from '../exit.js';
+
+// Guard: when true, the dashboard cleanup handler is a no-op
+let suppressCleanup = false;
+
+/**
+ * Run a command that might call exit() without killing the dashboard.
+ * Temporarily overrides process.exit, suppresses cleanup, and resets exit state.
+ */
+async function safeExec(fn: () => Promise<void>): Promise<void> {
+    const realExit = process.exit;
+    process.exit = (() => {}) as never;
+    suppressCleanup = true;
+    try {
+        await fn();
+    } catch { /* swallow ExitPendingError */ } finally {
+        // Wait a tick for any cleanup handlers to run (they'll be no-ops)
+        await new Promise(resolve => setTimeout(resolve, 50));
+        process.exit = realExit;
+        suppressCleanup = false;
+        resetExitState();
+    }
+}
 
 const execFileAsync = promisify(execFile);
 
@@ -40,36 +49,24 @@ interface DashboardEntry {
     pipeline: PipelineEntry;
     agent?: AgentSummary;
     inMainRepo: boolean;
-    /** 1-based index within the "needs attention" bucket, for keypress mapping */
     attentionIndex?: number;
-    /** 1-based index within the "ready" bucket, for [i] override */
-    readyIndex?: number;
 }
 
 interface AttachedPane {
     issueNumber: number;
-    /** tmux global pane ID, e.g. %23 */
     paneId: string;
-    /** Original window target the pane came from, e.g. ghp:ghp-271 */
-    sourceWindow: string;
+    sourceWindowName: string;
 }
 
 interface DashboardOptions {
     interval?: string;
 }
 
-// ---------------------------------------------------------------------------
-// tmux pane helpers
-// ---------------------------------------------------------------------------
+type TmuxMode = 'pane' | 'window';
 
-async function getCurrentPaneId(): Promise<string | null> {
-    try {
-        const { stdout } = await execFileAsync('tmux', ['display-message', '-p', '#{pane_id}']);
-        return stdout.trim() || null;
-    } catch {
-        return null;
-    }
-}
+// ---------------------------------------------------------------------------
+// tmux helpers — window mode (join-pane pull/release)
+// ---------------------------------------------------------------------------
 
 async function getCurrentWindowTarget(): Promise<string | null> {
     try {
@@ -80,43 +77,69 @@ async function getCurrentWindowTarget(): Promise<string | null> {
     }
 }
 
-/**
- * Pull a pane from a named window into the current window (horizontal split).
- * Returns the pane's global ID so we can send it back later.
- */
-async function pullPane(sourceWindowName: string): Promise<{ paneId: string; sourceWindow: string } | null> {
+async function pullPaneFromWindow(sourceWindowName: string, targetPaneId: string): Promise<{ paneId: string; sourceWindowName: string } | null> {
     try {
-        // Find the pane ID in the source window (first pane)
         const { stdout: paneIdOut } = await execFileAsync('tmux', [
             'display-message', '-t', sourceWindowName, '-p', '#{pane_id}',
         ]);
         const paneId = paneIdOut.trim();
         if (!paneId) return null;
 
-        const sourceWindow = await getCurrentWindowTarget();
-        if (!sourceWindow) return null;
-
-        // Join the pane into the current window, horizontal split
-        await execFileAsync('tmux', ['join-pane', '-h', '-s', paneId]);
-
-        return { paneId, sourceWindow };
+        // Split the dashboard pane vertically: dashboard stays on top, agent gets bottom 50%
+        await execFileAsync('tmux', ['join-pane', '-v', '-l', '50%', '-t', targetPaneId, '-s', paneId]);
+        return { paneId, sourceWindowName };
     } catch {
         return null;
     }
 }
 
-/**
- * Send a pane back to its original window.
- */
-async function releasePane(attached: AttachedPane): Promise<void> {
+async function releasePaneToWindow(attached: AttachedPane): Promise<void> {
     try {
-        await execFileAsync('tmux', ['join-pane', '-t', attached.sourceWindow, '-s', attached.paneId]);
-    } catch {
-        // If the window is gone, just break the pane into its own window
-        try {
-            await execFileAsync('tmux', ['break-pane', '-t', attached.paneId, '-d']);
-        } catch { /* best effort */ }
-    }
+        // break-pane -s = source pane to break out, -d = don't switch to it
+        await execFileAsync('tmux', ['break-pane', '-s', attached.paneId, '-d']);
+        // Restore the original window name (e.g., ghp-271)
+        const { stdout } = await execFileAsync('tmux', [
+            'display-message', '-t', attached.paneId, '-p', '#{window_id}',
+        ]);
+        const windowId = stdout.trim();
+        if (windowId) {
+            await execFileAsync('tmux', ['rename-window', '-t', windowId, attached.sourceWindowName]);
+        }
+    } catch { /* best effort */ }
+}
+
+// ---------------------------------------------------------------------------
+// tmux helpers — pane mode (zoom/select)
+// ---------------------------------------------------------------------------
+
+/** Find the pane ID that contains a process whose cwd matches the worktree path. */
+async function findPaneForWorktree(worktreePath: string): Promise<string | null> {
+    try {
+        const { stdout } = await execFileAsync('tmux', [
+            'list-panes', '-F', '#{pane_id} #{pane_current_path}',
+        ]);
+        for (const line of stdout.trim().split('\n')) {
+            const [paneId, panePath] = line.split(' ', 2);
+            if (panePath && panePath.startsWith(worktreePath)) {
+                return paneId;
+            }
+        }
+    } catch { /* ignore */ }
+    return null;
+}
+
+/** Select (focus) a pane. */
+async function selectPane(paneId: string): Promise<void> {
+    try {
+        await execFileAsync('tmux', ['select-pane', '-t', paneId]);
+    } catch { /* ignore */ }
+}
+
+/** Get the pane ID of the dashboard itself (this process). */
+function getDashboardPaneId(): string | null {
+    // TMUX_PANE is set by tmux for each pane's process — unlike display-message
+    // which returns the *active* pane, this reliably identifies our own pane.
+    return process.env.TMUX_PANE || null;
 }
 
 // ---------------------------------------------------------------------------
@@ -124,7 +147,6 @@ async function releasePane(attached: AttachedPane): Promise<void> {
 // ---------------------------------------------------------------------------
 
 async function findCoordinatorPane(): Promise<string | null> {
-    // Look for a window named ghp-root, ghp-coordinator, or ghp-main
     const candidates = ['ghp-root', 'ghp-coordinator', 'ghp-main'];
     for (const name of candidates) {
         try {
@@ -152,47 +174,67 @@ function issueLabel(entry: DashboardEntry): string {
 }
 
 function stageLine(entry: DashboardEntry): string {
-    const stage = chalk.dim(`S${entry.pipeline.stage}`);
+    const stage = chalk.dim(entry.pipeline.stage);
     const uptime = entry.agent?.uptime ? chalk.dim(` · ${entry.agent.uptime}`) : '';
     const port = entry.agent?.port ? chalk.dim(` :${entry.agent.port}`) : '';
     return `${stage}${uptime}${port}`;
 }
 
+function isAttached(entry: DashboardEntry, attached: AttachedPane | null): boolean {
+    return attached !== null && attached.issueNumber === entry.pipeline.issueNumber;
+}
+
+function renderEntry(
+    e: DashboardEntry,
+    prefix: string,
+    attached: AttachedPane | null,
+    showAction?: boolean
+): void {
+    const active = isAttached(e, attached);
+    const label = active
+        ? chalk.bgCyan.black(` #${e.pipeline.issueNumber} `) + '  ' + chalk.bold(e.pipeline.issueTitle.substring(0, 35))
+        : issueLabel(e);
+    const marker = active ? chalk.cyan('►') : ' ';
+    console.log(`  ${marker}${prefix} ${label}  ${stageLine(e)}`);
+    if (showAction && e.agent?.currentAction) {
+        console.log(`          ${chalk.dim(`└─ ${e.agent.currentAction.substring(0, 55)}`)}`);
+    }
+}
+
 function renderDashboard(
     entries: DashboardEntry[],
+    tmuxMode: TmuxMode,
     attached: AttachedPane | null,
     now: string
 ): void {
     process.stdout.write('\x1b[2J\x1b[H'); // clear
 
+    const triggerStage = getIntegrationTriggerStage();
     const waiting = entries.filter(e => e.agent?.waitingForInput);
-    const ready   = entries.filter(e => e.pipeline.stageStatus === 'ready' && !e.inMainRepo);
+    const ready   = entries.filter(e => e.pipeline.stage === triggerStage && !e.inMainRepo);
     const testing = entries.filter(e => e.inMainRepo);
     const working = entries.filter(e =>
         !e.agent?.waitingForInput &&
-        e.pipeline.stageStatus === 'in_progress' &&
+        e.pipeline.stage !== triggerStage &&
         !e.inMainRepo
     );
 
-    // Assign attention indices
-    waiting.forEach((e, i) => { e.attentionIndex = i + 1; });
-    ready.forEach((e, i)   => { e.readyIndex = i + 1; });
+    // Number all entries for keypress selection (attention first, then working)
+    const numbered = [...waiting, ...working];
+    numbered.forEach((e, i) => { e.attentionIndex = i + 1; });
 
-    const attachedNote = attached ? chalk.yellow(` │ ATTACHED: #${attached.issueNumber}`) : '';
-    console.log(chalk.bold('GHP Dashboard'), chalk.dim(`[${now}]`), attachedNote);
+    const attachedLabel = attached
+        ? chalk.bgCyan.black(` VIEWING: #${attached.issueNumber} `)
+        : '';
+
+    console.log(chalk.bold('GHP Pipeline'), chalk.dim(`[${now}]`), attachedLabel);
     console.log(chalk.dim('─'.repeat(70)));
-
-    // Top row: Needs Attention | Ready | In Testing (side by side if space)
-    const hasPriority = waiting.length > 0 || ready.length > 0 || testing.length > 0;
 
     if (waiting.length > 0) {
         console.log(chalk.yellow.bold('  NEEDS ATTENTION'));
         for (const e of waiting) {
             const key = chalk.yellow(`[${e.attentionIndex}]`);
-            console.log(`  ${key} ${issueLabel(e)}  ${stageLine(e)}`);
-            if (e.agent?.currentAction) {
-                console.log(`       ${chalk.yellow(`└─ ⚠ ${e.agent.currentAction.substring(0, 55)}`)}`);
-            }
+            renderEntry(e, key, attached, true);
         }
         console.log();
     }
@@ -200,19 +242,27 @@ function renderDashboard(
     if (ready.length > 0) {
         console.log(chalk.green.bold('  READY FOR INTEGRATION'));
         for (const e of ready) {
-            const age = formatAge(e.pipeline.readyAt);
-            console.log(`  ${chalk.green('✓')}  ${issueLabel(e)}  ${chalk.dim(age)}`);
+            const age = formatAge(e.pipeline.stageEnteredAt);
+            const active = isAttached(e, attached);
+            const marker = active ? chalk.cyan('►') : ' ';
+            const label = active
+                ? chalk.bgCyan.black(` #${e.pipeline.issueNumber} `) + '  ' + chalk.bold(e.pipeline.issueTitle.substring(0, 35))
+                : issueLabel(e);
+            console.log(`  ${marker}${chalk.green('✓')}  ${label}  ${chalk.dim(age)}`);
         }
-        console.log(`  ${chalk.dim(`[i] swap next   [i <n>] pick specific`)}`);
         console.log();
     }
 
     if (testing.length > 0) {
         console.log(chalk.blue.bold('  IN TESTING (main repo)'));
         for (const e of testing) {
-            console.log(`  ${chalk.blue('⟳')}  ${issueLabel(e)}`);
+            const active = isAttached(e, attached);
+            const marker = active ? chalk.cyan('►') : ' ';
+            const label = active
+                ? chalk.bgCyan.black(` #${e.pipeline.issueNumber} `) + '  ' + chalk.bold(e.pipeline.issueTitle.substring(0, 35))
+                : issueLabel(e);
+            console.log(`  ${marker}${chalk.blue('⟳')}  ${label}`);
         }
-        console.log(`  ${chalk.dim('[x] ghp wt clean')}`);
         console.log();
     }
 
@@ -220,26 +270,28 @@ function renderDashboard(
         console.log(chalk.white.bold('  WORKING'));
         for (const e of working) {
             const sym = e.agent?.status === 'running' ? chalk.green('●') : chalk.dim('○');
-            console.log(`  ${sym}  ${issueLabel(e)}  ${stageLine(e)}`);
-            if (e.agent?.currentAction) {
-                console.log(`       ${chalk.dim(`└─ ${e.agent.currentAction.substring(0, 55)}`)}`);
-            }
+            const key = e.attentionIndex ? chalk.dim(`[${e.attentionIndex}]`) : '   ';
+            renderEntry(e, `${key} ${sym}`, attached, true);
         }
         console.log();
     }
 
-    if (!hasPriority && working.length === 0) {
+    if (entries.length === 0) {
         console.log(chalk.dim('  No worktrees in pipeline.'));
-        console.log(chalk.dim('  Start one: ghp start <issue> --parallel'));
+        console.log(chalk.dim('  ghp start <issue> --parallel'));
         console.log();
     }
 
     console.log(chalk.dim('─'.repeat(70)));
 
-    if (attached) {
-        console.log(chalk.dim('[esc] send pane back  [c] coordinator  [q] quit'));
+    if (tmuxMode === 'pane') {
+        console.log(chalk.dim('[1-9] focus agent  [i] next integration  [x] clean  [q] quit'));
     } else {
-        console.log(chalk.dim('[1-9] pull agent pane  [i] next integration  [x] clean  [c] coordinator  [q] quit'));
+        if (attached) {
+            console.log(chalk.dim('[1-9] swap  [esc] send back  [c] coordinator  [q] quit'));
+        } else {
+            console.log(chalk.dim('[1-9] pull pane  [i] next integration  [x] clean  [c] coordinator  [q] quit'));
+        }
     }
 }
 
@@ -251,23 +303,29 @@ export async function pipelineDashboardCommand(options: DashboardOptions = {}): 
     const intervalSec = parseInt(options.interval || '2', 10);
     const intervalMs = intervalSec * 1000;
 
+    // Detect tmux mode from config
+    const parallelConfig = getConfig('parallelWork') as any;
+    const tmuxMode: TmuxMode = parallelConfig?.tmux?.mode ?? 'window';
+
     if (!process.env.TMUX) {
-        console.log(chalk.yellow('Warning:'), 'Not inside a tmux session — pane-pull features will be unavailable.');
-        console.log(chalk.dim('Displaying read-only status. Ctrl+C to exit.'));
+        console.log(chalk.yellow('Warning:'), 'Not inside tmux — interactive features disabled.');
+        console.log(chalk.dim('Showing read-only status. Ctrl+C to exit.'));
         console.log();
     }
 
     let attached: AttachedPane | null = null;
+    // zoomedIssue removed — pane mode uses select-pane (focus) instead of zoom
+    let dashboardPaneId: string | null = null;
     let coordinatorWindow: string | null = null;
     let refreshTimer: ReturnType<typeof setInterval> | null = null;
-    let running = true;
 
-    // Detect coordinator pane once at startup
     if (process.env.TMUX) {
-        coordinatorWindow = await findCoordinatorPane();
+        dashboardPaneId = getDashboardPaneId();
+        if (tmuxMode === 'window') {
+            coordinatorWindow = await findCoordinatorPane();
+        }
     }
 
-    // Build entries
     async function buildEntries(): Promise<DashboardEntry[]> {
         const repoRoot = await getMainWorktreeRoot();
         if (!repoRoot) return [];
@@ -288,47 +346,66 @@ export async function pipelineDashboardCommand(options: DashboardOptions = {}): 
 
     async function refresh(): Promise<void> {
         const entries = await buildEntries();
-        renderDashboard(entries, attached, new Date().toLocaleTimeString());
+        renderDashboard(entries, tmuxMode, attached, new Date().toLocaleTimeString());
     }
 
-    // Map attention-index → issue number for keypress handling
-    async function getAttentionMap(): Promise<Map<number, DashboardEntry>> {
-        const entries = await buildEntries();
-        const map = new Map<number, DashboardEntry>();
-        let idx = 1;
-        for (const e of entries) {
-            if (e.agent?.waitingForInput) {
-                map.set(idx++, e);
-            }
-        }
-        return map;
+    function getNumberedEntry(entries: DashboardEntry[], digit: number): DashboardEntry | undefined {
+        const triggerStage = getIntegrationTriggerStage();
+        const waiting = entries.filter(e => e.agent?.waitingForInput);
+        const working = entries.filter(e =>
+            !e.agent?.waitingForInput &&
+            e.pipeline.stage !== triggerStage &&
+            !e.inMainRepo
+        );
+        const numbered = [...waiting, ...working];
+        return numbered[digit - 1];
     }
 
-    async function pullAgentPane(issueNumber: number): Promise<void> {
-        if (attached) {
-            console.log(chalk.yellow('A pane is already attached. Send it back first (esc).'));
-            return;
-        }
+    // ---------------------------------------------------------------------------
+    // Pane mode: select (focus) agent pane
+    // ---------------------------------------------------------------------------
+
+    async function focusAgent(issueNumber: number): Promise<void> {
         const repoRoot = await getMainWorktreeRoot();
         if (!repoRoot) return;
 
         const entry = getAllPipelineEntries(repoRoot).find(e => e.issueNumber === issueNumber);
         if (!entry) return;
 
-        // Derive the tmux window name (matches the pattern used at spawn time)
-        const windowName = `ghp-${issueNumber}`;
-        const result = await pullPane(windowName);
-        if (!result) {
-            console.log(chalk.red('Could not pull pane from'), windowName);
-            return;
+        const paneId = await findPaneForWorktree(entry.worktreePath);
+        if (paneId) {
+            await selectPane(paneId);
         }
-        attached = { issueNumber, paneId: result.paneId, sourceWindow: result.sourceWindow };
+    }
+
+    // ---------------------------------------------------------------------------
+    // Window mode: pull/release
+    // ---------------------------------------------------------------------------
+
+    async function pullAgentPane(issueNumber: number): Promise<void> {
+        // Hot-swap: release current pane before pulling the new one
+        if (attached) {
+            if (attached.issueNumber === issueNumber) return; // already showing this one
+            await sendPaneBack();
+        }
+
+        const windowName = `ghp-${issueNumber}`;
+        if (!dashboardPaneId) return;
+        const result = await pullPaneFromWindow(windowName, dashboardPaneId);
+        if (!result) return;
+
+        // Set pane border title so it's visually clear which agent is shown
+        try {
+            await execFileAsync('tmux', ['select-pane', '-t', result.paneId, '-T', `Agent #${issueNumber}`]);
+        } catch { /* best effort */ }
+
+        attached = { issueNumber, paneId: result.paneId, sourceWindowName: result.sourceWindowName };
         await refresh();
     }
 
     async function sendPaneBack(): Promise<void> {
         if (!attached) return;
-        await releasePane(attached);
+        await releasePaneToWindow(attached);
         attached = null;
         await refresh();
     }
@@ -338,69 +415,74 @@ export async function pipelineDashboardCommand(options: DashboardOptions = {}): 
     // ---------------------------------------------------------------------------
 
     async function handleKey(key: string): Promise<void> {
-        // esc — send pane back
-        if (key === '\x1b' || key === '\x1b[') {
-            await sendPaneBack();
+        // esc — send pane back (window mode) or refocus dashboard (pane mode)
+        if (key === '\x1b') {
+            if (tmuxMode === 'pane' && dashboardPaneId) {
+                await selectPane(dashboardPaneId);
+            } else if (tmuxMode === 'window' && attached) {
+                await sendPaneBack();
+            }
             return;
         }
 
         // q — quit
         if (key === 'q' || key === 'Q') {
             if (attached) await sendPaneBack();
-            running = false;
             if (refreshTimer) clearInterval(refreshTimer);
-            process.stdin.setRawMode(false);
-            process.stdin.pause();
+            if (process.stdin.isTTY) {
+                process.stdin.setRawMode(false);
+                process.stdin.pause();
+            }
             console.log();
-            console.log(chalk.dim('Dashboard closed.'));
             process.exit(0);
         }
 
-        // c — pull coordinator pane
-        if (key === 'c' || key === 'C') {
+        // c — coordinator (window mode only)
+        if ((key === 'c' || key === 'C') && tmuxMode === 'window') {
             if (attached) {
                 await sendPaneBack();
                 return;
             }
+            if (!coordinatorWindow) coordinatorWindow = await findCoordinatorPane();
             if (!coordinatorWindow) {
-                // Try to detect again
-                coordinatorWindow = await findCoordinatorPane();
-            }
-            if (!coordinatorWindow) {
-                // Re-render with a brief note
                 process.stdout.write('\x1b[2J\x1b[H');
-                console.log(chalk.yellow('No coordinator window found (ghp-root, ghp-coordinator, or ghp-main)'));
+                console.log(chalk.yellow('No coordinator window found'));
                 setTimeout(() => refresh(), 1500);
                 return;
             }
-            const result = await pullPane(coordinatorWindow);
+            if (!dashboardPaneId) return;
+            const result = await pullPaneFromWindow(coordinatorWindow, dashboardPaneId);
             if (result) {
-                attached = { issueNumber: 0, paneId: result.paneId, sourceWindow: result.sourceWindow };
+                attached = { issueNumber: 0, paneId: result.paneId, sourceWindowName: result.sourceWindowName };
                 await refresh();
             }
             return;
         }
 
-        // i or n — swap next ready worktree (optionally with number)
+        // i or n — swap next ready worktree
         if (key === 'i' || key === 'I' || key === 'n' || key === 'N') {
-            await worktreeNextCommand(undefined);
+            await safeExec(() => worktreeNextCommand(undefined));
             await refresh();
             return;
         }
 
-        // x — clean (reverse current swap)
+        // x — clean
         if (key === 'x' || key === 'X') {
-            await worktreeCleanCommand({});
+            await safeExec(() => worktreeCleanCommand({}));
             await refresh();
             return;
         }
 
-        // 1-9 — pull attention pane
+        // 1-9 — zoom (pane mode) or pull (window mode)
         const digit = parseInt(key, 10);
         if (!isNaN(digit) && digit >= 1 && digit <= 9) {
-            const attentionMap = await getAttentionMap();
-            const entry = attentionMap.get(digit);
-            if (entry) {
+            const entries = await buildEntries();
+            const entry = getNumberedEntry(entries, digit);
+            if (!entry) return;
+
+            if (tmuxMode === 'pane') {
+                await focusAgent(entry.pipeline.issueNumber);
+            } else {
                 await pullAgentPane(entry.pipeline.issueNumber);
             }
             return;
@@ -416,23 +498,21 @@ export async function pipelineDashboardCommand(options: DashboardOptions = {}): 
         refresh().catch(() => {});
     }, intervalMs);
 
-    // Register cleanup
     registerCleanupHandler(() => {
+        if (suppressCleanup) return;
         if (refreshTimer) clearInterval(refreshTimer);
-        if (attached) releasePane(attached).catch(() => {});
+        if (attached) releasePaneToWindow(attached).catch(() => {});
         process.stdin.setRawMode?.(false);
         process.stdin.pause();
     });
 
-    // Raw keypress input
     if (process.stdin.isTTY) {
         process.stdin.setRawMode(true);
         process.stdin.resume();
         process.stdin.setEncoding('utf-8');
         process.stdin.on('data', (key: string) => {
-            // Ctrl+C
             if (key === '\u0003') {
-                if (attached) releasePane(attached).catch(() => {});
+                if (attached) releasePaneToWindow(attached).catch(() => {});
                 if (refreshTimer) clearInterval(refreshTimer);
                 process.stdin.setRawMode(false);
                 process.stdin.pause();
@@ -443,6 +523,5 @@ export async function pipelineDashboardCommand(options: DashboardOptions = {}): 
         });
     }
 
-    // Keep alive
     await new Promise<void>(() => {});
 }

--- a/packages/cli/src/commands/dashboard-pipeline.ts
+++ b/packages/cli/src/commands/dashboard-pipeline.ts
@@ -12,7 +12,7 @@ import { promisify } from 'util';
 import { getAgentSummaries, type AgentSummary } from '@bretwardjames/ghp-core';
 import { getMainWorktreeRoot } from '../git-utils.js';
 import { getConfig } from '../config.js';
-import { getAllPipelineEntries, getReadyWorktrees, getIntegrationTriggerStage, type PipelineEntry } from '../pipeline-registry.js';
+import { getAllPipelineEntries, getReadyWorktrees, getIntegrationTriggerStage, getStageEmoji, type PipelineEntry } from '../pipeline-registry.js';
 import { readSwapState } from './worktree-swap-state.js';
 import { worktreeCleanCommand, worktreeNextCommand } from './worktree-swap.js';
 import { registerCleanupHandler, resetExitState } from '../exit.js';
@@ -187,7 +187,9 @@ function issueLabel(entry: DashboardEntry): string {
 }
 
 function stageLine(entry: DashboardEntry): string {
-    const stage = chalk.dim(entry.pipeline.stage);
+    const emoji = getStageEmoji(entry.pipeline.stage);
+    const prefix = emoji ? `${emoji} ` : '';
+    const stage = chalk.dim(`${prefix}${entry.pipeline.stage}`);
     const uptime = entry.agent?.uptime ? chalk.dim(` · ${entry.agent.uptime}`) : '';
     const port = entry.agent?.port ? chalk.dim(` :${entry.agent.port}`) : '';
     return `${stage}${uptime}${port}`;

--- a/packages/cli/src/commands/dashboard-pipeline.ts
+++ b/packages/cli/src/commands/dashboard-pipeline.ts
@@ -1,0 +1,448 @@
+/**
+ * Pipeline dashboard — kanban view of all worktrees with pane-pull interaction.
+ *
+ * Layout (no pane attached):
+ *
+ *   GHP Dashboard                    [14:22:03]
+ *   ─────────────────────────────────────────────────────
+ *   NEEDS ATTENTION      READY           IN TESTING
+ *   ⚠ [1] #271 auth      ✓ [i] #269      ⟳ #268
+ *     S1 · 23m             ready 8m         [x] clean
+ *
+ *   WORKING
+ *   ● #273 export  S1 · 1h 4m
+ *   ● #275 dark    S3 · 22m
+ *   ─────────────────────────────────────────────────────
+ *   [1-9] pull  [i] next  [x] clean  [c] coord  [q] quit
+ *
+ * Layout (pane attached, split right):
+ *   The dashboard narrows and the agent pane fills the right side.
+ *   tmux handles the visual split; we just move the pane in/out.
+ */
+
+import chalk from 'chalk';
+import { execFile, execFileSync } from 'child_process';
+import { promisify } from 'util';
+import { getAgentSummaries, type AgentSummary } from '@bretwardjames/ghp-core';
+import { getMainWorktreeRoot } from '../git-utils.js';
+import { getAllPipelineEntries, getReadyWorktrees, type PipelineEntry } from '../pipeline-registry.js';
+import { readSwapState } from './worktree-swap-state.js';
+import { worktreeMoveToCommand, worktreeCleanCommand, worktreeNextCommand } from './worktree-swap.js';
+import { registerCleanupHandler } from '../exit.js';
+
+const execFileAsync = promisify(execFile);
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface DashboardEntry {
+    pipeline: PipelineEntry;
+    agent?: AgentSummary;
+    inMainRepo: boolean;
+    /** 1-based index within the "needs attention" bucket, for keypress mapping */
+    attentionIndex?: number;
+    /** 1-based index within the "ready" bucket, for [i] override */
+    readyIndex?: number;
+}
+
+interface AttachedPane {
+    issueNumber: number;
+    /** tmux global pane ID, e.g. %23 */
+    paneId: string;
+    /** Original window target the pane came from, e.g. ghp:ghp-271 */
+    sourceWindow: string;
+}
+
+interface DashboardOptions {
+    interval?: string;
+}
+
+// ---------------------------------------------------------------------------
+// tmux pane helpers
+// ---------------------------------------------------------------------------
+
+async function getCurrentPaneId(): Promise<string | null> {
+    try {
+        const { stdout } = await execFileAsync('tmux', ['display-message', '-p', '#{pane_id}']);
+        return stdout.trim() || null;
+    } catch {
+        return null;
+    }
+}
+
+async function getCurrentWindowTarget(): Promise<string | null> {
+    try {
+        const { stdout } = await execFileAsync('tmux', ['display-message', '-p', '#{session_name}:#{window_index}']);
+        return stdout.trim() || null;
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * Pull a pane from a named window into the current window (horizontal split).
+ * Returns the pane's global ID so we can send it back later.
+ */
+async function pullPane(sourceWindowName: string): Promise<{ paneId: string; sourceWindow: string } | null> {
+    try {
+        // Find the pane ID in the source window (first pane)
+        const { stdout: paneIdOut } = await execFileAsync('tmux', [
+            'display-message', '-t', sourceWindowName, '-p', '#{pane_id}',
+        ]);
+        const paneId = paneIdOut.trim();
+        if (!paneId) return null;
+
+        const sourceWindow = await getCurrentWindowTarget();
+        if (!sourceWindow) return null;
+
+        // Join the pane into the current window, horizontal split
+        await execFileAsync('tmux', ['join-pane', '-h', '-s', paneId]);
+
+        return { paneId, sourceWindow };
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * Send a pane back to its original window.
+ */
+async function releasePane(attached: AttachedPane): Promise<void> {
+    try {
+        await execFileAsync('tmux', ['join-pane', '-t', attached.sourceWindow, '-s', attached.paneId]);
+    } catch {
+        // If the window is gone, just break the pane into its own window
+        try {
+            await execFileAsync('tmux', ['break-pane', '-t', attached.paneId, '-d']);
+        } catch { /* best effort */ }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Coordinator pane detection
+// ---------------------------------------------------------------------------
+
+async function findCoordinatorPane(): Promise<string | null> {
+    // Look for a window named ghp-root, ghp-coordinator, or ghp-main
+    const candidates = ['ghp-root', 'ghp-coordinator', 'ghp-main'];
+    for (const name of candidates) {
+        try {
+            const { stdout } = await execFileAsync('tmux', ['display-message', '-t', name, '-p', '#{window_name}']);
+            if (stdout.trim()) return name;
+        } catch { /* not found */ }
+    }
+    return null;
+}
+
+// ---------------------------------------------------------------------------
+// Rendering
+// ---------------------------------------------------------------------------
+
+function formatAge(isoTimestamp?: string): string {
+    if (!isoTimestamp) return '';
+    const ms = Date.now() - new Date(isoTimestamp).getTime();
+    const minutes = Math.floor(ms / 60000);
+    if (minutes < 60) return `${minutes}m ago`;
+    return `${Math.floor(minutes / 60)}h ago`;
+}
+
+function issueLabel(entry: DashboardEntry): string {
+    return `${chalk.cyan(`#${entry.pipeline.issueNumber}`)}  ${entry.pipeline.issueTitle.substring(0, 38)}`;
+}
+
+function stageLine(entry: DashboardEntry): string {
+    const stage = chalk.dim(`S${entry.pipeline.stage}`);
+    const uptime = entry.agent?.uptime ? chalk.dim(` · ${entry.agent.uptime}`) : '';
+    const port = entry.agent?.port ? chalk.dim(` :${entry.agent.port}`) : '';
+    return `${stage}${uptime}${port}`;
+}
+
+function renderDashboard(
+    entries: DashboardEntry[],
+    attached: AttachedPane | null,
+    now: string
+): void {
+    process.stdout.write('\x1b[2J\x1b[H'); // clear
+
+    const waiting = entries.filter(e => e.agent?.waitingForInput);
+    const ready   = entries.filter(e => e.pipeline.stageStatus === 'ready' && !e.inMainRepo);
+    const testing = entries.filter(e => e.inMainRepo);
+    const working = entries.filter(e =>
+        !e.agent?.waitingForInput &&
+        e.pipeline.stageStatus === 'in_progress' &&
+        !e.inMainRepo
+    );
+
+    // Assign attention indices
+    waiting.forEach((e, i) => { e.attentionIndex = i + 1; });
+    ready.forEach((e, i)   => { e.readyIndex = i + 1; });
+
+    const attachedNote = attached ? chalk.yellow(` │ ATTACHED: #${attached.issueNumber}`) : '';
+    console.log(chalk.bold('GHP Dashboard'), chalk.dim(`[${now}]`), attachedNote);
+    console.log(chalk.dim('─'.repeat(70)));
+
+    // Top row: Needs Attention | Ready | In Testing (side by side if space)
+    const hasPriority = waiting.length > 0 || ready.length > 0 || testing.length > 0;
+
+    if (waiting.length > 0) {
+        console.log(chalk.yellow.bold('  NEEDS ATTENTION'));
+        for (const e of waiting) {
+            const key = chalk.yellow(`[${e.attentionIndex}]`);
+            console.log(`  ${key} ${issueLabel(e)}  ${stageLine(e)}`);
+            if (e.agent?.currentAction) {
+                console.log(`       ${chalk.yellow(`└─ ⚠ ${e.agent.currentAction.substring(0, 55)}`)}`);
+            }
+        }
+        console.log();
+    }
+
+    if (ready.length > 0) {
+        console.log(chalk.green.bold('  READY FOR INTEGRATION'));
+        for (const e of ready) {
+            const age = formatAge(e.pipeline.readyAt);
+            console.log(`  ${chalk.green('✓')}  ${issueLabel(e)}  ${chalk.dim(age)}`);
+        }
+        console.log(`  ${chalk.dim(`[i] swap next   [i <n>] pick specific`)}`);
+        console.log();
+    }
+
+    if (testing.length > 0) {
+        console.log(chalk.blue.bold('  IN TESTING (main repo)'));
+        for (const e of testing) {
+            console.log(`  ${chalk.blue('⟳')}  ${issueLabel(e)}`);
+        }
+        console.log(`  ${chalk.dim('[x] ghp wt clean')}`);
+        console.log();
+    }
+
+    if (working.length > 0) {
+        console.log(chalk.white.bold('  WORKING'));
+        for (const e of working) {
+            const sym = e.agent?.status === 'running' ? chalk.green('●') : chalk.dim('○');
+            console.log(`  ${sym}  ${issueLabel(e)}  ${stageLine(e)}`);
+            if (e.agent?.currentAction) {
+                console.log(`       ${chalk.dim(`└─ ${e.agent.currentAction.substring(0, 55)}`)}`);
+            }
+        }
+        console.log();
+    }
+
+    if (!hasPriority && working.length === 0) {
+        console.log(chalk.dim('  No worktrees in pipeline.'));
+        console.log(chalk.dim('  Start one: ghp start <issue> --parallel'));
+        console.log();
+    }
+
+    console.log(chalk.dim('─'.repeat(70)));
+
+    if (attached) {
+        console.log(chalk.dim('[esc] send pane back  [c] coordinator  [q] quit'));
+    } else {
+        console.log(chalk.dim('[1-9] pull agent pane  [i] next integration  [x] clean  [c] coordinator  [q] quit'));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Main command
+// ---------------------------------------------------------------------------
+
+export async function pipelineDashboardCommand(options: DashboardOptions = {}): Promise<void> {
+    const intervalSec = parseInt(options.interval || '2', 10);
+    const intervalMs = intervalSec * 1000;
+
+    if (!process.env.TMUX) {
+        console.log(chalk.yellow('Warning:'), 'Not inside a tmux session — pane-pull features will be unavailable.');
+        console.log(chalk.dim('Displaying read-only status. Ctrl+C to exit.'));
+        console.log();
+    }
+
+    let attached: AttachedPane | null = null;
+    let coordinatorWindow: string | null = null;
+    let refreshTimer: ReturnType<typeof setInterval> | null = null;
+    let running = true;
+
+    // Detect coordinator pane once at startup
+    if (process.env.TMUX) {
+        coordinatorWindow = await findCoordinatorPane();
+    }
+
+    // Build entries
+    async function buildEntries(): Promise<DashboardEntry[]> {
+        const repoRoot = await getMainWorktreeRoot();
+        if (!repoRoot) return [];
+
+        const pipeline = getAllPipelineEntries(repoRoot);
+        const agents = getAgentSummaries();
+        const swapState = readSwapState(repoRoot);
+
+        const agentByIssue = new Map<number, AgentSummary>();
+        for (const a of agents) agentByIssue.set(a.issueNumber, a);
+
+        return pipeline.map(p => ({
+            pipeline: p,
+            agent: agentByIssue.get(p.issueNumber),
+            inMainRepo: swapState?.worktreeBranch === p.branch,
+        }));
+    }
+
+    async function refresh(): Promise<void> {
+        const entries = await buildEntries();
+        renderDashboard(entries, attached, new Date().toLocaleTimeString());
+    }
+
+    // Map attention-index → issue number for keypress handling
+    async function getAttentionMap(): Promise<Map<number, DashboardEntry>> {
+        const entries = await buildEntries();
+        const map = new Map<number, DashboardEntry>();
+        let idx = 1;
+        for (const e of entries) {
+            if (e.agent?.waitingForInput) {
+                map.set(idx++, e);
+            }
+        }
+        return map;
+    }
+
+    async function pullAgentPane(issueNumber: number): Promise<void> {
+        if (attached) {
+            console.log(chalk.yellow('A pane is already attached. Send it back first (esc).'));
+            return;
+        }
+        const repoRoot = await getMainWorktreeRoot();
+        if (!repoRoot) return;
+
+        const entry = getAllPipelineEntries(repoRoot).find(e => e.issueNumber === issueNumber);
+        if (!entry) return;
+
+        // Derive the tmux window name (matches the pattern used at spawn time)
+        const windowName = `ghp-${issueNumber}`;
+        const result = await pullPane(windowName);
+        if (!result) {
+            console.log(chalk.red('Could not pull pane from'), windowName);
+            return;
+        }
+        attached = { issueNumber, paneId: result.paneId, sourceWindow: result.sourceWindow };
+        await refresh();
+    }
+
+    async function sendPaneBack(): Promise<void> {
+        if (!attached) return;
+        await releasePane(attached);
+        attached = null;
+        await refresh();
+    }
+
+    // ---------------------------------------------------------------------------
+    // Keypress handler
+    // ---------------------------------------------------------------------------
+
+    async function handleKey(key: string): Promise<void> {
+        // esc — send pane back
+        if (key === '\x1b' || key === '\x1b[') {
+            await sendPaneBack();
+            return;
+        }
+
+        // q — quit
+        if (key === 'q' || key === 'Q') {
+            if (attached) await sendPaneBack();
+            running = false;
+            if (refreshTimer) clearInterval(refreshTimer);
+            process.stdin.setRawMode(false);
+            process.stdin.pause();
+            console.log();
+            console.log(chalk.dim('Dashboard closed.'));
+            process.exit(0);
+        }
+
+        // c — pull coordinator pane
+        if (key === 'c' || key === 'C') {
+            if (attached) {
+                await sendPaneBack();
+                return;
+            }
+            if (!coordinatorWindow) {
+                // Try to detect again
+                coordinatorWindow = await findCoordinatorPane();
+            }
+            if (!coordinatorWindow) {
+                // Re-render with a brief note
+                process.stdout.write('\x1b[2J\x1b[H');
+                console.log(chalk.yellow('No coordinator window found (ghp-root, ghp-coordinator, or ghp-main)'));
+                setTimeout(() => refresh(), 1500);
+                return;
+            }
+            const result = await pullPane(coordinatorWindow);
+            if (result) {
+                attached = { issueNumber: 0, paneId: result.paneId, sourceWindow: result.sourceWindow };
+                await refresh();
+            }
+            return;
+        }
+
+        // i or n — swap next ready worktree (optionally with number)
+        if (key === 'i' || key === 'I' || key === 'n' || key === 'N') {
+            await worktreeNextCommand(undefined);
+            await refresh();
+            return;
+        }
+
+        // x — clean (reverse current swap)
+        if (key === 'x' || key === 'X') {
+            await worktreeCleanCommand({});
+            await refresh();
+            return;
+        }
+
+        // 1-9 — pull attention pane
+        const digit = parseInt(key, 10);
+        if (!isNaN(digit) && digit >= 1 && digit <= 9) {
+            const attentionMap = await getAttentionMap();
+            const entry = attentionMap.get(digit);
+            if (entry) {
+                await pullAgentPane(entry.pipeline.issueNumber);
+            }
+            return;
+        }
+    }
+
+    // ---------------------------------------------------------------------------
+    // Start
+    // ---------------------------------------------------------------------------
+
+    await refresh();
+    refreshTimer = setInterval(() => {
+        refresh().catch(() => {});
+    }, intervalMs);
+
+    // Register cleanup
+    registerCleanupHandler(() => {
+        if (refreshTimer) clearInterval(refreshTimer);
+        if (attached) releasePane(attached).catch(() => {});
+        process.stdin.setRawMode?.(false);
+        process.stdin.pause();
+    });
+
+    // Raw keypress input
+    if (process.stdin.isTTY) {
+        process.stdin.setRawMode(true);
+        process.stdin.resume();
+        process.stdin.setEncoding('utf-8');
+        process.stdin.on('data', (key: string) => {
+            // Ctrl+C
+            if (key === '\u0003') {
+                if (attached) releasePane(attached).catch(() => {});
+                if (refreshTimer) clearInterval(refreshTimer);
+                process.stdin.setRawMode(false);
+                process.stdin.pause();
+                console.log();
+                process.exit(0);
+            }
+            handleKey(key).catch(() => {});
+        });
+    }
+
+    // Keep alive
+    await new Promise<void>(() => {});
+}

--- a/packages/cli/src/commands/done.ts
+++ b/packages/cli/src/commands/done.ts
@@ -7,6 +7,7 @@ import { getBranchForIssue } from '../branch-linker.js';
 import { confirmWithDefault, isInteractive } from '../prompts.js';
 import { exit } from '../exit.js';
 import { deregisterWorktree } from '../pipeline-registry.js';
+import { killTmuxWindow, killTmuxSession, agentWindowName, agentSessionName } from '../terminal-utils.js';
 
 export async function doneCommand(issue: string): Promise<void> {
     const issueNumber = parseInt(issue, 10);
@@ -98,6 +99,10 @@ export async function doneCommand(issue: string): Promise<void> {
                     try {
                         await removeWorktree(worktree.path);
                         console.log(chalk.green('✓'), 'Removed worktree');
+
+                        // Kill tmux window/session for this agent (best-effort)
+                        await killTmuxWindow(agentWindowName(issueNumber)).catch(() => {});
+                        await killTmuxSession(agentSessionName(issueNumber)).catch(() => {});
 
                         // Clean up pipeline registry entry
                         try {

--- a/packages/cli/src/commands/done.ts
+++ b/packages/cli/src/commands/done.ts
@@ -1,11 +1,12 @@
 import chalk from 'chalk';
 import { api } from '../github-api.js';
-import { detectRepository, listWorktrees, removeWorktree, GitError } from '../git-utils.js';
+import { detectRepository, listWorktrees, removeWorktree, GitError, getMainWorktreeRoot } from '../git-utils.js';
 import { getConfig } from '../config.js';
 import { removeActiveLabelSafely } from '../active-label.js';
 import { getBranchForIssue } from '../branch-linker.js';
 import { confirmWithDefault, isInteractive } from '../prompts.js';
 import { exit } from '../exit.js';
+import { deregisterWorktree } from '../pipeline-registry.js';
 
 export async function doneCommand(issue: string): Promise<void> {
     const issueNumber = parseInt(issue, 10);
@@ -97,6 +98,14 @@ export async function doneCommand(issue: string): Promise<void> {
                     try {
                         await removeWorktree(worktree.path);
                         console.log(chalk.green('✓'), 'Removed worktree');
+
+                        // Clean up pipeline registry entry
+                        try {
+                            const mainRoot = await getMainWorktreeRoot();
+                            if (mainRoot) {
+                                deregisterWorktree(mainRoot, issueNumber);
+                            }
+                        } catch { /* pipeline cleanup is best-effort */ }
                     } catch (error) {
                         console.log(chalk.yellow('⚠'), 'Could not remove worktree');
                         if (error instanceof GitError) {

--- a/packages/cli/src/commands/mcp.ts
+++ b/packages/cli/src/commands/mcp.ts
@@ -42,10 +42,10 @@ function getClaudeDesktopConfig(repo?: string): object {
         if (!repo.includes('/')) {
             throw new Error('--repo requires owner/name format (e.g., bretwardjames/ghp)');
         }
-        const repoName = repo.split('/')[1];
+        const serverKey = `ghp-${repo.replace('/', '-')}`;
         return {
             mcpServers: {
-                [`ghp-${repoName}`]: {
+                [serverKey]: {
                     command: 'ghp-mcp',
                     args: ['--repo', repo],
                 },
@@ -162,7 +162,7 @@ export async function mcpCommand(options: McpOptions): Promise<void> {
 
         // Determine server key based on --repo
         const serverKey = options.repo
-            ? `ghp-${options.repo.split('/')[1]}`
+            ? `ghp-${options.repo.replace('/', '-')}`
             : 'ghp';
 
         // Check if already configured

--- a/packages/cli/src/commands/mcp.ts
+++ b/packages/cli/src/commands/mcp.ts
@@ -11,6 +11,7 @@ interface McpOptions {
     install?: boolean;
     installClaudeCommands?: boolean;
     status?: boolean;
+    repo?: string;
 }
 
 /**
@@ -34,8 +35,24 @@ function getClaudeConfigPath(): string | null {
 
 /**
  * Generate the MCP server config for ghp.
+ * When repo is provided, the server is scoped to that repo with a unique key.
  */
-function getClaudeDesktopConfig(): object {
+function getClaudeDesktopConfig(repo?: string): object {
+    if (repo) {
+        if (!repo.includes('/')) {
+            throw new Error('--repo requires owner/name format (e.g., bretwardjames/ghp)');
+        }
+        const repoName = repo.split('/')[1];
+        return {
+            mcpServers: {
+                [`ghp-${repoName}`]: {
+                    command: 'ghp-mcp',
+                    args: ['--repo', repo],
+                },
+            },
+        };
+    }
+
     return {
         mcpServers: {
             ghp: {
@@ -98,7 +115,7 @@ export async function mcpCommand(options: McpOptions): Promise<void> {
         console.log();
         console.log('Add this to your Claude Desktop config file:');
         console.log();
-        console.log(chalk.cyan(JSON.stringify(getClaudeDesktopConfig(), null, 2)));
+        console.log(chalk.cyan(JSON.stringify(getClaudeDesktopConfig(options.repo), null, 2)));
         console.log();
 
         const configPath = getClaudeConfigPath();
@@ -143,13 +160,18 @@ export async function mcpCommand(options: McpOptions): Promise<void> {
             config.mcpServers = {};
         }
 
-        // Check if ghp is already configured
+        // Determine server key based on --repo
+        const serverKey = options.repo
+            ? `ghp-${options.repo.split('/')[1]}`
+            : 'ghp';
+
+        // Check if already configured
         const mcpServers = config.mcpServers as Record<string, unknown>;
-        if (mcpServers.ghp) {
-            console.log(chalk.yellow('ghp MCP server is already configured'));
-            console.log('Current config:', JSON.stringify(mcpServers.ghp, null, 2));
+        if (mcpServers[serverKey]) {
+            console.log(chalk.yellow(`${serverKey} MCP server is already configured`));
+            console.log('Current config:', JSON.stringify(mcpServers[serverKey], null, 2));
             console.log();
-            console.log('To reconfigure, remove the "ghp" entry from your config and run this again.');
+            console.log(`To reconfigure, remove the "${serverKey}" entry from your config and run this again.`);
 
             // Still install Claude commands if requested
             if (options.installClaudeCommands) {
@@ -170,10 +192,10 @@ export async function mcpCommand(options: McpOptions): Promise<void> {
             return;
         }
 
-        // Add ghp config
-        mcpServers.ghp = {
-            command: 'ghp-mcp',
-        };
+        // Add server config
+        mcpServers[serverKey] = options.repo
+            ? { command: 'ghp-mcp', args: ['--repo', options.repo] }
+            : { command: 'ghp-mcp' };
 
         // Write config
         try {

--- a/packages/cli/src/commands/pipeline-commands.ts
+++ b/packages/cli/src/commands/pipeline-commands.ts
@@ -15,6 +15,7 @@ import {
     getPipelineEntry,
     getPipelineStages,
     getIntegrationTriggerStage,
+    getStageEmoji,
 } from '../pipeline-registry.js';
 import { exit } from '../exit.js';
 
@@ -109,8 +110,10 @@ export async function pipelineStagesCommand(): Promise<void> {
     console.log();
     for (let i = 0; i < stages.length; i++) {
         const name = stages[i];
+        const emoji = getStageEmoji(name);
+        const prefix = emoji ? `${emoji} ` : '  ';
         const marker = name === triggerStage ? chalk.green(' ← integration trigger') : '';
-        console.log(`  ${chalk.dim(`${i + 1}.`)} ${name}${marker}`);
+        console.log(`  ${chalk.dim(`${i + 1}.`)} ${prefix}${name}${marker}`);
     }
     console.log();
     console.log(chalk.dim('Configure with: ghp config pipeline.stages \'["stage1", "stage2", ...]\''));

--- a/packages/cli/src/commands/pipeline-commands.ts
+++ b/packages/cli/src/commands/pipeline-commands.ts
@@ -1,0 +1,118 @@
+/**
+ * Pipeline stage management commands.
+ *
+ * ghp pipeline advance [issue]  — advance to next stage
+ * ghp pipeline set <stage> [issue]  — jump to specific stage
+ * ghp pipeline stages  — list configured stages
+ */
+
+import chalk from 'chalk';
+import { execFileSync } from 'child_process';
+import { getMainWorktreeRoot } from '../git-utils.js';
+import {
+    advanceWorktreeStage,
+    setWorktreeStage,
+    getPipelineEntry,
+    getPipelineStages,
+    getIntegrationTriggerStage,
+} from '../pipeline-registry.js';
+import { exit } from '../exit.js';
+
+function extractIssueFromBranch(branch: string): number | null {
+    const match = branch.match(/\/(\d+)-/);
+    return match ? parseInt(match[1], 10) : null;
+}
+
+async function resolveIssueNumber(issueArg?: string): Promise<number | null> {
+    if (issueArg) {
+        const num = parseInt(issueArg, 10);
+        return isNaN(num) ? null : num;
+    }
+    // Auto-detect from current branch
+    try {
+        const branch = execFileSync('git', ['branch', '--show-current'], { encoding: 'utf-8' }).trim();
+        return extractIssueFromBranch(branch);
+    } catch {
+        return null;
+    }
+}
+
+export async function pipelineAdvanceCommand(issueArg?: string): Promise<void> {
+    const repoRoot = await getMainWorktreeRoot();
+    if (!repoRoot) {
+        console.error(chalk.red('Error:'), 'Could not determine repository root');
+        exit(1);
+        return;
+    }
+
+    const issueNumber = await resolveIssueNumber(issueArg);
+    if (!issueNumber) {
+        console.error(chalk.red('Error:'), 'Could not determine issue number. Pass it explicitly: ghp pipeline advance <issue>');
+        exit(1);
+        return;
+    }
+
+    const before = getPipelineEntry(repoRoot, issueNumber);
+    if (!before) {
+        console.error(chalk.red('Error:'), `Issue #${issueNumber} is not in the pipeline.`);
+        exit(1);
+        return;
+    }
+
+    const after = advanceWorktreeStage(repoRoot, issueNumber);
+    if (!after || after.stage === before.stage) {
+        console.log(chalk.yellow('Already at last stage:'), chalk.dim(before.stage));
+        return;
+    }
+
+    console.log(chalk.green('✓'), `#${issueNumber}: ${chalk.dim(before.stage)} → ${chalk.cyan(after.stage)}`);
+}
+
+export async function pipelineSetCommand(stage: string, issueArg?: string): Promise<void> {
+    const repoRoot = await getMainWorktreeRoot();
+    if (!repoRoot) {
+        console.error(chalk.red('Error:'), 'Could not determine repository root');
+        exit(1);
+        return;
+    }
+
+    const issueNumber = await resolveIssueNumber(issueArg);
+    if (!issueNumber) {
+        console.error(chalk.red('Error:'), 'Could not determine issue number. Pass it explicitly: ghp pipeline set <stage> <issue>');
+        exit(1);
+        return;
+    }
+
+    const stages = getPipelineStages();
+    if (!stages.includes(stage)) {
+        console.error(chalk.red('Error:'), `Unknown stage: ${stage}`);
+        console.error('Available stages:', stages.join(', '));
+        exit(1);
+        return;
+    }
+
+    const entry = setWorktreeStage(repoRoot, issueNumber, stage);
+    if (!entry) {
+        console.error(chalk.red('Error:'), `Issue #${issueNumber} is not in the pipeline.`);
+        exit(1);
+        return;
+    }
+
+    console.log(chalk.green('✓'), `#${issueNumber} → ${chalk.cyan(stage)}`);
+}
+
+export async function pipelineStagesCommand(): Promise<void> {
+    const stages = getPipelineStages();
+    const triggerStage = getIntegrationTriggerStage();
+
+    console.log(chalk.bold('Pipeline Stages'));
+    console.log();
+    for (let i = 0; i < stages.length; i++) {
+        const name = stages[i];
+        const marker = name === triggerStage ? chalk.green(' ← integration trigger') : '';
+        console.log(`  ${chalk.dim(`${i + 1}.`)} ${name}${marker}`);
+    }
+    console.log();
+    console.log(chalk.dim('Configure with: ghp config pipeline.stages \'["stage1", "stage2", ...]\''));
+    console.log(chalk.dim('Integration trigger: ghp config pipeline.integrationAfter "<stage>"'));
+}

--- a/packages/cli/src/commands/pipeline-commands.ts
+++ b/packages/cli/src/commands/pipeline-commands.ts
@@ -1,17 +1,25 @@
 /**
  * Pipeline stage management commands.
  *
- * ghp pipeline advance [issue]  — advance to next stage
- * ghp pipeline set <stage> [issue]  — jump to specific stage
- * ghp pipeline stages  — list configured stages
+ * ghp pipeline advance [issue]        — advance to next stage
+ * ghp pipeline set <stage> [issue]    — jump to specific stage
+ * ghp pipeline stages                 — list configured stages
+ * ghp pipeline agent-active           — set agent to working + fire user hooks (PostToolUse)
+ * ghp pipeline agent-stopped          — set agent to stopped + fire user hooks (Stop)
+ * ghp pipeline agent-focused <issue>  — fire user hooks (dashboard pull)
+ * ghp pipeline agent-unfocused <issue>— fire user hooks (dashboard release)
  */
 
 import chalk from 'chalk';
-import { execFileSync } from 'child_process';
+import { execFileSync, spawn } from 'child_process';
+import { existsSync } from 'fs';
+import { join } from 'path';
 import { getMainWorktreeRoot } from '../git-utils.js';
+import { getConfig } from '../config.js';
 import {
     advanceWorktreeStage,
     setWorktreeStage,
+    deregisterWorktree,
     getPipelineEntry,
     getPipelineStages,
     getIntegrationTriggerStage,
@@ -37,6 +45,101 @@ async function resolveIssueNumber(issueArg?: string): Promise<number | null> {
         return null;
     }
 }
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+/** Read all of stdin as a string (with a safety timeout). */
+async function readStdin(): Promise<string> {
+    try {
+        return await new Promise<string>((resolve, reject) => {
+            const chunks: Buffer[] = [];
+            process.stdin.on('data', (chunk) => chunks.push(chunk));
+            process.stdin.on('end', () => resolve(Buffer.concat(chunks).toString('utf-8')));
+            process.stdin.on('error', reject);
+            // Safety timeout — don't hang forever if stdin never closes
+            setTimeout(() => resolve(Buffer.concat(chunks).toString('utf-8')), 2000);
+        });
+    } catch {
+        return '';
+    }
+}
+
+/**
+ * Resolve a hook script path with mode-aware dot-suffix convention.
+ *
+ * When mode is set (and not 'default'):
+ *   1. Try `.ghp/hooks/<hookName>.<mode>` (mode-specific)
+ *   2. Fall back to `.ghp/hooks/<hookName>` (generic)
+ *
+ * When mode is unset or 'default', only the unsuffixed script is checked.
+ * Returns the full path if found, or null.
+ */
+export function resolveHookScript(repoRoot: string, hookName: string, mode?: string | null): string | null {
+    if (mode && mode !== 'default') {
+        const modedPath = join(repoRoot, '.ghp', 'hooks', `${hookName}.${mode}`);
+        if (existsSync(modedPath)) return modedPath;
+    }
+    const genericPath = join(repoRoot, '.ghp', 'hooks', hookName);
+    if (existsSync(genericPath)) return genericPath;
+    return null;
+}
+
+/**
+ * Run a user hook script from `.ghp/hooks/<hookName>` if it exists.
+ * Spawns fire-and-forget with stdinData piped to the script's stdin.
+ * Silent on errors. Supports mode-aware dot-suffix resolution.
+ */
+export async function runUserHookScript(hookName: string, stdinData: string, cwd: string, mode?: string | null): Promise<void> {
+    // Find the main worktree root (where .ghp/ lives)
+    const repoRoot = await getMainWorktreeRoot();
+    if (!repoRoot) return;
+
+    const scriptPath = resolveHookScript(repoRoot, hookName, mode);
+    if (!scriptPath) return;
+
+    try {
+        const child = spawn(scriptPath, [], {
+            cwd,
+            stdio: ['pipe', 'ignore', 'ignore'],
+            detached: true,
+        });
+        child.stdin.write(stdinData);
+        child.stdin.end();
+        child.unref();
+    } catch {
+        // Silent — user scripts failing should never break the pipeline
+    }
+}
+
+/**
+ * Resolve repo root and issue number from a cwd (extracted from hook JSON).
+ * Returns null if either cannot be determined.
+ */
+async function resolveFromCwd(cwd: string): Promise<{ repoRoot: string; issueNumber: number } | null> {
+    const repoRoot = await getMainWorktreeRoot();
+    if (!repoRoot) return null;
+
+    let issueNumber: number | null = null;
+    try {
+        const branch = execFileSync('git', ['branch', '--show-current'], {
+            encoding: 'utf-8',
+            cwd,
+            stdio: ['pipe', 'pipe', 'ignore'],
+        }).trim();
+        issueNumber = extractIssueFromBranch(branch);
+    } catch {
+        return null;
+    }
+    if (!issueNumber) return null;
+
+    return { repoRoot, issueNumber };
+}
+
+// ---------------------------------------------------------------------------
+// Existing commands (advance, set, remove, stages)
+// ---------------------------------------------------------------------------
 
 export async function pipelineAdvanceCommand(issueArg?: string): Promise<void> {
     const repoRoot = await getMainWorktreeRoot();
@@ -102,6 +205,32 @@ export async function pipelineSetCommand(stage: string, issueArg?: string): Prom
     console.log(chalk.green('✓'), `#${issueNumber} → ${chalk.cyan(stage)}`);
 }
 
+export async function pipelineRemoveCommand(issueArg?: string): Promise<void> {
+    const repoRoot = await getMainWorktreeRoot();
+    if (!repoRoot) {
+        console.error(chalk.red('Error:'), 'Could not determine repository root');
+        exit(1);
+        return;
+    }
+
+    const issueNumber = await resolveIssueNumber(issueArg);
+    if (!issueNumber) {
+        console.error(chalk.red('Error:'), 'Could not determine issue number. Pass it explicitly: ghp pipeline remove <issue>');
+        exit(1);
+        return;
+    }
+
+    const entry = getPipelineEntry(repoRoot, issueNumber);
+    if (!entry) {
+        console.error(chalk.red('Error:'), `Issue #${issueNumber} is not in the pipeline.`);
+        exit(1);
+        return;
+    }
+
+    deregisterWorktree(repoRoot, issueNumber);
+    console.log(chalk.green('✓'), `Removed #${issueNumber} from pipeline`);
+}
+
 export async function pipelineStagesCommand(): Promise<void> {
     const stages = getPipelineStages();
     const triggerStage = getIntegrationTriggerStage();
@@ -120,4 +249,239 @@ export async function pipelineStagesCommand(): Promise<void> {
     console.log();
     console.log(chalk.dim('Configure with: ghp config pipeline.stages \'["stage1", "stage2", ...]\''));
     console.log(chalk.dim('Integration trigger: ghp config pipeline.integrationAfter "<stage>"'));
+}
+
+// ---------------------------------------------------------------------------
+// New agent-* commands
+// ---------------------------------------------------------------------------
+
+/**
+ * ghp pipeline agent-active
+ *
+ * Called from Claude Code PostToolUse hook. Sets pipeline stage to 'working'
+ * (idempotent) and runs user scripts from .ghp/hooks/agent-active.
+ */
+export async function pipelineAgentActiveCommand(): Promise<void> {
+    const input = await readStdin();
+    if (!input.trim()) return;
+
+    let hookData: { cwd?: string; [key: string]: any };
+    try {
+        hookData = JSON.parse(input);
+    } catch {
+        return;
+    }
+
+    const { cwd } = hookData;
+    if (!cwd) return;
+
+    const resolved = await resolveFromCwd(cwd);
+    if (!resolved) return;
+
+    const { repoRoot, issueNumber } = resolved;
+
+    // Set to 'working' — idempotent, no-op if already 'working'
+    const entry = getPipelineEntry(repoRoot, issueNumber);
+    if (entry && entry.stage !== 'working') {
+        setWorktreeStage(repoRoot, issueNumber, 'working');
+    }
+
+    // Fire user hook script (fire-and-forget)
+    runUserHookScript('agent-active', input, cwd);
+}
+
+/**
+ * ghp pipeline agent-stopped
+ *
+ * Called from Claude Code Stop hook. Sets pipeline stage to 'stopped'
+ * and runs user scripts from .ghp/hooks/agent-stopped.
+ */
+export async function pipelineAgentStoppedCommand(): Promise<void> {
+    const input = await readStdin();
+    if (!input.trim()) return;
+
+    let hookData: { cwd?: string; [key: string]: any };
+    try {
+        hookData = JSON.parse(input);
+    } catch {
+        return;
+    }
+
+    const { cwd } = hookData;
+    if (!cwd) return;
+
+    const resolved = await resolveFromCwd(cwd);
+    if (!resolved) return;
+
+    const { repoRoot, issueNumber } = resolved;
+
+    // Set to 'stopped'
+    const entry = getPipelineEntry(repoRoot, issueNumber);
+    if (entry && entry.stage !== 'stopped') {
+        setWorktreeStage(repoRoot, issueNumber, 'stopped');
+    }
+
+    // Fire user hook script (fire-and-forget)
+    runUserHookScript('agent-stopped', input, cwd);
+}
+
+/**
+ * ghp pipeline agent-focused <issue> [--mode <mode>]
+ *
+ * Called from the dashboard's pullAgentPane(). Runs user scripts
+ * from .ghp/hooks/agent-focused (with mode-aware resolution).
+ */
+export async function pipelineAgentFocusedCommand(issueArg: string, options?: { mode?: string }): Promise<void> {
+    const issueNumber = parseInt(issueArg, 10);
+    if (isNaN(issueNumber)) return;
+
+    const repoRoot = await getMainWorktreeRoot();
+    if (!repoRoot) return;
+
+    const entry = getPipelineEntry(repoRoot, issueNumber);
+    if (!entry) return;
+
+    const payload = JSON.stringify({
+        issueNumber,
+        worktreePath: entry.worktreePath,
+        branch: entry.branch,
+    });
+
+    runUserHookScript('agent-focused', payload, entry.worktreePath, options?.mode);
+}
+
+/**
+ * ghp pipeline agent-unfocused <issue> [--mode <mode>]
+ *
+ * Called from the dashboard's sendPaneBack(). Runs user scripts
+ * from .ghp/hooks/agent-unfocused (with mode-aware resolution).
+ */
+export async function pipelineAgentUnfocusedCommand(issueArg: string, options?: { mode?: string }): Promise<void> {
+    const issueNumber = parseInt(issueArg, 10);
+    if (isNaN(issueNumber)) return;
+
+    const repoRoot = await getMainWorktreeRoot();
+    if (!repoRoot) return;
+
+    const entry = getPipelineEntry(repoRoot, issueNumber);
+    if (!entry) return;
+
+    const payload = JSON.stringify({
+        issueNumber,
+        worktreePath: entry.worktreePath,
+        branch: entry.branch,
+    });
+
+    runUserHookScript('agent-unfocused', payload, entry.worktreePath, options?.mode);
+}
+
+/**
+ * ghp pipeline agent-swapped <oldIssue> <newIssue> [--mode <mode>]
+ *
+ * Called from the dashboard when switching directly from one focused agent
+ * to another. Fires a single `agent-swapped` hook (with mode suffix if
+ * applicable). Falls back to sequential unfocus→focus if no swapped hook exists.
+ */
+export async function pipelineAgentSwappedCommand(
+    oldIssueArg: string,
+    newIssueArg: string,
+    options?: { mode?: string }
+): Promise<void> {
+    const oldIssue = parseInt(oldIssueArg, 10);
+    const newIssue = parseInt(newIssueArg, 10);
+    if (isNaN(oldIssue) || isNaN(newIssue)) return;
+
+    const repoRoot = await getMainWorktreeRoot();
+    if (!repoRoot) return;
+
+    const oldEntry = getPipelineEntry(repoRoot, oldIssue);
+    const newEntry = getPipelineEntry(repoRoot, newIssue);
+    if (!oldEntry || !newEntry) return;
+
+    const mode = options?.mode;
+
+    // Check if agent-swapped hook exists (with mode resolution)
+    const swapScript = resolveHookScript(repoRoot, 'agent-swapped', mode);
+
+    if (swapScript) {
+        // Fire atomic agent-swapped hook
+        const payload = JSON.stringify({
+            old: { issueNumber: oldIssue, worktreePath: oldEntry.worktreePath, branch: oldEntry.branch },
+            new: { issueNumber: newIssue, worktreePath: newEntry.worktreePath, branch: newEntry.branch },
+        });
+
+        try {
+            const child = spawn(swapScript, [], {
+                cwd: newEntry.worktreePath,
+                stdio: ['pipe', 'ignore', 'ignore'],
+                detached: true,
+            });
+            child.stdin.write(payload);
+            child.stdin.end();
+            child.unref();
+        } catch {
+            // Silent
+        }
+    } else {
+        // Fallback: sequential unfocus→focus (respecting hookModeSwapOrder)
+        const pipelineConfig = getConfig('pipeline') as any;
+        const swapOrder = pipelineConfig?.hookModeSwapOrder ?? 'unfocus-first';
+
+        const unfocusPayload = JSON.stringify({
+            issueNumber: oldIssue,
+            worktreePath: oldEntry.worktreePath,
+            branch: oldEntry.branch,
+        });
+        const focusPayload = JSON.stringify({
+            issueNumber: newIssue,
+            worktreePath: newEntry.worktreePath,
+            branch: newEntry.branch,
+        });
+
+        // Await the first to guarantee ordering; second is fire-and-forget
+        if (swapOrder === 'focus-first') {
+            await runUserHookScript('agent-focused', focusPayload, newEntry.worktreePath, mode);
+            runUserHookScript('agent-unfocused', unfocusPayload, oldEntry.worktreePath, mode);
+        } else {
+            await runUserHookScript('agent-unfocused', unfocusPayload, oldEntry.worktreePath, mode);
+            runUserHookScript('agent-focused', focusPayload, newEntry.worktreePath, mode);
+        }
+    }
+}
+
+/**
+ * ghp pipeline mode [name]
+ *
+ * Get or set the current hook mode. Without args, prints current mode.
+ * With a name, validates against configured hookModes and prints the new mode.
+ * (Runtime mode changes happen in the dashboard; this command is for scripting.)
+ */
+export async function pipelineModeCommand(modeName?: string): Promise<void> {
+    const pipelineConfig = getConfig('pipeline') as any;
+    const hookModes: string[] = pipelineConfig?.hookModes ?? [];
+
+    if (!modeName) {
+        // Print available modes
+        if (hookModes.length === 0) {
+            console.log(chalk.dim('No hook modes configured.'));
+            console.log(chalk.dim('Configure with: ghp config pipeline.hookModes \'["planning","testing"]\''));
+        } else {
+            const defaultMode = pipelineConfig?.defaultHookMode;
+            console.log(chalk.bold('Hook Modes'));
+            for (const mode of hookModes) {
+                const marker = mode === defaultMode ? chalk.green(' (default)') : '';
+                console.log(`  ${chalk.cyan(mode)}${marker}`);
+            }
+        }
+        return;
+    }
+
+    if (!hookModes.includes(modeName)) {
+        console.error(chalk.red('Error:'), `Unknown mode: ${modeName}`);
+        console.error('Available modes:', hookModes.join(', ') || '(none configured)');
+        exit(1);
+        return;
+    }
+
+    console.log(chalk.green('✓'), `Mode: ${chalk.cyan(modeName)}`);
 }

--- a/packages/cli/src/commands/pipeline-commands.ts
+++ b/packages/cli/src/commands/pipeline-commands.ts
@@ -13,7 +13,7 @@
 import chalk from 'chalk';
 import { execFileSync, spawn } from 'child_process';
 import { existsSync } from 'fs';
-import { join } from 'path';
+import { basename, join } from 'path';
 import { getMainWorktreeRoot } from '../git-utils.js';
 import { getConfig } from '../config.js';
 import {
@@ -24,6 +24,7 @@ import {
     getPipelineStages,
     getIntegrationTriggerStage,
     getStageEmoji,
+    type PipelineEntry,
 } from '../pipeline-registry.js';
 import { exit } from '../exit.js';
 
@@ -110,6 +111,35 @@ export async function runUserHookScript(hookName: string, stdinData: string, cwd
         child.unref();
     } catch {
         // Silent — user scripts failing should never break the pipeline
+    }
+}
+
+/**
+ * Send a desktop notification for agent lifecycle events (Linux only).
+ * Fire-and-forget — never breaks the pipeline on failure.
+ */
+function sendAgentNotification(
+    status: 'stopped' | 'working',
+    entry: PipelineEntry,
+    repoRoot: string,
+): void {
+    if (process.platform !== 'linux') return;
+    try {
+        const repoName = basename(repoRoot);
+        const title = status === 'stopped'
+            ? `Agent stopped — #${entry.issueNumber}`
+            : `Agent working — #${entry.issueNumber}`;
+        const body = entry.issueTitle
+            ? `${entry.issueTitle}\n${repoName}`
+            : repoName;
+        spawn('notify-send', [
+            '--app-name=claude',
+            `--urgency=${status === 'stopped' ? 'normal' : 'low'}`,
+            title,
+            body,
+        ], { stdio: 'ignore', detached: true }).unref();
+    } catch {
+        // Non-critical — never break pipeline for notification failure
     }
 }
 
@@ -284,6 +314,7 @@ export async function pipelineAgentActiveCommand(): Promise<void> {
     const entry = getPipelineEntry(repoRoot, issueNumber);
     if (entry && entry.stage !== 'working') {
         setWorktreeStage(repoRoot, issueNumber, 'working');
+        sendAgentNotification('working', entry, repoRoot);
     }
 
     // Fire user hook script (fire-and-forget)
@@ -319,6 +350,7 @@ export async function pipelineAgentStoppedCommand(): Promise<void> {
     const entry = getPipelineEntry(repoRoot, issueNumber);
     if (entry && entry.stage !== 'stopped') {
         setWorktreeStage(repoRoot, issueNumber, 'stopped');
+        sendAgentNotification('stopped', entry, repoRoot);
     }
 
     // Fire user hook script (fire-and-forget)

--- a/packages/cli/src/commands/pipeline-commands.ts
+++ b/packages/cli/src/commands/pipeline-commands.ts
@@ -85,9 +85,9 @@ export async function pipelineSetCommand(stage: string, issueArg?: string): Prom
     }
 
     const stages = getPipelineStages();
-    if (!stages.includes(stage)) {
+    if (!stages.includes(stage) && stage !== 'needs_attention') {
         console.error(chalk.red('Error:'), `Unknown stage: ${stage}`);
-        console.error('Available stages:', stages.join(', '));
+        console.error('Available stages:', stages.join(', ') + ', needs_attention');
         exit(1);
         return;
     }
@@ -115,6 +115,8 @@ export async function pipelineStagesCommand(): Promise<void> {
         const marker = name === triggerStage ? chalk.green(' ← integration trigger') : '';
         console.log(`  ${chalk.dim(`${i + 1}.`)} ${prefix}${name}${marker}`);
     }
+    console.log();
+    console.log(`     ${getStageEmoji('needs_attention')} needs_attention${chalk.yellow(' (non-linear — enter from any stage, advance to resume)')}`);
     console.log();
     console.log(chalk.dim('Configure with: ghp config pipeline.stages \'["stage1", "stage2", ...]\''));
     console.log(chalk.dim('Integration trigger: ghp config pipeline.integrationAfter "<stage>"'));

--- a/packages/cli/src/commands/pipeline-setup.ts
+++ b/packages/cli/src/commands/pipeline-setup.ts
@@ -78,6 +78,26 @@ const QUESTIONS: Question[] = [
         hint: 'Reapply later with: ghp pipeline setup --flavor <name>',
     },
 
+    // ── Agent spawn mode ─────────────────────────────────────────────────────
+    {
+        id: 'agent_spawn_mode',
+        question: 'How should agents be spawned in tmux?',
+        type: 'select',
+        options: [
+            { value: 'window', label: 'Window (default)', description: 'Each agent gets its own tmux window' },
+            { value: 'pane', label: 'Pane', description: 'Split the current tmux window into panes' },
+            { value: 'session', label: 'Session', description: 'Each agent gets its own tmux session (nested attach in dashboard viewport)' },
+        ],
+        default: 'window',
+    },
+    {
+        id: 'tmux_prefix',
+        question: 'Tmux naming prefix (used for windows, sessions, admin):',
+        type: 'text',
+        default: 'ghp',
+        hint: 'All tmux names use this prefix (e.g., myproj → myproj-86, myproj-admin). Useful when multiple projects share a tmux server.',
+    },
+
     // ── Dashboard layout ────────────────────────────────────────────────────
     {
         id: 'dashboard_mode',
@@ -210,6 +230,13 @@ const QUESTIONS: Question[] = [
         type: 'text',
         default: '',
         hint: 'Creates .ghp/hooks/agent-swapped. Fires when you press [3] while [1] is focused — an atomic swap. Stdin JSON: {"old":{"issueNumber":123,"worktreePath":"/old","branch":"..."},"new":{"issueNumber":456,"worktreePath":"/new","branch":"..."}}. If this hook doesn\'t exist, falls back to sequential unfocus→focus. If modes are configured, mode-specific variants will also be scaffolded. Leave blank to skip.',
+    },
+    {
+        id: 'hook_mode_switched',
+        question: 'What should happen when the dashboard hook mode changes (via [m] key)?',
+        type: 'text',
+        default: '',
+        hint: 'Creates .ghp/hooks/mode-switched. Fires when you press [m] to cycle hook modes. Stdin JSON: {"oldMode":"planning","newMode":"testing"} (null = default/no mode). Runs from the main repo root. Unlike other hooks, mode-specific variants are NOT created (this hook IS the mode change notification). Leave blank to skip.',
     },
 
     // ── Event hooks (registered via ghp hooks add) ──────────────────────────
@@ -360,6 +387,7 @@ const DIRECTORY_HOOKS: Record<string, { hookName: string; template: string }> = 
     hook_agent_focused: { hookName: 'agent-focused', template: DEFAULT_AGENT_FOCUSED_SCRIPT() },
     hook_agent_unfocused: { hookName: 'agent-unfocused', template: DEFAULT_AGENT_UNFOCUSED_SCRIPT() },
     hook_agent_swapped: { hookName: 'agent-swapped', template: DEFAULT_AGENT_SWAPPED_SCRIPT() },
+    hook_mode_switched: { hookName: 'mode-switched', template: DEFAULT_MODE_SWITCHED_SCRIPT() },
 };
 
 /** Map of event hook answer IDs to event names. */
@@ -429,6 +457,21 @@ async function applyAnswers(answers: Answers): Promise<void> {
         summary.push(`Saved flavor "${answers.flavor_name.trim()}" — reapply with: ghp pipeline setup --flavor ${answers.flavor_name.trim()}`);
     }
 
+    // Agent spawn mode + tmux prefix
+    if (answers.agent_spawn_mode) {
+        setConfigByPath('parallelWork.tmux.mode', answers.agent_spawn_mode, scope);
+        summary.push(`tmux.mode = ${answers.agent_spawn_mode}`);
+    }
+    if (answers.tmux_prefix && typeof answers.tmux_prefix === 'string' && answers.tmux_prefix.trim() && answers.tmux_prefix !== 'ghp') {
+        const trimmed = answers.tmux_prefix.trim();
+        if (!/^[a-zA-Z0-9_-]+$/.test(trimmed)) {
+            console.log(chalk.yellow('Warning:'), 'Prefix contains invalid characters — use only letters, numbers, hyphens, and underscores. Skipped.');
+        } else {
+            setConfigByPath('parallelWork.tmux.prefix', trimmed, scope);
+            summary.push(`tmux.prefix = ${trimmed}`);
+        }
+    }
+
     // Dashboard config
     if (answers.dashboard_mode) {
         setConfigByPath('parallelWork.dashboard.mode', answers.dashboard_mode, scope);
@@ -486,7 +529,9 @@ async function applyAnswers(answers: Answers): Promise<void> {
                 if (!existsSync(hooksDir)) {
                     mkdirSync(hooksDir, { recursive: true });
                 }
-                const msgs = scaffoldDirectoryHook(hooksDir, hookName, template, answer.trim(), hookModes);
+                // mode-switched should never have mode-specific variants (it IS the mode notification)
+                const modes = hookName === 'mode-switched' ? [] : hookModes;
+                const msgs = scaffoldDirectoryHook(hooksDir, hookName, template, answer.trim(), modes);
                 summary.push(...msgs);
             }
         }
@@ -685,6 +730,40 @@ NEW_BRANCH=$(echo "$INPUT" | jq -r '.new.branch')
 #   kill $(cat "$OLD_WORKTREE/.dev-server.pid") 2>/dev/null
 #   cd "$NEW_WORKTREE" && pnpm dev &
 #   echo $! > "$NEW_WORKTREE/.dev-server.pid"
+# ─────────────────────────────────────────────────────────────────────────────
+`;
+}
+
+function DEFAULT_MODE_SWITCHED_SCRIPT(): string {
+    return `#!/usr/bin/env bash
+# Hook: mode-switched
+# Runs when the dashboard hook mode changes (via [m] key).
+# Use this to start/stop dev servers, swap tmux layouts, toggle test watchers, etc.
+#
+# Receives JSON on stdin with these exact keys:
+#   { "oldMode": "planning", "newMode": "testing" }
+#
+# null means "default" (no mode active).
+# This script runs from the main repo root as its working directory.
+# NOTE: Mode-specific variants of this hook are NOT created — this hook
+# IS the mode change notification.
+
+INPUT=$(cat)
+OLD_MODE=$(echo "$INPUT" | jq -r '.oldMode // "null"')
+NEW_MODE=$(echo "$INPUT" | jq -r '.newMode // "null"')
+
+# ── Add your mode-switch actions below ────────────────────────────────────────
+# Examples:
+#
+# Start test watcher when entering testing mode:
+#   if [ "$NEW_MODE" = "testing" ]; then
+#     pnpm test --watch &
+#   fi
+#
+# Stop dev server when leaving planning mode:
+#   if [ "$OLD_MODE" = "planning" ]; then
+#     kill $(cat .dev-server.pid) 2>/dev/null
+#   fi
 # ─────────────────────────────────────────────────────────────────────────────
 `;
 }

--- a/packages/cli/src/commands/pipeline-setup.ts
+++ b/packages/cli/src/commands/pipeline-setup.ts
@@ -1,0 +1,832 @@
+/**
+ * ghp pipeline setup — Agent-friendly setup wizard for pipeline configuration.
+ *
+ * Three modes:
+ *   --questions         Output JSON question schema (no side effects)
+ *   --apply             Read answers JSON from stdin, write config + hook scripts
+ *   (no flags)          Interactive CLI wizard
+ *
+ * Flavors (saved presets):
+ *   --save <name>       Save answers from stdin as a named flavor
+ *   --flavor <name>     Load and apply a saved flavor
+ *   --flavors           List saved flavors
+ *   --delete-flavor <n> Delete a saved flavor
+ */
+
+import chalk from 'chalk';
+import { readFileSync, writeFileSync, existsSync, mkdirSync, chmodSync } from 'fs';
+import { join } from 'path';
+import {
+    setConfigByPath,
+    getUserConfigPath,
+    type ConfigScope,
+} from '../config.js';
+import {
+    isInteractive,
+    promptSelect,
+    promptWithDefault,
+    confirmWithDefault,
+} from '../prompts.js';
+import { getMainWorktreeRoot } from '../git-utils.js';
+import { exit } from '../exit.js';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Question schema
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface QuestionOption {
+    value: string;
+    label: string;
+    description?: string;
+}
+
+interface Question {
+    id: string;
+    question: string;
+    type: 'select' | 'confirm' | 'text';
+    options?: QuestionOption[];
+    default?: string | boolean;
+    dependsOn?: Record<string, string | boolean>;
+    hint?: string;
+}
+
+const QUESTIONS: Question[] = [
+    // ── General config ──────────────────────────────────────────────────────
+    {
+        id: 'config_scope',
+        question: 'Where should this configuration be saved?',
+        type: 'select',
+        options: [
+            { value: 'workspace', label: 'This project only (.ghp/config.json)', description: 'Checked into the repo — the whole team gets this config' },
+            { value: 'user', label: 'Global (~/.config/ghp-cli/config.json)', description: 'Your personal preference across all projects' },
+        ],
+        default: 'user',
+    },
+    {
+        id: 'save_flavor',
+        question: 'Also save these answers as a reusable flavor?',
+        type: 'confirm',
+        default: false,
+        hint: 'Flavors let you reapply this exact setup later with: ghp pipeline setup --flavor <name>',
+    },
+    {
+        id: 'flavor_name',
+        question: 'Flavor name:',
+        type: 'text',
+        default: '',
+        dependsOn: { save_flavor: true },
+        hint: 'Reapply later with: ghp pipeline setup --flavor <name>',
+    },
+
+    // ── Dashboard layout ────────────────────────────────────────────────────
+    {
+        id: 'dashboard_mode',
+        question: 'Where should the pipeline dashboard open?',
+        type: 'select',
+        options: [
+            { value: 'pane', label: 'Split pane', description: 'Split the current tmux window' },
+            { value: 'window', label: 'New window', description: 'Separate tmux window' },
+        ],
+        default: 'window',
+    },
+    {
+        id: 'dashboard_direction',
+        question: 'When opening as a pane, which direction should it split?',
+        type: 'select',
+        dependsOn: { dashboard_mode: 'pane' },
+        options: [
+            { value: 'horizontal', label: 'Side by side' },
+            { value: 'vertical', label: 'Stacked (top/bottom)' },
+        ],
+        default: 'horizontal',
+    },
+    {
+        id: 'dashboard_size',
+        question: 'What percentage of space should the dashboard take?',
+        type: 'text',
+        dependsOn: { dashboard_mode: 'pane' },
+        default: '50%',
+        hint: 'e.g., 30%, 50%, 40',
+    },
+    {
+        id: 'focused_agent_direction',
+        question: 'When you pull an agent into view, where should it appear relative to the dashboard?',
+        type: 'select',
+        options: [
+            { value: 'vertical', label: 'Below the dashboard' },
+            { value: 'horizontal', label: 'Beside the dashboard' },
+        ],
+        default: 'vertical',
+    },
+    {
+        id: 'focused_agent_size',
+        question: 'What percentage of space should the focused agent pane take?',
+        type: 'text',
+        default: '50%',
+        hint: 'e.g., 50%, 60%, 70%',
+    },
+
+    // ── Pipeline stages ─────────────────────────────────────────────────────
+    {
+        id: 'custom_stages',
+        question: 'Do you want to use custom pipeline stages beyond the defaults (working, stopped)?',
+        type: 'confirm',
+        default: false,
+    },
+    {
+        id: 'stage_list',
+        question: 'List your pipeline stages in order (comma-separated):',
+        type: 'text',
+        dependsOn: { custom_stages: true },
+        default: 'working, stopped',
+        hint: 'e.g., planning, working, code_review, pr_submitted, stopped',
+    },
+
+    // ── Hook modes ──────────────────────────────────────────────────────────
+    {
+        id: 'hook_modes',
+        question: 'What workflow modes do you want? (comma-separated, leave blank for none)',
+        type: 'text',
+        default: '',
+        hint: 'Modes change which hook scripts run. e.g., "planning, testing, review". When mode is "testing", hooks resolve as .ghp/hooks/<name>.testing before falling back to .ghp/hooks/<name>. Press [m] in the dashboard to cycle modes. Leave blank to skip mode support.',
+    },
+    {
+        id: 'hook_default_mode',
+        question: 'Which mode should be active when the dashboard starts?',
+        type: 'text',
+        default: '',
+        hint: 'Must be one of the modes listed above. Leave blank to start with no mode active.',
+    },
+    {
+        id: 'hook_swap_order',
+        question: 'When hot-swapping agents, should the old agent\'s hooks run first or the new agent\'s?',
+        type: 'select',
+        options: [
+            { value: 'unfocus-first', label: 'Unfocus first (default)', description: 'Stop old servers before starting new ones — avoids port conflicts' },
+            { value: 'focus-first', label: 'Focus first', description: 'Start new servers before stopping old ones — minimizes downtime' },
+        ],
+        default: 'unfocus-first',
+    },
+
+    // ── Directory hooks (.ghp/hooks/<name>) ─────────────────────────────────
+    {
+        id: 'hook_dashboard_opened',
+        question: 'What should happen when the pipeline dashboard opens?',
+        type: 'text',
+        default: '',
+        hint: 'Creates .ghp/hooks/dashboard-opened. Fires when the dashboard starts. Stdin JSON: {"pane_id":"%42","window_name":"ghp-admin"}. Runs from the main repo root. Use this for companion panes (dev servers, log viewers). If modes are configured, mode-specific variants (.ghp/hooks/dashboard-opened.<mode>) will also be scaffolded. Leave blank to skip.',
+    },
+    {
+        id: 'hook_agent_active',
+        question: 'What should happen when an agent starts working (PostToolUse)?',
+        type: 'text',
+        default: '',
+        hint: 'Creates .ghp/hooks/agent-active. Fires on Claude Code PostToolUse hook. Stdin: Claude Code hook JSON (includes "cwd"). Runs from the agent\'s cwd. If modes are configured, mode-specific variants will also be scaffolded. Leave blank to skip.',
+    },
+    {
+        id: 'hook_agent_stopped',
+        question: 'What should happen when an agent stops?',
+        type: 'text',
+        default: '',
+        hint: 'Creates .ghp/hooks/agent-stopped. Fires on Claude Code Stop hook. Stdin: Claude Code hook JSON (includes "cwd"). Runs from the agent\'s cwd. If modes are configured, mode-specific variants will also be scaffolded. Leave blank to skip.',
+    },
+    {
+        id: 'hook_agent_focused',
+        question: 'What should happen when you pull an agent into the dashboard view?',
+        type: 'text',
+        default: '',
+        hint: 'Creates .ghp/hooks/agent-focused. Fires when an agent pane is focused via [1-9] in the dashboard. Stdin JSON: {"issueNumber":123,"worktreePath":"/path/to/worktree","branch":"user/123-feature"}. Runs from the worktree directory. If modes are configured, mode-specific variants will also be scaffolded. Leave blank to skip.',
+    },
+    {
+        id: 'hook_agent_unfocused',
+        question: 'What should happen when an agent is released from the dashboard view?',
+        type: 'text',
+        default: '',
+        hint: 'Creates .ghp/hooks/agent-unfocused. Fires when an agent pane is sent back via [esc]. Same stdin payload as agent-focused. Runs from the worktree directory. If modes are configured, mode-specific variants will also be scaffolded. Leave blank to skip.',
+    },
+    {
+        id: 'hook_agent_swapped',
+        question: 'What should happen when switching directly between focused agents (hot-swap)?',
+        type: 'text',
+        default: '',
+        hint: 'Creates .ghp/hooks/agent-swapped. Fires when you press [3] while [1] is focused — an atomic swap. Stdin JSON: {"old":{"issueNumber":123,"worktreePath":"/old","branch":"..."},"new":{"issueNumber":456,"worktreePath":"/new","branch":"..."}}. If this hook doesn\'t exist, falls back to sequential unfocus→focus. If modes are configured, mode-specific variants will also be scaffolded. Leave blank to skip.',
+    },
+
+    // ── Event hooks (registered via ghp hooks add) ──────────────────────────
+    {
+        id: 'hook_issue_created',
+        question: 'What command should run when a new issue is created (ghp add)?',
+        type: 'text',
+        default: '',
+        hint: 'Registers an event hook for "issue-created". Template vars: ${number}, ${title}, ${url}. Example: "echo Issue #${number} created: ${title}". This is an event hook (registered with ghp hooks add --event issue-created), not a directory hook. Leave blank to skip.',
+    },
+    {
+        id: 'hook_issue_started',
+        question: 'What command should run when work starts on an issue (ghp start)?',
+        type: 'text',
+        default: '',
+        hint: 'Registers an event hook for "issue-started". Template vars: ${number}, ${branch}, ${worktreePath}. Leave blank to skip.',
+    },
+    {
+        id: 'hook_worktree_created',
+        question: 'What command should run after a worktree is created?',
+        type: 'text',
+        default: '',
+        hint: 'Registers an event hook for "worktree-created". Template vars: ${number}, ${worktreePath}, ${branch}. Leave blank to skip.',
+    },
+    {
+        id: 'hook_worktree_removed',
+        question: 'What command should run after a worktree is removed?',
+        type: 'text',
+        default: '',
+        hint: 'Registers an event hook for "worktree-removed". Template vars: ${number}, ${worktreePath}, ${branch}. Leave blank to skip.',
+    },
+    {
+        id: 'hook_pre_pr',
+        question: 'What command should run before PR creation?',
+        type: 'text',
+        default: '',
+        hint: 'Registers an event hook for "pre-pr". Template vars: ${number}, ${branch}. Runs in blocking mode by default. Leave blank to skip.',
+    },
+    {
+        id: 'hook_pr_created',
+        question: 'What command should run after a PR is created?',
+        type: 'text',
+        default: '',
+        hint: 'Registers an event hook for "pr-created". Template vars: ${number}, ${prNumber}, ${prUrl}. Leave blank to skip.',
+    },
+    {
+        id: 'hook_pr_merged',
+        question: 'What command should run after a PR is merged?',
+        type: 'text',
+        default: '',
+        hint: 'Registers an event hook for "pr-merged". Template vars: ${number}, ${prNumber}, ${branch}. Leave blank to skip.',
+    },
+];
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Answers type
+// ─────────────────────────────────────────────────────────────────────────────
+
+type Answers = Record<string, string | boolean>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Read all of stdin as a string. */
+async function readStdin(): Promise<string> {
+    return new Promise<string>((resolve, reject) => {
+        const chunks: Buffer[] = [];
+        process.stdin.on('data', (chunk) => chunks.push(chunk));
+        process.stdin.on('end', () => resolve(Buffer.concat(chunks).toString('utf-8')));
+        process.stdin.on('error', reject);
+        setTimeout(() => resolve(Buffer.concat(chunks).toString('utf-8')), 3000);
+    });
+}
+
+/** Check if a question's dependsOn conditions are met. */
+function isDependencyMet(question: Question, answers: Answers): boolean {
+    if (!question.dependsOn) return true;
+    for (const [key, expected] of Object.entries(question.dependsOn)) {
+        if (answers[key] !== expected) return false;
+    }
+    return true;
+}
+
+/** Read the raw user config JSON (including non-Config fields like flavors). */
+function loadRawUserConfig(): Record<string, unknown> {
+    const configPath = getUserConfigPath();
+    try {
+        if (existsSync(configPath)) {
+            return JSON.parse(readFileSync(configPath, 'utf-8'));
+        }
+    } catch { /* ignore */ }
+    return {};
+}
+
+/** Write raw user config JSON. */
+function saveRawUserConfig(data: Record<string, unknown>): void {
+    const configPath = getUserConfigPath();
+    const dir = join(configPath, '..');
+    if (!existsSync(dir)) {
+        mkdirSync(dir, { recursive: true });
+    }
+    writeFileSync(configPath, JSON.stringify(data, null, 2));
+}
+
+/** Parse comma-separated string into array, filtering empties. */
+function parseCommaSeparated(value: string | boolean | undefined): string[] {
+    if (!value || typeof value !== 'string') return [];
+    return value.split(',').map(s => s.trim()).filter(Boolean);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Flavor CRUD
+// ─────────────────────────────────────────────────────────────────────────────
+
+function getFlavors(): Record<string, Answers> {
+    const raw = loadRawUserConfig();
+    return (raw.pipelineSetupFlavors as Record<string, Answers>) ?? {};
+}
+
+function saveFlavor(name: string, answers: Answers): void {
+    const raw = loadRawUserConfig();
+    const flavors = (raw.pipelineSetupFlavors as Record<string, Answers>) ?? {};
+    flavors[name] = answers;
+    raw.pipelineSetupFlavors = flavors;
+    saveRawUserConfig(raw);
+}
+
+function deleteFlavor(name: string): boolean {
+    const raw = loadRawUserConfig();
+    const flavors = (raw.pipelineSetupFlavors as Record<string, Answers>) ?? {};
+    if (!(name in flavors)) return false;
+    delete flavors[name];
+    raw.pipelineSetupFlavors = flavors;
+    saveRawUserConfig(raw);
+    return true;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Directory hook scaffolding
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Map of directory hook answer IDs to hook script names and templates. */
+const DIRECTORY_HOOKS: Record<string, { hookName: string; template: string }> = {
+    hook_dashboard_opened: { hookName: 'dashboard-opened', template: DEFAULT_DASHBOARD_OPENED_SCRIPT() },
+    hook_agent_active: { hookName: 'agent-active', template: DEFAULT_AGENT_ACTIVE_SCRIPT() },
+    hook_agent_stopped: { hookName: 'agent-stopped', template: DEFAULT_AGENT_STOPPED_SCRIPT() },
+    hook_agent_focused: { hookName: 'agent-focused', template: DEFAULT_AGENT_FOCUSED_SCRIPT() },
+    hook_agent_unfocused: { hookName: 'agent-unfocused', template: DEFAULT_AGENT_UNFOCUSED_SCRIPT() },
+    hook_agent_swapped: { hookName: 'agent-swapped', template: DEFAULT_AGENT_SWAPPED_SCRIPT() },
+};
+
+/** Map of event hook answer IDs to event names. */
+const EVENT_HOOKS: Record<string, { event: string; defaultMode?: string }> = {
+    hook_issue_created: { event: 'issue-created' },
+    hook_issue_started: { event: 'issue-started' },
+    hook_worktree_created: { event: 'worktree-created' },
+    hook_worktree_removed: { event: 'worktree-removed' },
+    hook_pre_pr: { event: 'pre-pr', defaultMode: 'blocking' },
+    hook_pr_created: { event: 'pr-created' },
+    hook_pr_merged: { event: 'pr-merged' },
+};
+
+/**
+ * Scaffold a directory hook script (and mode-specific variants).
+ * Returns array of summary messages.
+ */
+function scaffoldDirectoryHook(
+    hooksDir: string,
+    hookName: string,
+    template: string,
+    description: string,
+    modes: string[],
+): string[] {
+    const summary: string[] = [];
+
+    // Base hook
+    const basePath = join(hooksDir, hookName);
+    if (existsSync(basePath)) {
+        summary.push(`Skipped ${basePath} (already exists)`);
+    } else {
+        writeFileSync(basePath, template);
+        chmodSync(basePath, 0o755);
+        summary.push(`Created ${basePath} — ${description}`);
+    }
+
+    // Mode-specific variants
+    for (const mode of modes) {
+        const modePath = join(hooksDir, `${hookName}.${mode}`);
+        if (existsSync(modePath)) {
+            summary.push(`Skipped ${modePath} (already exists)`);
+        } else {
+            const modeTemplate = template.replace(
+                /^(# Hook: .+)$/m,
+                `$1 (mode: ${mode})`
+            );
+            writeFileSync(modePath, modeTemplate);
+            chmodSync(modePath, 0o755);
+            summary.push(`Created ${modePath}`);
+        }
+    }
+
+    return summary;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Apply logic
+// ─────────────────────────────────────────────────────────────────────────────
+
+async function applyAnswers(answers: Answers): Promise<void> {
+    const scope = (answers.config_scope as ConfigScope) || 'user';
+    const summary: string[] = [];
+
+    // Save flavor if requested
+    if (answers.save_flavor === true && answers.flavor_name && typeof answers.flavor_name === 'string' && answers.flavor_name.trim()) {
+        saveFlavor(answers.flavor_name.trim(), answers);
+        summary.push(`Saved flavor "${answers.flavor_name.trim()}" — reapply with: ghp pipeline setup --flavor ${answers.flavor_name.trim()}`);
+    }
+
+    // Dashboard config
+    if (answers.dashboard_mode) {
+        setConfigByPath('parallelWork.dashboard.mode', answers.dashboard_mode, scope);
+        summary.push(`dashboard.mode = ${answers.dashboard_mode}`);
+    }
+    if (answers.dashboard_direction) {
+        setConfigByPath('parallelWork.dashboard.direction', answers.dashboard_direction, scope);
+        summary.push(`dashboard.direction = ${answers.dashboard_direction}`);
+    }
+    if (answers.dashboard_size) {
+        setConfigByPath('parallelWork.dashboard.size', answers.dashboard_size, scope);
+        summary.push(`dashboard.size = ${answers.dashboard_size}`);
+    }
+    if (answers.focused_agent_direction) {
+        setConfigByPath('parallelWork.dashboard.focusedAgent.direction', answers.focused_agent_direction, scope);
+        summary.push(`focusedAgent.direction = ${answers.focused_agent_direction}`);
+    }
+    if (answers.focused_agent_size) {
+        setConfigByPath('parallelWork.dashboard.focusedAgent.size', answers.focused_agent_size, scope);
+        summary.push(`focusedAgent.size = ${answers.focused_agent_size}`);
+    }
+
+    // Pipeline stages
+    if (answers.custom_stages === true && answers.stage_list) {
+        const stages = parseCommaSeparated(answers.stage_list);
+        if (stages.length > 0) {
+            setConfigByPath('pipeline.stages', stages, scope);
+            summary.push(`pipeline.stages = [${stages.join(', ')}]`);
+        }
+    }
+
+    // Hook modes config
+    const hookModes = parseCommaSeparated(answers.hook_modes);
+    if (hookModes.length > 0) {
+        setConfigByPath('pipeline.hookModes', hookModes, scope);
+        summary.push(`pipeline.hookModes = [${hookModes.join(', ')}]`);
+    }
+    if (answers.hook_default_mode && typeof answers.hook_default_mode === 'string' && answers.hook_default_mode.trim()) {
+        setConfigByPath('pipeline.defaultHookMode', answers.hook_default_mode.trim(), scope);
+        summary.push(`pipeline.defaultHookMode = ${answers.hook_default_mode}`);
+    }
+    if (answers.hook_swap_order && answers.hook_swap_order !== 'unfocus-first') {
+        setConfigByPath('pipeline.hookModeSwapOrder', answers.hook_swap_order, scope);
+        summary.push(`pipeline.hookModeSwapOrder = ${answers.hook_swap_order}`);
+    }
+
+    // Directory hooks
+    const repoRoot = await getMainWorktreeRoot();
+    if (repoRoot) {
+        const hooksDir = join(repoRoot, '.ghp', 'hooks');
+
+        for (const [answerId, { hookName, template }] of Object.entries(DIRECTORY_HOOKS)) {
+            const answer = answers[answerId];
+            if (answer && typeof answer === 'string' && answer.trim()) {
+                if (!existsSync(hooksDir)) {
+                    mkdirSync(hooksDir, { recursive: true });
+                }
+                const msgs = scaffoldDirectoryHook(hooksDir, hookName, template, answer.trim(), hookModes);
+                summary.push(...msgs);
+            }
+        }
+    } else if (Object.keys(DIRECTORY_HOOKS).some(id => {
+        const a = answers[id];
+        return a && typeof a === 'string' && a.trim();
+    })) {
+        console.error(chalk.yellow('Warning:'), 'Not in a git repository — skipped hook script generation');
+    }
+
+    // Event hooks (register via ghp hooks add)
+    for (const [answerId, { event, defaultMode }] of Object.entries(EVENT_HOOKS)) {
+        const answer = answers[answerId];
+        if (answer && typeof answer === 'string' && answer.trim()) {
+            const hookName = `setup-${event}`;
+            const mode = defaultMode || 'fire-and-forget';
+            try {
+                const { execFileSync } = await import('child_process');
+                execFileSync('ghp', [
+                    'hooks', 'add', hookName,
+                    '--event', event,
+                    '--command', answer.trim(),
+                    '--mode', mode,
+                ], { stdio: 'pipe' });
+                summary.push(`Registered event hook: ${hookName} (${event}) → ${answer.trim().substring(0, 60)}`);
+            } catch (err) {
+                summary.push(`Failed to register event hook ${hookName}: ${err instanceof Error ? err.message : 'unknown error'}`);
+            }
+        }
+    }
+
+    // Print summary
+    console.log();
+    console.log(chalk.bold.green('Setup complete!'));
+    console.log();
+    const scopeLabel = scope === 'workspace' ? '.ghp/config.json' : '~/.config/ghp-cli/config.json';
+    console.log(chalk.dim(`Config scope: ${scopeLabel}`));
+    console.log();
+    for (const line of summary) {
+        console.log(`  ${chalk.green('✓')} ${line}`);
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Default hook scripts (scaffolded for devs/agents to customize)
+// ─────────────────────────────────────────────────────────────────────────────
+
+function DEFAULT_DASHBOARD_OPENED_SCRIPT(): string {
+    return `#!/usr/bin/env bash
+# Hook: dashboard-opened
+# Runs when the pipeline dashboard opens. Use this to spawn companion panes
+# (dev servers, log viewers, test watchers, etc.) alongside the dashboard.
+#
+# Receives JSON on stdin with these exact keys:
+#   { "pane_id": "%42", "window_name": "ghp-admin" }
+#
+# IMPORTANT: The pane_id is the tmux pane where the dashboard is running.
+# All split-window commands should target this pane with -t "$DASHBOARD_PANE".
+# This script runs from the main repo root as its working directory.
+
+INPUT=$(cat)
+DASHBOARD_PANE=$(echo "$INPUT" | jq -r '.pane_id')
+
+if [ -z "$DASHBOARD_PANE" ] || [ "$DASHBOARD_PANE" = "null" ]; then
+  DASHBOARD_PANE=$(tmux display-message -p "#{pane_id}")
+fi
+
+# ── Add your companion panes below ──────────────────────────────────────────
+# Examples:
+#
+# Split left of dashboard, run dev server (50% width):
+#   DEV=$(tmux split-window -hb -l 50% -t "$DASHBOARD_PANE" -P -F '#{pane_id}' 'pnpm dev')
+#   tmux select-pane -t "$DEV" -T 'Dev Server'
+#
+# Split below dashboard, run tests (30% height):
+#   TESTS=$(tmux split-window -v -l 30% -t "$DASHBOARD_PANE" -P -F '#{pane_id}' 'pnpm test --watch')
+#   tmux select-pane -t "$TESTS" -T 'Tests'
+# ─────────────────────────────────────────────────────────────────────────────
+
+# Refocus the dashboard
+tmux select-pane -t "$DASHBOARD_PANE"
+`;
+}
+
+function DEFAULT_AGENT_ACTIVE_SCRIPT(): string {
+    return `#!/usr/bin/env bash
+# Hook: agent-active
+# Runs when a Claude agent starts working (PostToolUse hook).
+# Stdin: Claude Code hook JSON (includes "cwd", "tool_name", etc.)
+# This script runs from the agent's cwd.
+
+INPUT=$(cat)
+CWD=$(echo "$INPUT" | jq -r '.cwd')
+
+# ── Add your actions below ───────────────────────────────────────────────────
+# ─────────────────────────────────────────────────────────────────────────────
+`;
+}
+
+function DEFAULT_AGENT_STOPPED_SCRIPT(): string {
+    return `#!/usr/bin/env bash
+# Hook: agent-stopped
+# Runs when a Claude agent stops (Stop hook).
+# Stdin: Claude Code hook JSON (includes "cwd")
+# This script runs from the agent's cwd.
+
+INPUT=$(cat)
+CWD=$(echo "$INPUT" | jq -r '.cwd')
+
+# ── Add your actions below ───────────────────────────────────────────────────
+# ─────────────────────────────────────────────────────────────────────────────
+`;
+}
+
+function DEFAULT_AGENT_FOCUSED_SCRIPT(): string {
+    return `#!/usr/bin/env bash
+# Hook: agent-focused
+# Runs when an agent pane is pulled into the dashboard view (via [1-9] key).
+# Use this to show extra context for the focused agent.
+#
+# Receives JSON on stdin with these exact keys:
+#   { "issueNumber": 123, "worktreePath": "/path/to/worktree", "branch": "user/123-feature" }
+#
+# This script runs from the worktree directory.
+
+INPUT=$(cat)
+ISSUE=$(echo "$INPUT" | jq -r '.issueNumber')
+WORKTREE=$(echo "$INPUT" | jq -r '.worktreePath')
+BRANCH=$(echo "$INPUT" | jq -r '.branch')
+
+# ── Add your focus actions below ─────────────────────────────────────────────
+# Examples:
+#
+# Show git log for this agent's branch:
+#   tmux split-window -v -l 20% -t "$TMUX_PANE" "cd '$WORKTREE' && git log --oneline -20"
+#
+# Tail the agent's conversation log:
+#   tmux split-window -v -l 30% -t "$TMUX_PANE" "tail -f '$WORKTREE/.claude/logs/latest.log'"
+# ─────────────────────────────────────────────────────────────────────────────
+`;
+}
+
+function DEFAULT_AGENT_UNFOCUSED_SCRIPT(): string {
+    return `#!/usr/bin/env bash
+# Hook: agent-unfocused
+# Runs when an agent pane is released from the dashboard view (via [esc] key).
+# Use this to clean up anything spawned by agent-focused.
+#
+# Receives JSON on stdin with these exact keys:
+#   { "issueNumber": 123, "worktreePath": "/path/to/worktree", "branch": "user/123-feature" }
+#
+# This script runs from the worktree directory.
+
+INPUT=$(cat)
+ISSUE=$(echo "$INPUT" | jq -r '.issueNumber')
+WORKTREE=$(echo "$INPUT" | jq -r '.worktreePath')
+BRANCH=$(echo "$INPUT" | jq -r '.branch')
+
+# ── Add your cleanup actions below ───────────────────────────────────────────
+# Examples:
+#
+# Kill any extra panes spawned by agent-focused:
+#   # (track pane IDs in a temp file from agent-focused, then kill them here)
+# ─────────────────────────────────────────────────────────────────────────────
+`;
+}
+
+function DEFAULT_AGENT_SWAPPED_SCRIPT(): string {
+    return `#!/usr/bin/env bash
+# Hook: agent-swapped
+# Runs when switching directly from one focused agent to another (hot-swap).
+# This is an atomic swap — use it to stop old servers and start new ones
+# without port conflicts.
+#
+# Receives JSON on stdin with these exact keys:
+#   {
+#     "old": { "issueNumber": 123, "worktreePath": "/path/old", "branch": "user/123-feat" },
+#     "new": { "issueNumber": 456, "worktreePath": "/path/new", "branch": "user/456-other" }
+#   }
+#
+# If this hook doesn't exist, falls back to sequential unfocus→focus.
+# This script runs from the NEW agent's worktree directory.
+
+INPUT=$(cat)
+OLD_ISSUE=$(echo "$INPUT" | jq -r '.old.issueNumber')
+OLD_WORKTREE=$(echo "$INPUT" | jq -r '.old.worktreePath')
+OLD_BRANCH=$(echo "$INPUT" | jq -r '.old.branch')
+NEW_ISSUE=$(echo "$INPUT" | jq -r '.new.issueNumber')
+NEW_WORKTREE=$(echo "$INPUT" | jq -r '.new.worktreePath')
+NEW_BRANCH=$(echo "$INPUT" | jq -r '.new.branch')
+
+# ── Add your swap actions below ──────────────────────────────────────────────
+# Examples:
+#
+# Stop old dev server, start new one:
+#   kill $(cat "$OLD_WORKTREE/.dev-server.pid") 2>/dev/null
+#   cd "$NEW_WORKTREE" && pnpm dev &
+#   echo $! > "$NEW_WORKTREE/.dev-server.pid"
+# ─────────────────────────────────────────────────────────────────────────────
+`;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Interactive wizard
+// ─────────────────────────────────────────────────────────────────────────────
+
+async function runInteractiveWizard(): Promise<Answers> {
+    const answers: Answers = {};
+
+    console.log(chalk.bold('Pipeline Setup Wizard'));
+    console.log(chalk.dim('Configure your pipeline dashboard.\n'));
+
+    for (const q of QUESTIONS) {
+        if (!isDependencyMet(q, answers)) continue;
+
+        if (q.type === 'select' && q.options) {
+            const optionLabels = q.options.map(o =>
+                o.description ? `${o.label} ${chalk.dim(`— ${o.description}`)}` : o.label
+            );
+            const defaultIdx = q.options.findIndex(o => o.value === q.default);
+            const idx = await promptSelect(chalk.bold(q.question), optionLabels);
+            answers[q.id] = q.options[idx >= 0 ? idx : (defaultIdx >= 0 ? defaultIdx : 0)].value;
+            console.log();
+        } else if (q.type === 'confirm') {
+            const defaultVal = q.default === true;
+            const result = await confirmWithDefault(chalk.bold(q.question), defaultVal);
+            answers[q.id] = result;
+            console.log();
+        } else if (q.type === 'text') {
+            const defaultVal = (q.default as string) || '';
+            if (q.hint) console.log(chalk.dim(`  ${q.hint}`));
+            const val = await promptWithDefault(`${chalk.bold(q.question)} [${defaultVal}] `, defaultVal);
+            answers[q.id] = val || defaultVal;
+            console.log();
+        }
+    }
+
+    return answers;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Main command
+// ─────────────────────────────────────────────────────────────────────────────
+
+export async function pipelineSetupCommand(options: {
+    questions?: boolean;
+    apply?: boolean;
+    save?: string;
+    flavor?: string;
+    flavors?: boolean;
+    deleteFlavor?: string;
+}): Promise<void> {
+    // ── --questions: output schema ───────────────────────────────────────────
+    if (options.questions) {
+        console.log(JSON.stringify(QUESTIONS, null, 2));
+        return;
+    }
+
+    // ── --flavors: list saved flavors ────────────────────────────────────────
+    if (options.flavors) {
+        const flavors = getFlavors();
+        const names = Object.keys(flavors);
+        if (names.length === 0) {
+            console.log(chalk.dim('No saved flavors.'));
+            console.log(chalk.dim('Save one with: echo \'{"answers":"..."}\' | ghp pipeline setup --save <name>'));
+            return;
+        }
+        console.log(chalk.bold('Saved flavors:'));
+        for (const name of names) {
+            const flavor = flavors[name];
+            const mode = flavor.dashboard_mode || 'default';
+            console.log(`  ${chalk.cyan(name)} ${chalk.dim(`— dashboard: ${mode}`)}`);
+        }
+        return;
+    }
+
+    // ── --delete-flavor <name> ───────────────────────────────────────────────
+    if (options.deleteFlavor) {
+        if (deleteFlavor(options.deleteFlavor)) {
+            console.log(chalk.green('✓'), `Deleted flavor "${options.deleteFlavor}"`);
+        } else {
+            console.error(chalk.red('Error:'), `Flavor "${options.deleteFlavor}" not found`);
+            exit(1);
+        }
+        return;
+    }
+
+    // ── --save <name>: save answers from stdin as a flavor ───────────────────
+    if (options.save) {
+        let answers: Answers;
+        try {
+            const input = await readStdin();
+            answers = JSON.parse(input.trim());
+        } catch {
+            console.error(chalk.red('Error:'), 'Could not parse JSON from stdin');
+            exit(1);
+            return;
+        }
+        saveFlavor(options.save, answers);
+        console.log(chalk.green('✓'), `Saved flavor "${options.save}"`);
+        return;
+    }
+
+    // ── --flavor <name>: load and apply a saved flavor ───────────────────────
+    if (options.flavor) {
+        const flavors = getFlavors();
+        const answers = flavors[options.flavor];
+        if (!answers) {
+            console.error(chalk.red('Error:'), `Flavor "${options.flavor}" not found`);
+            console.error('Available flavors:', Object.keys(flavors).join(', ') || '(none)');
+            exit(1);
+            return;
+        }
+        console.log(chalk.dim(`Applying flavor "${options.flavor}"...`));
+        await applyAnswers(answers);
+        return;
+    }
+
+    // ── --apply: read answers from stdin and apply ───────────────────────────
+    if (options.apply) {
+        let answers: Answers;
+        try {
+            const input = await readStdin();
+            answers = JSON.parse(input.trim());
+        } catch {
+            console.error(chalk.red('Error:'), 'Could not parse JSON from stdin');
+            exit(1);
+            return;
+        }
+        await applyAnswers(answers);
+        return;
+    }
+
+    // ── Interactive wizard (no flags) ────────────────────────────────────────
+    if (!isInteractive()) {
+        console.error(chalk.red('Error:'), 'Interactive mode requires a TTY. Use --questions/--apply for non-interactive use.');
+        exit(1);
+        return;
+    }
+
+    const answers = await runInteractiveWizard();
+    await applyAnswers(answers);
+}

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -26,6 +26,8 @@ import { linkBranch, getBranchForIssue } from '../branch-linker.js';
 import { confirmWithDefault, promptSelectWithDefault, isInteractive } from '../prompts.js';
 import { applyActiveLabel } from '../active-label.js';
 import { createParallelWorktree, getBranchWorktree } from '../worktree-utils.js';
+import { registerWorktree } from '../pipeline-registry.js';
+import { getMainWorktreeRoot } from '../git-utils.js';
 import { openParallelWorkTerminal, openAdminPane, isInsideTmux } from '../terminal-utils.js';
 import type { SubagentSpawnDirective } from '../types.js';
 import {
@@ -958,6 +960,19 @@ export async function startCommand(issue: string, options: StartOptions): Promis
                     console.log(chalk.dim(`  ${result.error}`));
                 }
             }
+        }
+    }
+
+    // Register new worktree in pipeline (stage 1 / in_progress)
+    if (worktreeWasCreated && worktreePath && worktreeBranch) {
+        const mainRoot = await getMainWorktreeRoot();
+        if (mainRoot) {
+            registerWorktree(mainRoot, {
+                issueNumber,
+                issueTitle: item.title,
+                branch: worktreeBranch,
+                worktreePath,
+            });
         }
     }
 

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -965,7 +965,7 @@ export async function startCommand(issue: string, options: StartOptions): Promis
         }
     }
 
-    // Register worktree in pipeline (starts at first stage, typically 'initiating')
+    // Register worktree in pipeline (starts at first stage, default: 'working')
     // Always register in parallel mode — even if the worktree already existed —
     // so re-running `ghp start` on an existing worktree still shows up in the dashboard.
     if (isParallelMode && worktreePath && worktreeBranch) {

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -26,7 +26,7 @@ import { linkBranch, getBranchForIssue } from '../branch-linker.js';
 import { confirmWithDefault, promptSelectWithDefault, isInteractive } from '../prompts.js';
 import { applyActiveLabel } from '../active-label.js';
 import { createParallelWorktree, getBranchWorktree } from '../worktree-utils.js';
-import { registerWorktree } from '../pipeline-registry.js';
+import { registerWorktree, getPipelineEntry } from '../pipeline-registry.js';
 import { getMainWorktreeRoot } from '../git-utils.js';
 import { openParallelWorkTerminal, openAdminPane, isDashboardOpen, isInsideTmux } from '../terminal-utils.js';
 import type { SubagentSpawnDirective } from '../types.js';
@@ -965,10 +965,12 @@ export async function startCommand(issue: string, options: StartOptions): Promis
         }
     }
 
-    // Register new worktree in pipeline (starts at first stage, typically 'initiating')
-    if (worktreeWasCreated && worktreePath && worktreeBranch) {
+    // Register worktree in pipeline (starts at first stage, typically 'initiating')
+    // Always register in parallel mode — even if the worktree already existed —
+    // so re-running `ghp start` on an existing worktree still shows up in the dashboard.
+    if (isParallelMode && worktreePath && worktreeBranch) {
         const mainRoot = await getMainWorktreeRoot();
-        if (mainRoot) {
+        if (mainRoot && !getPipelineEntry(mainRoot, issueNumber)) {
             registerWorktree(mainRoot, {
                 issueNumber,
                 issueTitle: item.title,

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -28,7 +28,7 @@ import { applyActiveLabel } from '../active-label.js';
 import { createParallelWorktree, getBranchWorktree } from '../worktree-utils.js';
 import { registerWorktree } from '../pipeline-registry.js';
 import { getMainWorktreeRoot } from '../git-utils.js';
-import { openParallelWorkTerminal, openAdminPane, isInsideTmux } from '../terminal-utils.js';
+import { openParallelWorkTerminal, openAdminPane, isDashboardOpen, isInsideTmux } from '../terminal-utils.js';
 import type { SubagentSpawnDirective } from '../types.js';
 import {
     registerAgent,
@@ -84,6 +84,8 @@ interface StartOptions {
     open?: boolean;
     /** Whether to open the admin pane (ghp agents watch) in parallel mode */
     admin?: boolean;
+    /** Open agent terminal in background (don't switch focus to it) */
+    background?: boolean;
     // Terminal mode overrides
     /** Use nvim with claudecode.nvim plugin */
     nvim?: boolean;
@@ -963,7 +965,7 @@ export async function startCommand(issue: string, options: StartOptions): Promis
         }
     }
 
-    // Register new worktree in pipeline (stage 1 / in_progress)
+    // Register new worktree in pipeline (starts at first stage, typically 'initiating')
     if (worktreeWasCreated && worktreePath && worktreeBranch) {
         const mainRoot = await getMainWorktreeRoot();
         if (mainRoot) {
@@ -1048,13 +1050,30 @@ Use the GHP tools available via MCP to:
             }
 
             console.log(chalk.dim('Opening terminal...'));
+            // Open pipeline dashboard BEFORE spawning agent window
+            // (so the split targets this window, not the agent's)
+            const dashboardAlreadyOpen = await isDashboardOpen();
+            if (!dashboardAlreadyOpen) {
+                let shouldOpen = options.admin === true;
+                if (!shouldOpen && isInteractive() && !options.forceDefaults) {
+                    shouldOpen = await confirmWithDefault('Open pipeline dashboard?', true);
+                }
+                if (shouldOpen) {
+                    const adminResult = await openAdminPane();
+                    if (adminResult.success) {
+                        console.log(chalk.dim('Opened pipeline dashboard'));
+                    }
+                }
+            }
+
             const modeOverride = getTerminalModeOverride(options);
             const result = await openParallelWorkTerminal(
                 worktreePath,
                 issueNumber,
                 item.title,
                 directive,
-                modeOverride
+                modeOverride,
+                { background: options.background }
             );
 
             if (result.success) {
@@ -1072,14 +1091,6 @@ Use the GHP tools available via MCP to:
                 });
                 updateAgent(agent.id, { status: 'running' });
                 console.log(chalk.dim(`Agent registered: ${agent.id.substring(0, 8)}...`));
-
-                // Open admin pane (ghp agents watch) if --admin flag is set
-                if (options.admin) {
-                    const adminResult = await openAdminPane();
-                    if (adminResult.success && !adminResult.alreadyOpen) {
-                        console.log(chalk.dim('Opened admin pane (ghp-admin window)'));
-                    }
-                }
             } else {
                 console.log(chalk.yellow('⚠'), 'Could not open terminal:', result.error);
                 console.log(chalk.dim('Run manually:'), `cd ${worktreePath} && claude`);

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -1,0 +1,126 @@
+/**
+ * ghp status — unified view of pipeline + agents.
+ *
+ * Merges the pipeline registry (per-worktree stage) with the agent registry
+ * (live process info). The --json flag outputs a machine-readable format for
+ * slash commands and the dashboard to consume.
+ */
+
+import chalk from 'chalk';
+import { getMainWorktreeRoot } from '../git-utils.js';
+import { getAllPipelineEntries, getReadyWorktrees, type PipelineEntry } from '../pipeline-registry.js';
+import { getAgentSummaries, type AgentSummary } from '@bretwardjames/ghp-core';
+import { readSwapState } from './worktree-swap-state.js';
+import { exit } from '../exit.js';
+
+export interface StatusEntry {
+    // Identity
+    issueNumber: number;
+    issueTitle: string;
+    branch: string;
+    worktreePath: string;
+
+    // Pipeline
+    stage: number;
+    stageStatus: string;
+    readyAt?: string;
+    registeredAt: string;
+
+    // Swap
+    inMainRepo: boolean;
+
+    // Agent (null when no agent running)
+    agentStatus?: string;
+    waitingForInput?: boolean;
+    currentAction?: string;
+    uptime?: string;
+    port?: number;
+}
+
+interface StatusOptions {
+    json?: boolean;
+}
+
+export async function statusCommand(options: StatusOptions = {}): Promise<void> {
+    const repoRoot = await getMainWorktreeRoot();
+    if (!repoRoot) {
+        console.error(chalk.red('Error:'), 'Could not determine repository root');
+        exit(1);
+        return;
+    }
+
+    const pipeline = getAllPipelineEntries(repoRoot);
+    const agents = getAgentSummaries();
+    const swapState = readSwapState(repoRoot);
+
+    // Build agent lookup by issue number
+    const agentByIssue = new Map<number, AgentSummary>();
+    for (const agent of agents) {
+        agentByIssue.set(agent.issueNumber, agent);
+    }
+
+    const entries: StatusEntry[] = pipeline.map(p => {
+        const agent = agentByIssue.get(p.issueNumber);
+        const inMainRepo = swapState?.worktreeBranch === p.branch;
+
+        return {
+            issueNumber: p.issueNumber,
+            issueTitle: p.issueTitle,
+            branch: p.branch,
+            worktreePath: p.worktreePath,
+            stage: p.stage,
+            stageStatus: p.stageStatus,
+            readyAt: p.readyAt,
+            registeredAt: p.registeredAt,
+            inMainRepo,
+            agentStatus: agent?.status,
+            waitingForInput: agent?.waitingForInput,
+            currentAction: agent?.currentAction,
+            uptime: agent?.uptime,
+            port: agent?.port,
+        };
+    });
+
+    if (options.json) {
+        console.log(JSON.stringify(entries, null, 2));
+        return;
+    }
+
+    if (entries.length === 0) {
+        console.log(chalk.dim('No worktrees in pipeline.'));
+        console.log(chalk.dim('Start a parallel worktree with: ghp start <issue> --parallel'));
+        return;
+    }
+
+    // Group by bucket
+    const waiting = entries.filter(e => e.waitingForInput);
+    const ready   = entries.filter(e => e.stageStatus === 'ready' && !e.inMainRepo);
+    const testing = entries.filter(e => e.inMainRepo);
+    const working = entries.filter(e => !e.waitingForInput && e.stageStatus === 'in_progress' && !e.inMainRepo);
+
+    const printBucket = (label: string, color: (s: string) => string, items: StatusEntry[]) => {
+        if (items.length === 0) return;
+        console.log(color(label));
+        for (const e of items) {
+            const stage = chalk.dim(`S${e.stage}`);
+            const agent = e.agentStatus ? ` · ${e.agentStatus}` : '';
+            const time = e.uptime ? chalk.dim(` · ${e.uptime}`) : '';
+            console.log(`  ${chalk.cyan(`#${e.issueNumber}`)}  ${e.issueTitle.substring(0, 45).padEnd(45)}  ${stage}${agent}${time}`);
+            if (e.currentAction) {
+                console.log(`       ${chalk.dim(`└─ ${e.currentAction}`)}`);
+            }
+        }
+        console.log();
+    };
+
+    console.log();
+    printBucket('⚠  Needs Attention', chalk.yellow, waiting);
+    printBucket('✓  Ready for Integration', chalk.green, ready);
+    printBucket('⟳  In Testing (main repo)', chalk.blue, testing);
+    printBucket('●  Working', chalk.white, working);
+
+    const readyCount = ready.length;
+    if (readyCount > 0) {
+        console.log(`Run ${chalk.cyan('ghp wt next')} to swap in the next ready worktree.`);
+    }
+}

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -8,7 +8,13 @@
 
 import chalk from 'chalk';
 import { getMainWorktreeRoot } from '../git-utils.js';
-import { getAllPipelineEntries, getReadyWorktrees, type PipelineEntry } from '../pipeline-registry.js';
+import {
+    getAllPipelineEntries,
+    getReadyWorktrees,
+    getIntegrationTriggerStage,
+    isAtOrPastIntegration,
+    type PipelineEntry,
+} from '../pipeline-registry.js';
 import { getAgentSummaries, type AgentSummary } from '@bretwardjames/ghp-core';
 import { readSwapState } from './worktree-swap-state.js';
 import { exit } from '../exit.js';
@@ -21,9 +27,8 @@ export interface StatusEntry {
     worktreePath: string;
 
     // Pipeline
-    stage: number;
-    stageStatus: string;
-    readyAt?: string;
+    stage: string;
+    stageEnteredAt: string;
     registeredAt: string;
 
     // Swap
@@ -69,8 +74,7 @@ export async function statusCommand(options: StatusOptions = {}): Promise<void> 
             branch: p.branch,
             worktreePath: p.worktreePath,
             stage: p.stage,
-            stageStatus: p.stageStatus,
-            readyAt: p.readyAt,
+            stageEnteredAt: p.stageEnteredAt,
             registeredAt: p.registeredAt,
             inMainRepo,
             agentStatus: agent?.status,
@@ -93,19 +97,24 @@ export async function statusCommand(options: StatusOptions = {}): Promise<void> 
     }
 
     // Group by bucket
+    const triggerStage = getIntegrationTriggerStage();
     const waiting = entries.filter(e => e.waitingForInput);
-    const ready   = entries.filter(e => e.stageStatus === 'ready' && !e.inMainRepo);
+    const ready   = entries.filter(e => e.stage === triggerStage && !e.inMainRepo);
     const testing = entries.filter(e => e.inMainRepo);
-    const working = entries.filter(e => !e.waitingForInput && e.stageStatus === 'in_progress' && !e.inMainRepo);
+    const working = entries.filter(e =>
+        !e.waitingForInput &&
+        e.stage !== triggerStage &&
+        !e.inMainRepo
+    );
 
     const printBucket = (label: string, color: (s: string) => string, items: StatusEntry[]) => {
         if (items.length === 0) return;
         console.log(color(label));
         for (const e of items) {
-            const stage = chalk.dim(`S${e.stage}`);
+            const stage = chalk.dim(e.stage);
             const agent = e.agentStatus ? ` · ${e.agentStatus}` : '';
             const time = e.uptime ? chalk.dim(` · ${e.uptime}`) : '';
-            console.log(`  ${chalk.cyan(`#${e.issueNumber}`)}  ${e.issueTitle.substring(0, 45).padEnd(45)}  ${stage}${agent}${time}`);
+            console.log(`  ${chalk.cyan(`#${e.issueNumber}`)}  ${e.issueTitle.substring(0, 40).padEnd(40)}  ${stage}${agent}${time}`);
             if (e.currentAction) {
                 console.log(`       ${chalk.dim(`└─ ${e.currentAction}`)}`);
             }

--- a/packages/cli/src/commands/stop.ts
+++ b/packages/cli/src/commands/stop.ts
@@ -1,9 +1,10 @@
 import chalk from 'chalk';
 import { api } from '../github-api.js';
-import { detectRepository, listWorktrees, removeWorktree, GitError } from '../git-utils.js';
+import { detectRepository, listWorktrees, removeWorktree, GitError, getMainWorktreeRoot } from '../git-utils.js';
 import { removeActiveLabelSafely } from '../active-label.js';
 import { getBranchForIssue, unlinkBranch } from '../branch-linker.js';
 import { exit } from '../exit.js';
+import { deregisterWorktree } from '../pipeline-registry.js';
 
 interface StopOptions {
     unlink?: boolean;
@@ -80,6 +81,14 @@ export async function stopCommand(issue: string, options: StopOptions): Promise<
                 try {
                     await removeWorktree(worktree.path);
                     console.log(chalk.green('✓'), 'Removed worktree:', worktree.path);
+
+                    // Clean up pipeline registry entry
+                    try {
+                        const mainRoot = await getMainWorktreeRoot();
+                        if (mainRoot) {
+                            deregisterWorktree(mainRoot, issueNumber);
+                        }
+                    } catch { /* pipeline cleanup is best-effort */ }
                 } catch (error) {
                     console.log(chalk.yellow('⚠'), 'Could not remove worktree');
                     if (error instanceof GitError) {

--- a/packages/cli/src/commands/stop.ts
+++ b/packages/cli/src/commands/stop.ts
@@ -5,6 +5,7 @@ import { removeActiveLabelSafely } from '../active-label.js';
 import { getBranchForIssue, unlinkBranch } from '../branch-linker.js';
 import { exit } from '../exit.js';
 import { deregisterWorktree } from '../pipeline-registry.js';
+import { killTmuxWindow, killTmuxSession, agentWindowName, agentSessionName } from '../terminal-utils.js';
 
 interface StopOptions {
     unlink?: boolean;
@@ -108,6 +109,10 @@ export async function stopCommand(issue: string, options: StopOptions): Promise<
             console.log(chalk.dim('No branch linked to this issue'));
         }
     }
+
+    // Kill tmux window/session for this agent (best-effort)
+    await killTmuxWindow(agentWindowName(issueNumber)).catch(() => {});
+    await killTmuxSession(agentSessionName(issueNumber)).catch(() => {});
 
     console.log(chalk.green('✓'), 'Stopped work on issue');
 }

--- a/packages/cli/src/commands/worktree-swap-state.ts
+++ b/packages/cli/src/commands/worktree-swap-state.ts
@@ -1,0 +1,41 @@
+/**
+ * Shared swap state helpers — extracted so both worktree-swap.ts and status.ts
+ * can read/write swap state without a circular import.
+ */
+
+import { existsSync, readFileSync, writeFileSync, unlinkSync } from 'fs';
+import { join } from 'path';
+
+export interface SwapState {
+    /** Branch main was on before the swap */
+    mainBranch: string;
+    /** Absolute path to the worktree */
+    worktreePath: string;
+    /** Branch the worktree was (and should return to) */
+    worktreeBranch: string;
+    /** ISO timestamp */
+    swappedAt: string;
+}
+
+export function getStateFilePath(repoRoot: string): string {
+    return join(repoRoot, '.git', 'ghp-wt-state.json');
+}
+
+export function readSwapState(repoRoot: string): SwapState | null {
+    const path = getStateFilePath(repoRoot);
+    if (!existsSync(path)) return null;
+    try {
+        return JSON.parse(readFileSync(path, 'utf-8')) as SwapState;
+    } catch {
+        return null;
+    }
+}
+
+export function writeSwapState(repoRoot: string, state: SwapState): void {
+    writeFileSync(getStateFilePath(repoRoot), JSON.stringify(state, null, 2));
+}
+
+export function clearSwapState(repoRoot: string): void {
+    const path = getStateFilePath(repoRoot);
+    if (existsSync(path)) unlinkSync(path);
+}

--- a/packages/cli/src/commands/worktree-swap.ts
+++ b/packages/cli/src/commands/worktree-swap.ts
@@ -20,10 +20,11 @@ import { detectRepository, listWorktrees, getMainWorktreeRoot, getCurrentBranch,
 import { getBranchForIssue } from '../branch-linker.js';
 import { exit } from '../exit.js';
 import {
-    markWorktreeReady,
     advanceWorktreeStage,
+    setWorktreeStage,
     getReadyWorktrees,
     getPipelineEntry,
+    getIntegrationTriggerStage,
     type PipelineEntry,
 } from '../pipeline-registry.js';
 
@@ -351,7 +352,7 @@ export async function worktreeCleanCommand(options: CleanOptions): Promise<void>
         console.log();
         console.log(chalk.bold(`${ready.length} worktree(s) ready for integration testing:`));
         for (const entry of ready) {
-            const age = entry.readyAt ? formatAge(entry.readyAt) : '';
+            const age = entry.stageEnteredAt ? formatAge(entry.stageEnteredAt) : '';
             console.log(`  ${chalk.cyan(`#${entry.issueNumber}`)}  ${entry.issueTitle.substring(0, 40).padEnd(40)}  ${chalk.dim(age)}`);
         }
         console.log();
@@ -451,7 +452,8 @@ export async function worktreeReadyCommand(issueArg?: string): Promise<void> {
         }
     }
 
-    const entry = markWorktreeReady(repoRoot, issueNumber);
+    const triggerStage = getIntegrationTriggerStage();
+    const entry = setWorktreeStage(repoRoot, issueNumber, triggerStage);
     if (!entry) {
         console.error(chalk.red('Error:'), `Issue #${issueNumber} is not registered in the pipeline.`);
         console.error('It may not have been started with --parallel, or the pipeline registry is missing.');
@@ -459,7 +461,7 @@ export async function worktreeReadyCommand(issueArg?: string): Promise<void> {
         return;
     }
 
-    console.log(chalk.green('✓'), `#${issueNumber} marked ready for integration testing`);
+    console.log(chalk.green('✓'), `#${issueNumber} marked ${chalk.cyan(triggerStage)}`);
     console.log(chalk.dim(`  Branch: ${entry.branch}`));
     console.log(chalk.dim(`  Worktree: ${entry.worktreePath}`));
     console.log();
@@ -472,7 +474,7 @@ export async function worktreeReadyCommand(issueArg?: string): Promise<void> {
 
 /**
  * Swap the next ready worktree into the main repo.
- * Picks FIFO by readyAt unless a specific issue is given.
+ * Picks FIFO by stageEnteredAt unless a specific issue is given.
  */
 export async function worktreeNextCommand(issueArg?: string): Promise<void> {
     const repoRoot = await getMainWorktreeRoot();
@@ -497,8 +499,9 @@ export async function worktreeNextCommand(issueArg?: string): Promise<void> {
             exit(1);
             return;
         }
-        if (found.stageStatus !== 'ready') {
-            console.error(chalk.red('Error:'), `Issue #${issueNumber} is not ready (status: ${found.stageStatus}).`);
+        const triggerStage = getIntegrationTriggerStage();
+        if (found.stage !== triggerStage) {
+            console.error(chalk.red('Error:'), `Issue #${issueNumber} is not ready (stage: ${found.stage}, need: ${triggerStage}).`);
             exit(1);
             return;
         }

--- a/packages/cli/src/commands/worktree-swap.ts
+++ b/packages/cli/src/commands/worktree-swap.ts
@@ -9,52 +9,25 @@
 import chalk from 'chalk';
 import { execFile } from 'child_process';
 import { promisify } from 'util';
-import { existsSync, readFileSync, writeFileSync, unlinkSync } from 'fs';
-import { join } from 'path';
 import { api } from '../github-api.js';
-import { detectRepository, listWorktrees, getRepositoryRoot, getMainWorktreeRoot, getCurrentBranch, hasUncommittedChanges } from '../git-utils.js';
+import {
+    readSwapState,
+    writeSwapState,
+    clearSwapState,
+    type SwapState,
+} from './worktree-swap-state.js';
+import { detectRepository, listWorktrees, getMainWorktreeRoot, getCurrentBranch, hasUncommittedChanges } from '../git-utils.js';
 import { getBranchForIssue } from '../branch-linker.js';
 import { exit } from '../exit.js';
+import {
+    markWorktreeReady,
+    advanceWorktreeStage,
+    getReadyWorktrees,
+    getPipelineEntry,
+    type PipelineEntry,
+} from '../pipeline-registry.js';
 
 const execFileAsync = promisify(execFile);
-
-// ---------------------------------------------------------------------------
-// State file
-// ---------------------------------------------------------------------------
-
-interface SwapState {
-    /** Branch main was on before the swap */
-    mainBranch: string;
-    /** Absolute path to the worktree */
-    worktreePath: string;
-    /** Branch the worktree was (and should return to) */
-    worktreeBranch: string;
-    /** ISO timestamp */
-    swappedAt: string;
-}
-
-function getStateFilePath(repoRoot: string): string {
-    return join(repoRoot, '.git', 'ghp-wt-state.json');
-}
-
-function readSwapState(repoRoot: string): SwapState | null {
-    const path = getStateFilePath(repoRoot);
-    if (!existsSync(path)) return null;
-    try {
-        return JSON.parse(readFileSync(path, 'utf-8')) as SwapState;
-    } catch {
-        return null;
-    }
-}
-
-function writeSwapState(repoRoot: string, state: SwapState): void {
-    writeFileSync(getStateFilePath(repoRoot), JSON.stringify(state, null, 2));
-}
-
-function clearSwapState(repoRoot: string): void {
-    const path = getStateFilePath(repoRoot);
-    if (existsSync(path)) unlinkSync(path);
-}
 
 // ---------------------------------------------------------------------------
 // Git helpers (use execFile to avoid shell injection via branch names)
@@ -255,13 +228,14 @@ export async function worktreeMoveToCommand(issue: string, options: MoveToOption
         return;
     }
 
-    // Step 3: Save state
+    // Step 3: Save state and advance pipeline to stage 2
     writeSwapState(repoRoot, {
         mainBranch,
         worktreePath: worktree.path,
         worktreeBranch: branchName,
         swappedAt: new Date().toISOString(),
     });
+    advanceWorktreeStage(repoRoot, issueNumber);
 
     console.log(chalk.green('✓'), `Now on ${chalk.cyan(branchName)} in main repo`);
     console.log(chalk.dim(`  Main was on: ${mainBranch}`));
@@ -360,10 +334,43 @@ export async function worktreeCleanCommand(options: CleanOptions): Promise<void>
 
     clearSwapState(repoRoot);
 
+    // Advance worktree to stage 3 (polish)
+    const issueNum = extractIssueFromBranch(state.worktreeBranch);
+    if (issueNum) {
+        advanceWorktreeStage(repoRoot, issueNum);
+    }
+
     console.log();
     console.log(chalk.green('✓'), 'Swap reversed');
     console.log(chalk.dim(`  Main: back on ${state.mainBranch}`));
     console.log(chalk.dim(`  Worktree: ${state.worktreePath} re-attached to ${state.worktreeBranch}`));
+
+    // Prompt about next ready worktrees
+    const ready = getReadyWorktrees(repoRoot);
+    if (ready.length > 0) {
+        console.log();
+        console.log(chalk.bold(`${ready.length} worktree(s) ready for integration testing:`));
+        for (const entry of ready) {
+            const age = entry.readyAt ? formatAge(entry.readyAt) : '';
+            console.log(`  ${chalk.cyan(`#${entry.issueNumber}`)}  ${entry.issueTitle.substring(0, 40).padEnd(40)}  ${chalk.dim(age)}`);
+        }
+        console.log();
+        console.log(`Run ${chalk.cyan('ghp wt next')} to swap in the next one.`);
+    }
+}
+
+function extractIssueFromBranch(branch: string): number | null {
+    const match = branch.match(/\/(\d+)[-_]/);
+    if (match) return parseInt(match[1], 10);
+    return null;
+}
+
+function formatAge(isoTimestamp: string): string {
+    const ms = Date.now() - new Date(isoTimestamp).getTime();
+    const minutes = Math.floor(ms / 60000);
+    if (minutes < 60) return `ready ${minutes}m ago`;
+    const hours = Math.floor(minutes / 60);
+    return `ready ${hours}h ago`;
 }
 
 // ---------------------------------------------------------------------------
@@ -394,4 +401,121 @@ export async function worktreeSwapStatusCommand(): Promise<void> {
     console.log(`  Since:     ${chalk.dim(new Date(state.swappedAt).toLocaleString())}`);
     console.log();
     console.log(`Run ${chalk.cyan('ghp wt clean')} to restore both repos.`);
+}
+
+// ---------------------------------------------------------------------------
+// ready
+// ---------------------------------------------------------------------------
+
+/**
+ * Mark the current worktree's stage as complete — ready for integration testing.
+ * Auto-detects the issue from the current branch if not specified.
+ */
+export async function worktreeReadyCommand(issueArg?: string): Promise<void> {
+    const repoRoot = await getMainWorktreeRoot();
+    if (!repoRoot) {
+        console.error(chalk.red('Error:'), 'Could not determine repository root');
+        exit(1);
+        return;
+    }
+
+    let issueNumber: number;
+
+    if (issueArg) {
+        issueNumber = parseInt(issueArg, 10);
+        if (isNaN(issueNumber)) {
+            console.error(chalk.red('Error:'), 'Issue must be a number');
+            exit(1);
+            return;
+        }
+    } else {
+        // Auto-detect from cwd branch
+        const { execFile } = await import('child_process');
+        const { promisify } = await import('util');
+        const execFileAsync = promisify(execFile);
+        try {
+            const { stdout } = await execFileAsync('git', ['branch', '--show-current'], { cwd: process.cwd() });
+            const branch = stdout.trim();
+            const detected = extractIssueFromBranch(branch);
+            if (!detected) {
+                console.error(chalk.red('Error:'), `Could not detect issue number from branch: ${branch}`);
+                console.error('Pass the issue number explicitly: ghp wt ready <issue>');
+                exit(1);
+                return;
+            }
+            issueNumber = detected;
+        } catch {
+            console.error(chalk.red('Error:'), 'Could not determine current branch');
+            exit(1);
+            return;
+        }
+    }
+
+    const entry = markWorktreeReady(repoRoot, issueNumber);
+    if (!entry) {
+        console.error(chalk.red('Error:'), `Issue #${issueNumber} is not registered in the pipeline.`);
+        console.error('It may not have been started with --parallel, or the pipeline registry is missing.');
+        exit(1);
+        return;
+    }
+
+    console.log(chalk.green('✓'), `#${issueNumber} marked ready for integration testing`);
+    console.log(chalk.dim(`  Branch: ${entry.branch}`));
+    console.log(chalk.dim(`  Worktree: ${entry.worktreePath}`));
+    console.log();
+    console.log(`From the main repo, run ${chalk.cyan('ghp wt next')} to swap it in.`);
+}
+
+// ---------------------------------------------------------------------------
+// next
+// ---------------------------------------------------------------------------
+
+/**
+ * Swap the next ready worktree into the main repo.
+ * Picks FIFO by readyAt unless a specific issue is given.
+ */
+export async function worktreeNextCommand(issueArg?: string): Promise<void> {
+    const repoRoot = await getMainWorktreeRoot();
+    if (!repoRoot) {
+        console.error(chalk.red('Error:'), 'Could not determine repository root');
+        exit(1);
+        return;
+    }
+
+    let entry: PipelineEntry;
+
+    if (issueArg) {
+        const issueNumber = parseInt(issueArg, 10);
+        if (isNaN(issueNumber)) {
+            console.error(chalk.red('Error:'), 'Issue must be a number');
+            exit(1);
+            return;
+        }
+        const found = getPipelineEntry(repoRoot, issueNumber);
+        if (!found) {
+            console.error(chalk.red('Error:'), `Issue #${issueNumber} is not in the pipeline.`);
+            exit(1);
+            return;
+        }
+        if (found.stageStatus !== 'ready') {
+            console.error(chalk.red('Error:'), `Issue #${issueNumber} is not ready (status: ${found.stageStatus}).`);
+            exit(1);
+            return;
+        }
+        entry = found;
+    } else {
+        const ready = getReadyWorktrees(repoRoot);
+        if (ready.length === 0) {
+            console.log(chalk.dim('No worktrees are ready for integration testing.'));
+            console.log(chalk.dim('Agents signal readiness with: ghp wt ready'));
+            return;
+        }
+        entry = ready[0];
+        if (ready.length > 1) {
+            console.log(chalk.dim(`${ready.length} worktrees ready — picking oldest: #${entry.issueNumber}`));
+        }
+    }
+
+    // Delegate to move-to logic
+    await worktreeMoveToCommand(String(entry.issueNumber), {});
 }

--- a/packages/cli/src/commands/worktree-swap.ts
+++ b/packages/cli/src/commands/worktree-swap.ts
@@ -1,0 +1,397 @@
+/**
+ * Worktree branch-swapping commands for ghp CLI.
+ *
+ * Enables "move-to" testing workflow:
+ *   ghp wt move-to <issue>  — detach worktree HEAD, checkout branch in main repo
+ *   ghp wt clean            — reverse the swap, restore both repos to original state
+ */
+
+import chalk from 'chalk';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import { existsSync, readFileSync, writeFileSync, unlinkSync } from 'fs';
+import { join } from 'path';
+import { api } from '../github-api.js';
+import { detectRepository, listWorktrees, getRepositoryRoot, getMainWorktreeRoot, getCurrentBranch, hasUncommittedChanges } from '../git-utils.js';
+import { getBranchForIssue } from '../branch-linker.js';
+import { exit } from '../exit.js';
+
+const execFileAsync = promisify(execFile);
+
+// ---------------------------------------------------------------------------
+// State file
+// ---------------------------------------------------------------------------
+
+interface SwapState {
+    /** Branch main was on before the swap */
+    mainBranch: string;
+    /** Absolute path to the worktree */
+    worktreePath: string;
+    /** Branch the worktree was (and should return to) */
+    worktreeBranch: string;
+    /** ISO timestamp */
+    swappedAt: string;
+}
+
+function getStateFilePath(repoRoot: string): string {
+    return join(repoRoot, '.git', 'ghp-wt-state.json');
+}
+
+function readSwapState(repoRoot: string): SwapState | null {
+    const path = getStateFilePath(repoRoot);
+    if (!existsSync(path)) return null;
+    try {
+        return JSON.parse(readFileSync(path, 'utf-8')) as SwapState;
+    } catch {
+        return null;
+    }
+}
+
+function writeSwapState(repoRoot: string, state: SwapState): void {
+    writeFileSync(getStateFilePath(repoRoot), JSON.stringify(state, null, 2));
+}
+
+function clearSwapState(repoRoot: string): void {
+    const path = getStateFilePath(repoRoot);
+    if (existsSync(path)) unlinkSync(path);
+}
+
+// ---------------------------------------------------------------------------
+// Git helpers (use execFile to avoid shell injection via branch names)
+// ---------------------------------------------------------------------------
+
+/** Detach HEAD in a specific worktree directory. */
+async function detachWorktreeHead(worktreePath: string): Promise<void> {
+    await execFileAsync('git', ['checkout', '--detach'], { cwd: worktreePath });
+}
+
+/** Re-attach a worktree to a branch (checkout the branch inside it). */
+async function reattachWorktree(worktreePath: string, branch: string): Promise<void> {
+    await execFileAsync('git', ['checkout', branch], { cwd: worktreePath });
+}
+
+/** Checkout a branch in the main repo. */
+async function checkoutInMain(branch: string, repoRoot: string): Promise<void> {
+    await execFileAsync('git', ['checkout', branch], { cwd: repoRoot });
+}
+
+/**
+ * Determine how main's HEAD relates to the worktree branch.
+ *
+ * During a swap the worktree branch pointer has not moved since move-to, so
+ * the only realistic outcomes are:
+ *   'same'     — HEAD matches branch tip (no commits made while testing)
+ *   'behind'   — branch advanced elsewhere (e.g. a push from the worktree)
+ *   'diverged' — unrelated commits on both sides
+ *
+ * 'ahead' is theoretically possible only if the user committed directly on top
+ * of the branch in main during the swap (unusual). We keep the check for
+ * correctness but document it as the uncommon path.
+ */
+async function headRelationToBranch(
+    branch: string,
+    repoRoot: string
+): Promise<'ahead' | 'same' | 'behind' | 'diverged'> {
+    let branchSha: string;
+    let headSha: string;
+    try {
+        branchSha = (await execFileAsync('git', ['rev-parse', branch],  { cwd: repoRoot })).stdout.trim();
+        headSha   = (await execFileAsync('git', ['rev-parse', 'HEAD'],  { cwd: repoRoot })).stdout.trim();
+    } catch {
+        return 'diverged';
+    }
+
+    if (headSha === branchSha) return 'same';
+
+    // Is branch an ancestor of HEAD? (HEAD is ahead of branch — user committed during swap)
+    try {
+        await execFileAsync('git', ['merge-base', '--is-ancestor', branch, 'HEAD'], { cwd: repoRoot });
+        return 'ahead';
+    } catch { /* not an ancestor */ }
+
+    // Is HEAD an ancestor of branch? (branch moved forward elsewhere)
+    try {
+        await execFileAsync('git', ['merge-base', '--is-ancestor', 'HEAD', branch], { cwd: repoRoot });
+        return 'behind';
+    } catch { /* not an ancestor */ }
+
+    return 'diverged';
+}
+
+// ---------------------------------------------------------------------------
+// move-to
+// ---------------------------------------------------------------------------
+
+interface MoveToOptions {
+    force?: boolean;
+}
+
+/**
+ * Swap a worktree's branch into the main repo for live testing.
+ *
+ * Steps:
+ *   1. Verify we're in the main worktree (not a linked one)
+ *   2. Verify no swap already in progress
+ *   3. Locate the worktree for the given issue
+ *   4. Save current state (main branch, worktree path/branch)
+ *   5. Detach worktree HEAD (so git allows main to check out the branch)
+ *   6. Checkout the branch in main
+ *   7. On failure at step 6: automatically re-attach worktree and abort
+ */
+export async function worktreeMoveToCommand(issue: string, options: MoveToOptions): Promise<void> {
+    const issueNumber = parseInt(issue, 10);
+    if (isNaN(issueNumber)) {
+        console.error(chalk.red('Error:'), 'Issue must be a number');
+        exit(1);
+        return;
+    }
+
+    const repo = await detectRepository();
+    if (!repo) {
+        console.error(chalk.red('Error:'), 'Not in a git repository with a GitHub remote');
+        exit(1);
+        return;
+    }
+
+    // Resolve the main worktree root (not the cwd, which may be a linked worktree)
+    const repoRoot = await getMainWorktreeRoot();
+    if (!repoRoot) {
+        console.error(chalk.red('Error:'), 'Could not determine repository root');
+        exit(1);
+        return;
+    }
+
+    // Guard: must be run from the main worktree, not a linked one
+    const cwd = process.cwd();
+    if (!cwd.startsWith(repoRoot) || cwd !== repoRoot) {
+        // Allow subdirectories of main repo, but not linked worktrees
+        const worktrees = await listWorktrees();
+        const isLinked = worktrees.some(wt => !wt.isMain && cwd.startsWith(wt.path));
+        if (isLinked) {
+            console.error(chalk.red('Error:'), 'Run this command from the main repository, not from a linked worktree.');
+            exit(1);
+            return;
+        }
+    }
+
+    // Guard: swap already in progress
+    const existing = readSwapState(repoRoot);
+    if (existing) {
+        console.error(chalk.red('Error:'), 'A worktree swap is already in progress.');
+        console.error(`  Branch: ${chalk.cyan(existing.worktreeBranch)}`);
+        console.error(`  Since:  ${chalk.dim(existing.swappedAt)}`);
+        console.error(`Run ${chalk.cyan('ghp wt clean')} to finish or undo the current swap.`);
+        exit(1);
+        return;
+    }
+
+    // Check for uncommitted changes in main
+    if (!options.force && await hasUncommittedChanges()) {
+        console.error(chalk.red('Error:'), 'Main repo has uncommitted changes.');
+        console.error('Commit or stash them first, or use --force to proceed anyway.');
+        exit(1);
+        return;
+    }
+
+    const authenticated = await api.authenticate();
+    if (!authenticated) {
+        console.error(chalk.red('Error:'), 'Not authenticated. Run', chalk.cyan('ghp auth'));
+        exit(1);
+        return;
+    }
+
+    // Find branch for the issue
+    const branchName = await getBranchForIssue(repo, issueNumber);
+    if (!branchName) {
+        console.error(chalk.red('Error:'), `No branch linked to issue #${issueNumber}`);
+        exit(1);
+        return;
+    }
+
+    // Find the worktree for this branch
+    const worktrees = await listWorktrees();
+    const worktree = worktrees.find(wt => wt.branch === branchName && !wt.isMain);
+    if (!worktree) {
+        console.error(chalk.red('Error:'), `No worktree found for issue #${issueNumber} (branch: ${branchName})`);
+        console.error(`Create one with ${chalk.cyan(`ghp start ${issueNumber} --parallel`)}`);
+        exit(1);
+        return;
+    }
+
+    const mainBranch = await getCurrentBranch();
+    if (!mainBranch) {
+        console.error(chalk.red('Error:'), 'Could not determine current branch');
+        exit(1);
+        return;
+    }
+
+    console.log(chalk.dim(`Swapping ${chalk.cyan(branchName)} into main repo...`));
+    console.log(chalk.dim(`  Worktree: ${worktree.path}`));
+
+    // Step 1: Detach worktree HEAD
+    try {
+        await detachWorktreeHead(worktree.path);
+        console.log(chalk.dim(`  Detached HEAD in worktree`));
+    } catch (error) {
+        console.error(chalk.red('Error:'), 'Failed to detach worktree HEAD:', error instanceof Error ? error.message : String(error));
+        exit(1);
+        return;
+    }
+
+    // Step 2: Checkout the branch in main (with rollback on failure)
+    try {
+        await checkoutInMain(branchName, repoRoot);
+    } catch (error) {
+        console.error(chalk.red('Error:'), 'Failed to checkout branch in main repo:', error instanceof Error ? error.message : String(error));
+        console.log(chalk.yellow('Rolling back:'), 're-attaching worktree...');
+        try {
+            await reattachWorktree(worktree.path, branchName);
+            console.log(chalk.dim('  Worktree re-attached.'));
+        } catch {
+            console.error(chalk.yellow('Warning:'), 'Could not re-attach worktree automatically.');
+            console.error(`  Run manually: ${chalk.cyan(`git -C "${worktree.path}" checkout "${branchName}"`)}`);
+        }
+        exit(1);
+        return;
+    }
+
+    // Step 3: Save state
+    writeSwapState(repoRoot, {
+        mainBranch,
+        worktreePath: worktree.path,
+        worktreeBranch: branchName,
+        swappedAt: new Date().toISOString(),
+    });
+
+    console.log(chalk.green('✓'), `Now on ${chalk.cyan(branchName)} in main repo`);
+    console.log(chalk.dim(`  Main was on: ${mainBranch}`));
+    console.log(chalk.dim(`  Worktree HEAD detached at: ${worktree.path}`));
+    console.log();
+    console.log(`When done testing, run ${chalk.cyan('ghp wt clean')} to restore both repos.`);
+}
+
+// ---------------------------------------------------------------------------
+// clean
+// ---------------------------------------------------------------------------
+
+interface CleanOptions {
+    force?: boolean;
+}
+
+/**
+ * Reverse a worktree swap: restore main to its previous branch and re-attach
+ * the worktree. If main accumulated new commits during testing, safely advances
+ * the branch pointer before switching away.
+ */
+export async function worktreeCleanCommand(options: CleanOptions): Promise<void> {
+    const repoRoot = await getMainWorktreeRoot();
+    if (!repoRoot) {
+        console.error(chalk.red('Error:'), 'Could not determine repository root');
+        exit(1);
+        return;
+    }
+
+    const state = readSwapState(repoRoot);
+    if (!state) {
+        console.error(chalk.red('Error:'), 'No worktree swap in progress.');
+        console.error(`Use ${chalk.cyan('ghp wt move-to <issue>')} to start a swap.`);
+        exit(1);
+        return;
+    }
+
+    // Check for uncommitted changes before switching away
+    if (!options.force && await hasUncommittedChanges()) {
+        console.error(chalk.red('Error:'), 'Main repo has uncommitted changes.');
+        console.error('Commit or stash them first, or use --force to restore anyway.');
+        exit(1);
+        return;
+    }
+
+    console.log(chalk.dim(`Cleaning up swap for ${chalk.cyan(state.worktreeBranch)}...`));
+
+    // Check if main accumulated commits during testing
+    const relation = await headRelationToBranch(state.worktreeBranch, repoRoot);
+
+    if (relation === 'ahead') {
+        // Uncommon: user committed directly on the branch in main during the swap.
+        // Advance branch pointer so the worktree picks them up.
+        console.log(chalk.dim(`  Main has new commits — advancing ${state.worktreeBranch} branch pointer`));
+        try {
+            await execFileAsync('git', ['branch', '-f', state.worktreeBranch, 'HEAD'], { cwd: repoRoot });
+            console.log(chalk.green('✓'), `Advanced ${chalk.cyan(state.worktreeBranch)} to current HEAD`);
+        } catch (error) {
+            console.error(chalk.red('Error:'), 'Failed to advance branch pointer:', error instanceof Error ? error.message : String(error));
+            if (!options.force) {
+                exit(1);
+                return;
+            }
+        }
+    } else if (relation === 'diverged') {
+        console.log(chalk.yellow('Warning:'), `${state.worktreeBranch} and current HEAD have diverged.`);
+        console.log(chalk.dim('  The branch pointer will NOT be moved. Resolve the divergence manually.'));
+        if (!options.force) {
+            console.error(`Use --force to restore repos anyway (branch pointer will be left as-is).`);
+            exit(1);
+            return;
+        }
+    } else if (relation === 'same') {
+        console.log(chalk.dim('  No new commits in main — branch pointer unchanged'));
+    }
+
+    // Restore main to its previous branch
+    try {
+        await checkoutInMain(state.mainBranch, repoRoot);
+        console.log(chalk.dim(`  Restored main to ${state.mainBranch}`));
+    } catch (error) {
+        console.error(chalk.red('Error:'), 'Failed to restore main branch:', error instanceof Error ? error.message : String(error));
+        exit(1);
+        return;
+    }
+
+    // Re-attach worktree
+    try {
+        await reattachWorktree(state.worktreePath, state.worktreeBranch);
+        console.log(chalk.dim(`  Re-attached worktree to ${state.worktreeBranch}`));
+    } catch (error) {
+        console.error(chalk.red('Error:'), 'Failed to re-attach worktree:', error instanceof Error ? error.message : String(error));
+        console.error(`  Run manually: ${chalk.cyan(`git -C "${state.worktreePath}" checkout "${state.worktreeBranch}"`)}`);
+        // Still clear state since main was restored
+    }
+
+    clearSwapState(repoRoot);
+
+    console.log();
+    console.log(chalk.green('✓'), 'Swap reversed');
+    console.log(chalk.dim(`  Main: back on ${state.mainBranch}`));
+    console.log(chalk.dim(`  Worktree: ${state.worktreePath} re-attached to ${state.worktreeBranch}`));
+}
+
+// ---------------------------------------------------------------------------
+// status
+// ---------------------------------------------------------------------------
+
+/**
+ * Show the current swap state, if any.
+ */
+export async function worktreeSwapStatusCommand(): Promise<void> {
+    const repoRoot = await getMainWorktreeRoot();
+    if (!repoRoot) {
+        console.error(chalk.red('Error:'), 'Could not determine repository root');
+        exit(1);
+        return;
+    }
+
+    const state = readSwapState(repoRoot);
+    if (!state) {
+        console.log(chalk.dim('No worktree swap in progress.'));
+        return;
+    }
+
+    console.log(chalk.bold('Active worktree swap:'));
+    console.log(`  Branch:    ${chalk.cyan(state.worktreeBranch)}`);
+    console.log(`  Worktree:  ${chalk.dim(state.worktreePath)}`);
+    console.log(`  Main was:  ${chalk.dim(state.mainBranch)}`);
+    console.log(`  Since:     ${chalk.dim(new Date(state.swappedAt).toLocaleString())}`);
+    console.log();
+    console.log(`Run ${chalk.cyan('ghp wt clean')} to restore both repos.`);
+}

--- a/packages/cli/src/commands/worktree.ts
+++ b/packages/cli/src/commands/worktree.ts
@@ -16,6 +16,8 @@ import {
 } from '@bretwardjames/ghp-core';
 import { exit } from '../exit.js';
 import { getHooksConfig } from '../config.js';
+import { deregisterWorktree } from '../pipeline-registry.js';
+import { getMainWorktreeRoot } from '../git-utils.js';
 
 interface WorktreeRemoveOptions {
     force?: boolean;
@@ -133,6 +135,14 @@ export async function worktreeRemoveCommand(
     }
 
     console.log(chalk.green('✓'), `Removed worktree: ${result.worktree?.path}`);
+
+    // Clean up pipeline registry entry
+    try {
+        const mainRoot = await getMainWorktreeRoot();
+        if (mainRoot) {
+            deregisterWorktree(mainRoot, issueNumber);
+        }
+    } catch { /* pipeline cleanup is best-effort */ }
 
     // Display hook results
     if (result.hookResults.length > 0) {

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -167,6 +167,14 @@ export interface Config {
     // Event hooks configuration
     hooks?: HooksConfig;
 
+    // Pipeline configuration
+    pipeline?: {
+        /** Ordered list of pipeline stage names */
+        stages?: string[];
+        /** Stage name after which integration testing is triggered */
+        integrationAfter?: string;
+    };
+
     // Command defaults
     defaults?: {
         plan?: PlanShortcut;

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -152,6 +152,7 @@ export interface Config {
     // Worktree settings for parallel work mode
     worktreePath?: string;           // Base path for worktrees (default: ~/.ghp/worktrees)
     worktreeCopyFiles?: string[];    // Files to copy to new worktrees (default: ['.env', '.env.local'])
+    worktreeSymlinkFiles?: string[]; // Files to symlink from main repo into new worktrees
     worktreeSetupCommand?: string;   // Command to run in new worktrees (default: 'pnpm install')
     worktreeAutoSetup?: boolean;     // Whether to run setup automatically (default: true)
 
@@ -635,7 +636,7 @@ export function getAddIssueDefaults(): { template?: string; project?: string; st
     return config.defaults?.addIssue || {};
 }
 
-export const CONFIG_KEYS = ['mainBranch', 'branchPattern', 'startWorkingStatus', 'doneStatus', 'columns', 'worktreePath', 'worktreeCopyFiles', 'worktreeSetupCommand', 'worktreeAutoSetup', 'parallelWork'] as const;
+export const CONFIG_KEYS = ['mainBranch', 'branchPattern', 'startWorkingStatus', 'doneStatus', 'columns', 'worktreePath', 'worktreeCopyFiles', 'worktreeSymlinkFiles', 'worktreeSetupCommand', 'worktreeAutoSetup', 'parallelWork'] as const;
 
 export type ConfigSource = 'default' | 'workspace' | 'user';
 
@@ -653,6 +654,7 @@ export function listConfig(): Record<string, string | string[] | boolean | undef
         doneStatus: config.doneStatus,
         worktreePath: config.worktreePath,
         worktreeCopyFiles: config.worktreeCopyFiles,
+        worktreeSymlinkFiles: config.worktreeSymlinkFiles,
         worktreeSetupCommand: config.worktreeSetupCommand,
         worktreeAutoSetup: config.worktreeAutoSetup,
     };
@@ -661,6 +663,7 @@ export function listConfig(): Record<string, string | string[] | boolean | undef
 export interface WorktreeConfig {
     path: string;
     copyFiles: string[];
+    symlinkFiles: string[];
     setupCommand: string;
     autoSetup: boolean;
 }
@@ -673,6 +676,7 @@ export function getWorktreeConfig(): WorktreeConfig {
     return {
         path: config.worktreePath ?? DEFAULT_CONFIG.worktreePath!,
         copyFiles: config.worktreeCopyFiles ?? DEFAULT_CONFIG.worktreeCopyFiles!,
+        symlinkFiles: config.worktreeSymlinkFiles ?? [],
         setupCommand: config.worktreeSetupCommand ?? DEFAULT_CONFIG.worktreeSetupCommand!,
         autoSetup: config.worktreeAutoSetup ?? DEFAULT_CONFIG.worktreeAutoSetup!,
     };

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -84,10 +84,12 @@ export interface ParallelWorkConfig {
     nvimCommand?: string;
     /** Tmux-specific configuration (used when terminal is 'tmux' or auto-detected inside tmux) */
     tmux?: {
-        /** Whether to spawn a new window or split the current window into a pane */
-        mode?: 'window' | 'pane';
+        /** Whether to spawn a new window, split pane, or create a separate session per agent */
+        mode?: 'window' | 'pane' | 'session';
         /** Direction to split when mode is 'pane' */
         paneDirection?: 'horizontal' | 'vertical';
+        /** Prefix for all tmux naming (windows, sessions, admin). Default: 'ghp' */
+        prefix?: string;
     };
     /** Dashboard layout configuration */
     dashboard?: DashboardConfig;

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -51,6 +51,22 @@ export interface WorkDefaults {
  */
 export type TerminalMode = 'claude' | 'nvim-claude' | 'terminal';
 
+export interface DashboardConfig {
+    /** Where to open the dashboard: 'pane' (split current window) or 'window' (new tmux window) */
+    mode?: 'pane' | 'window';
+    /** Split direction when mode is 'pane': 'horizontal' (side-by-side) or 'vertical' (stacked) */
+    direction?: 'horizontal' | 'vertical';
+    /** Dashboard size as percentage or cells (e.g., '50%', '80') */
+    size?: string;
+    /** Where focused agents appear relative to dashboard */
+    focusedAgent?: {
+        /** Split direction: 'horizontal' (side-by-side) or 'vertical' (stacked below) */
+        direction?: 'horizontal' | 'vertical';
+        /** Size of the focused agent pane */
+        size?: string;
+    };
+}
+
 export interface ParallelWorkConfig {
     /** Terminal emulator to use (e.g., 'ghostty', 'gnome-terminal', 'tmux') */
     terminal?: string;
@@ -73,6 +89,8 @@ export interface ParallelWorkConfig {
         /** Direction to split when mode is 'pane' */
         paneDirection?: 'horizontal' | 'vertical';
     };
+    /** Dashboard layout configuration */
+    dashboard?: DashboardConfig;
 }
 
 /**
@@ -174,6 +192,12 @@ export interface Config {
         stages?: string[];
         /** Stage name after which integration testing is triggered */
         integrationAfter?: string;
+        /** Available hook modes (e.g., ["planning", "testing", "review"]) */
+        hookModes?: string[];
+        /** Default hook mode at dashboard startup (must be in hookModes) */
+        defaultHookMode?: string;
+        /** When hot-swapping agents, run unfocus hooks first or focus hooks first */
+        hookModeSwapOrder?: 'unfocus-first' | 'focus-first';
     };
 
     // Command defaults
@@ -210,6 +234,15 @@ const DEFAULT_CONFIG: Config = {
     parallelWork: {
         openTerminal: true,
         autoRunClaude: true,
+        dashboard: {
+            mode: 'pane',
+            direction: 'horizontal',
+            size: '50%',
+            focusedAgent: {
+                direction: 'vertical',
+                size: '50%',
+            },
+        },
     },
     defaults: {},
     shortcuts: {},
@@ -682,6 +715,16 @@ export function getWorktreeConfig(): WorktreeConfig {
     };
 }
 
+export interface ResolvedDashboardConfig {
+    mode: 'pane' | 'window';
+    direction: 'horizontal' | 'vertical';
+    size: string;
+    focusedAgent: {
+        direction: 'horizontal' | 'vertical';
+        size: string;
+    };
+}
+
 export interface ResolvedParallelWorkConfig {
     terminal?: string;
     openTerminal: boolean;
@@ -690,6 +733,7 @@ export interface ResolvedParallelWorkConfig {
     autoResume: boolean;
     terminalMode: TerminalMode;
     nvimCommand: string;
+    dashboard: ResolvedDashboardConfig;
 }
 
 /**
@@ -698,6 +742,8 @@ export interface ResolvedParallelWorkConfig {
 export function getParallelWorkConfig(): ResolvedParallelWorkConfig {
     const config = loadConfig();
     const parallelWork = config.parallelWork ?? {};
+    const db = parallelWork.dashboard ?? {};
+    const fa = db.focusedAgent ?? {};
     return {
         terminal: parallelWork.terminal,
         openTerminal: parallelWork.openTerminal ?? true,
@@ -706,6 +752,15 @@ export function getParallelWorkConfig(): ResolvedParallelWorkConfig {
         autoResume: parallelWork.autoResume ?? true,
         terminalMode: parallelWork.terminalMode ?? 'claude',
         nvimCommand: parallelWork.nvimCommand ?? 'nvim',
+        dashboard: {
+            mode: db.mode ?? 'pane',
+            direction: db.direction ?? 'horizontal',
+            size: db.size ?? '50%',
+            focusedAgent: {
+                direction: fa.direction ?? 'vertical',
+                size: fa.size ?? '50%',
+            },
+        },
     };
 }
 

--- a/packages/cli/src/exit.ts
+++ b/packages/cli/src/exit.ts
@@ -17,6 +17,14 @@ const cleanupHandlers: CleanupHandler[] = [];
 let isExiting = false;
 
 /**
+ * Reset the exit state. Used by embedded contexts (e.g., the pipeline dashboard)
+ * that intercept exit() to prevent process termination.
+ */
+export function resetExitState(): void {
+    isExiting = false;
+}
+
+/**
  * Register a cleanup handler to run before process exit.
  * Handlers are called in reverse order (LIFO - last registered runs first).
  *

--- a/packages/cli/src/git-utils.ts
+++ b/packages/cli/src/git-utils.ts
@@ -5,6 +5,8 @@
  * The core library accepts an optional { cwd } parameter for IDE integrations.
  */
 
+import { listWorktrees as _listWorktrees } from '@bretwardjames/ghp-core';
+
 // Re-export all git utilities from core
 // These all use process.cwd() by default, which is correct for CLI usage
 export {
@@ -43,3 +45,21 @@ export {
 
 // Re-export the RepoInfo and WorktreeInfo types
 export type { RepoInfo, GitOptions, WorktreeInfo } from '@bretwardjames/ghp-core';
+
+/**
+ * Return the path of the main (non-linked) worktree.
+ *
+ * Unlike `getRepositoryRoot()`, which resolves relative to process.cwd() and
+ * therefore returns the linked worktree's root when called from inside one,
+ * this function always returns the primary worktree path by reading
+ * `git worktree list --porcelain` and finding the entry marked as `isMain`.
+ */
+export async function getMainWorktreeRoot(): Promise<string | null> {
+    try {
+        const worktrees = await _listWorktrees();
+        const main = worktrees.find(wt => wt.isMain);
+        return main?.path ?? null;
+    } catch {
+        return null;
+    }
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -533,6 +533,7 @@ program
     .option('-i, --install', 'Auto-configure Claude Desktop')
     .option('--install-claude-commands', 'Also install Claude slash commands (use with --install)')
     .option('-s, --status', 'Show enabled/disabled MCP tools')
+    .option('-r, --repo <owner/name>', 'Scope MCP server to a specific repo')
     .action(mcpCommand);
 
 // Slash command installation

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -30,10 +30,12 @@ import { editCommand } from './commands/edit.js';
 import { mcpCommand } from './commands/mcp.js';
 import { installCommandsCommand } from './commands/install-commands.js';
 import { worktreeRemoveCommand, worktreeListCommand } from './commands/worktree.js';
-import { worktreeMoveToCommand, worktreeCleanCommand, worktreeSwapStatusCommand } from './commands/worktree-swap.js';
+import { worktreeMoveToCommand, worktreeCleanCommand, worktreeSwapStatusCommand, worktreeReadyCommand, worktreeNextCommand } from './commands/worktree-swap.js';
 import { planEpicCommand } from './commands/plan-epic.js';
 import { setParentCommand } from './commands/set-parent.js';
 import { agentsListCommand, agentsStopCommand, agentsWatchCommand } from './commands/agents.js';
+import { statusCommand } from './commands/status.js';
+import { pipelineDashboardCommand } from './commands/dashboard-pipeline.js';
 import { progressCommand } from './commands/progress.js';
 import { standupCommand } from './commands/standup.js';
 import { fieldsCommand } from './commands/fields.js';
@@ -576,6 +578,23 @@ worktreeCmd
     .description('Show current worktree swap state')
     .action(worktreeSwapStatusCommand);
 
+worktreeCmd
+    .command('ready [issue]')
+    .description('Mark this worktree\'s stage complete — queues it for integration testing')
+    .action(worktreeReadyCommand);
+
+worktreeCmd
+    .command('next [issue]')
+    .description('Swap the next ready worktree into main (FIFO, or specify issue to override)')
+    .action(worktreeNextCommand);
+
+// Unified status
+program
+    .command('status')
+    .description('Show pipeline + agent status for all worktrees')
+    .option('--json', 'Output as JSON (for slash commands and dashboard)')
+    .action(statusCommand);
+
 // Agent management
 const agentsCmd = program
     .command('agents')
@@ -602,6 +621,14 @@ agentsCmd
     .description('Watch agents with auto-refresh (simple dashboard)')
     .option('-i, --interval <seconds>', 'Refresh interval in seconds', '2')
     .action(agentsWatchCommand);
+
+// Pipeline dashboard (kanban + pane pull)
+program
+    .command('pipeline')
+    .alias('pl')
+    .description('Pipeline dashboard — kanban view of all worktrees with interactive pane-pull')
+    .option('-i, --interval <seconds>', 'Refresh interval in seconds', '2')
+    .action(pipelineDashboardCommand);
 
 // Self-update
 program

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -30,6 +30,7 @@ import { editCommand } from './commands/edit.js';
 import { mcpCommand } from './commands/mcp.js';
 import { installCommandsCommand } from './commands/install-commands.js';
 import { worktreeRemoveCommand, worktreeListCommand } from './commands/worktree.js';
+import { worktreeMoveToCommand, worktreeCleanCommand, worktreeSwapStatusCommand } from './commands/worktree-swap.js';
 import { planEpicCommand } from './commands/plan-epic.js';
 import { setParentCommand } from './commands/set-parent.js';
 import { agentsListCommand, agentsStopCommand, agentsWatchCommand } from './commands/agents.js';
@@ -557,6 +558,23 @@ worktreeCmd
     .description('List all worktrees')
     .option('--json', 'Output as JSON (for programmatic use)')
     .action(worktreeListCommand);
+
+worktreeCmd
+    .command('move-to <issue>')
+    .description('Swap a worktree branch into the main repo for live testing')
+    .option('-f, --force', 'Proceed even with uncommitted changes in main')
+    .action(worktreeMoveToCommand);
+
+worktreeCmd
+    .command('clean')
+    .description('Reverse a move-to swap: restore main and re-attach the worktree')
+    .option('-f, --force', 'Restore repos even if branches have diverged')
+    .action(worktreeCleanCommand);
+
+worktreeCmd
+    .command('status')
+    .description('Show current worktree swap state')
+    .action(worktreeSwapStatusCommand);
 
 // Agent management
 const agentsCmd = program

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -36,6 +36,7 @@ import { setParentCommand } from './commands/set-parent.js';
 import { agentsListCommand, agentsStopCommand, agentsWatchCommand } from './commands/agents.js';
 import { statusCommand } from './commands/status.js';
 import { pipelineDashboardCommand } from './commands/dashboard-pipeline.js';
+import { pipelineAdvanceCommand, pipelineSetCommand, pipelineStagesCommand } from './commands/pipeline-commands.js';
 import { progressCommand } from './commands/progress.js';
 import { standupCommand } from './commands/standup.js';
 import { fieldsCommand } from './commands/fields.js';
@@ -272,6 +273,7 @@ program
     .option('--keep-branch', 'With --parallel: never switch branches in the main repo (zero-checkout worktree creation)')
     .option('--no-open', 'Skip opening terminal (with --parallel, just create worktree)')
     .option('--admin', 'Open admin pane (ghp agents watch) with --parallel')
+    .option('--background', 'Open agent terminal in background (don\'t switch focus)')
     .option('--worktree-path <path>', 'Custom path for parallel worktree')
     // Terminal mode overrides (for use with --parallel)
     .option('--nvim', 'Use nvim with claudecode.nvim plugin (overrides config)')
@@ -313,6 +315,7 @@ program
     .option('--parallel', 'Create worktree and open new terminal (work in parallel)')
     .option('--no-open', 'Skip opening terminal (with --parallel, just create worktree)')
     .option('--admin', 'Open admin pane (ghp agents watch) with --parallel')
+    .option('--background', 'Open agent terminal in background (don\'t switch focus)')
     .option('--worktree-path <path>', 'Custom path for parallel worktree')
     // Terminal mode overrides (for use with --parallel)
     .option('--nvim', 'Use nvim with claudecode.nvim plugin (overrides config)')
@@ -622,13 +625,33 @@ agentsCmd
     .option('-i, --interval <seconds>', 'Refresh interval in seconds', '2')
     .action(agentsWatchCommand);
 
-// Pipeline dashboard (kanban + pane pull)
-program
+// Pipeline management
+const pipelineCmd = program
     .command('pipeline')
     .alias('pl')
-    .description('Pipeline dashboard — kanban view of all worktrees with interactive pane-pull')
+    .description('Pipeline management and dashboard');
+
+pipelineCmd
+    .command('dashboard')
+    .alias('db')
+    .description('Pipeline dashboard — kanban view with interactive pane-pull')
     .option('-i, --interval <seconds>', 'Refresh interval in seconds', '2')
     .action(pipelineDashboardCommand);
+
+pipelineCmd
+    .command('advance [issue]')
+    .description('Advance a worktree to the next pipeline stage')
+    .action(pipelineAdvanceCommand);
+
+pipelineCmd
+    .command('set <stage> [issue]')
+    .description('Set a worktree to a specific pipeline stage')
+    .action(pipelineSetCommand);
+
+pipelineCmd
+    .command('stages')
+    .description('List configured pipeline stages')
+    .action(pipelineStagesCommand);
 
 // Self-update
 program

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -36,7 +36,8 @@ import { setParentCommand } from './commands/set-parent.js';
 import { agentsListCommand, agentsStopCommand, agentsWatchCommand } from './commands/agents.js';
 import { statusCommand } from './commands/status.js';
 import { pipelineDashboardCommand } from './commands/dashboard-pipeline.js';
-import { pipelineAdvanceCommand, pipelineSetCommand, pipelineStagesCommand } from './commands/pipeline-commands.js';
+import { pipelineAdvanceCommand, pipelineSetCommand, pipelineRemoveCommand, pipelineStagesCommand, pipelineAgentActiveCommand, pipelineAgentStoppedCommand, pipelineAgentFocusedCommand, pipelineAgentUnfocusedCommand, pipelineAgentSwappedCommand, pipelineModeCommand } from './commands/pipeline-commands.js';
+import { pipelineSetupCommand } from './commands/pipeline-setup.js';
 import { progressCommand } from './commands/progress.js';
 import { standupCommand } from './commands/standup.js';
 import { fieldsCommand } from './commands/fields.js';
@@ -649,9 +650,59 @@ pipelineCmd
     .action(pipelineSetCommand);
 
 pipelineCmd
+    .command('remove [issue]')
+    .alias('rm')
+    .description('Remove a worktree entry from the pipeline registry')
+    .action(pipelineRemoveCommand);
+
+pipelineCmd
     .command('stages')
     .description('List configured pipeline stages')
     .action(pipelineStagesCommand);
+
+pipelineCmd
+    .command('setup')
+    .description('Setup wizard for pipeline configuration (agent-friendly)')
+    .option('--questions', 'Output question schema as JSON (no side effects)')
+    .option('--apply', 'Read answers JSON from stdin and apply configuration')
+    .option('--save <name>', 'Save answers from stdin as a named flavor')
+    .option('--flavor <name>', 'Load and apply a saved flavor')
+    .option('--flavors', 'List saved flavors')
+    .option('--delete-flavor <name>', 'Delete a saved flavor')
+    .action(pipelineSetupCommand);
+
+pipelineCmd
+    .command('agent-active')
+    .description('Set agent to working + fire user hooks (called by PostToolUse)')
+    .action(pipelineAgentActiveCommand);
+
+pipelineCmd
+    .command('agent-stopped')
+    .description('Set agent to stopped + fire user hooks (called by Stop)')
+    .action(pipelineAgentStoppedCommand);
+
+pipelineCmd
+    .command('agent-focused <issue>')
+    .description('Fire user hooks when agent is pulled into dashboard view')
+    .option('--mode <mode>', 'Hook mode for mode-aware resolution')
+    .action(pipelineAgentFocusedCommand);
+
+pipelineCmd
+    .command('agent-unfocused <issue>')
+    .description('Fire user hooks when agent is released from dashboard view')
+    .option('--mode <mode>', 'Hook mode for mode-aware resolution')
+    .action(pipelineAgentUnfocusedCommand);
+
+pipelineCmd
+    .command('agent-swapped <oldIssue> <newIssue>')
+    .description('Fire user hooks when switching between focused agents (hot-swap)')
+    .option('--mode <mode>', 'Hook mode for mode-aware resolution')
+    .action(pipelineAgentSwappedCommand);
+
+pipelineCmd
+    .command('mode [name]')
+    .description('Show or validate hook modes')
+    .action(pipelineModeCommand);
 
 // Self-update
 program

--- a/packages/cli/src/pipeline-registry.ts
+++ b/packages/cli/src/pipeline-registry.ts
@@ -11,6 +11,7 @@ import { existsSync, readFileSync, writeFileSync } from 'fs';
 import { execFileSync } from 'child_process';
 import { join } from 'path';
 import { getConfig } from './config.js';
+import { agentWindowName } from './terminal-utils.js';
 
 // ---------------------------------------------------------------------------
 // Default stages
@@ -86,10 +87,10 @@ export function getStageEmoji(stage: string): string {
 /** Rename the tmux window for an issue to reflect its current stage. */
 function renameWorktreeWindow(issueNumber: number, stage: string): void {
     const emoji = getStageEmoji(stage);
-    const prefix = emoji ? `${emoji} ` : '';
-    const windowName = `ghp-${issueNumber}`;
+    const emojiPrefix = emoji ? `${emoji} ` : '';
+    const windowName = agentWindowName(issueNumber);
     try {
-        execFileSync('tmux', ['rename-window', '-t', windowName, `${prefix}${windowName}`], { stdio: 'ignore' });
+        execFileSync('tmux', ['rename-window', '-t', windowName, `${emojiPrefix}${windowName}`], { stdio: 'ignore' });
     } catch { /* not in tmux or window doesn't exist — fine */ }
 }
 

--- a/packages/cli/src/pipeline-registry.ts
+++ b/packages/cli/src/pipeline-registry.ts
@@ -16,19 +16,7 @@ import { getConfig } from './config.js';
 // Default stages
 // ---------------------------------------------------------------------------
 
-const DEFAULT_STAGES = [
-    'initiating',
-    'planning',
-    'plan_ready',
-    'building_tests',
-    'working',
-    'code_review',
-    'ready_for_integration',
-    'integration_testing',
-    'code_review_loop',
-    'writing_pr',
-    'pr_submitted',
-];
+const DEFAULT_STAGES = ['working', 'stopped'];
 
 /**
  * Special non-linear stage. Can be entered from any stage; advancing from it
@@ -85,18 +73,9 @@ export function getStageIndex(stageName: string): number {
 // ---------------------------------------------------------------------------
 
 const STAGE_EMOJIS: Record<string, string> = {
-    initiating: '⏳',
-    planning: '📋',
-    plan_ready: '📝',
-    building_tests: '🧪',
     working: '🔨',
+    stopped: '⏸',
     needs_attention: '🚨',
-    code_review: '👀',
-    ready_for_integration: '✅',
-    integration_testing: '🔄',
-    code_review_loop: '🔍',
-    writing_pr: '📤',
-    pr_submitted: '🏁',
 };
 
 /** Get the emoji for a pipeline stage. Returns empty string for unknown stages. */
@@ -140,7 +119,7 @@ function saveRegistry(repoRoot: string, registry: PipelineRegistry): void {
 // Public API
 // ---------------------------------------------------------------------------
 
-/** Register a new worktree at the first stage (typically 'initiating'). */
+/** Register a new worktree at the first stage (default: 'working'). */
 export function registerWorktree(
     repoRoot: string,
     entry: Omit<PipelineEntry, 'stage' | 'previousStage' | 'stageEnteredAt' | 'registeredAt'>

--- a/packages/cli/src/pipeline-registry.ts
+++ b/packages/cli/src/pipeline-registry.ts
@@ -22,7 +22,6 @@ const DEFAULT_STAGES = [
     'plan_ready',
     'building_tests',
     'working',
-    'needs_attention',
     'code_review',
     'ready_for_integration',
     'integration_testing',
@@ -30,6 +29,12 @@ const DEFAULT_STAGES = [
     'writing_pr',
     'pr_submitted',
 ];
+
+/**
+ * Special non-linear stage. Can be entered from any stage; advancing from it
+ * restores the previous stage. Not part of the linear pipeline.
+ */
+const NEEDS_ATTENTION = 'needs_attention';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -40,8 +45,10 @@ export interface PipelineEntry {
     issueTitle: string;
     branch: string;
     worktreePath: string;
-    /** Current stage name (from configured stages list) */
+    /** Current stage name (from configured stages list, or 'needs_attention') */
     stage: string;
+    /** Stage before entering needs_attention (used to restore on advance) */
+    previousStage?: string;
     /** ISO timestamp of when the entry moved to the current stage */
     stageEnteredAt: string;
     /** ISO timestamp of initial registration */
@@ -136,7 +143,7 @@ function saveRegistry(repoRoot: string, registry: PipelineRegistry): void {
 /** Register a new worktree at the first stage (typically 'initiating'). */
 export function registerWorktree(
     repoRoot: string,
-    entry: Omit<PipelineEntry, 'stage' | 'stageEnteredAt' | 'registeredAt'>
+    entry: Omit<PipelineEntry, 'stage' | 'previousStage' | 'stageEnteredAt' | 'registeredAt'>
 ): PipelineEntry {
     const registry = loadRegistry(repoRoot);
     const stages = getPipelineStages();
@@ -153,31 +160,52 @@ export function registerWorktree(
     return full;
 }
 
-/** Advance a worktree to the next stage in the pipeline. Returns null if not found or already at last stage. */
+/** Advance a worktree to the next stage in the pipeline. Returns null if not found or already at last stage.
+ *  If currently at needs_attention, restores to the previous stage instead of advancing. */
 export function advanceWorktreeStage(repoRoot: string, issueNumber: number): PipelineEntry | null {
     const registry = loadRegistry(repoRoot);
     const entry = registry[String(issueNumber)];
     if (!entry) return null;
+
+    // Restore from needs_attention → go back to where we were
+    if (entry.stage === NEEDS_ATTENTION && entry.previousStage) {
+        entry.stage = entry.previousStage;
+        delete entry.previousStage;
+        entry.stageEnteredAt = new Date().toISOString();
+        saveRegistry(repoRoot, registry);
+        renameWorktreeWindow(issueNumber, entry.stage);
+        return entry;
+    }
 
     const stages = getPipelineStages();
     const currentIndex = stages.indexOf(entry.stage);
     if (currentIndex < 0 || currentIndex >= stages.length - 1) return entry;
 
     entry.stage = stages[currentIndex + 1];
+    delete entry.previousStage;
     entry.stageEnteredAt = new Date().toISOString();
     saveRegistry(repoRoot, registry);
     renameWorktreeWindow(issueNumber, entry.stage);
     return entry;
 }
 
-/** Set a worktree to a specific stage by name. */
+/** Set a worktree to a specific stage by name. Accepts linear stages and 'needs_attention'. */
 export function setWorktreeStage(repoRoot: string, issueNumber: number, stageName: string): PipelineEntry | null {
     const registry = loadRegistry(repoRoot);
     const entry = registry[String(issueNumber)];
     if (!entry) return null;
 
     const stages = getPipelineStages();
-    if (!stages.includes(stageName)) return null;
+    if (!stages.includes(stageName) && stageName !== NEEDS_ATTENTION) return null;
+
+    // Entering needs_attention: save current stage so advance can restore it
+    if (stageName === NEEDS_ATTENTION && entry.stage !== NEEDS_ATTENTION) {
+        entry.previousStage = entry.stage;
+    }
+    // Leaving needs_attention via explicit set: clear previousStage
+    if (stageName !== NEEDS_ATTENTION) {
+        delete entry.previousStage;
+    }
 
     entry.stage = stageName;
     entry.stageEnteredAt = new Date().toISOString();
@@ -221,6 +249,7 @@ export function getReadyWorktrees(repoRoot: string): PipelineEntry[] {
 
 /** Check if a stage is at or past the integration trigger point. */
 export function isAtOrPastIntegration(stageName: string): boolean {
+    if (stageName === NEEDS_ATTENTION) return false;
     const stages = getPipelineStages();
     const triggerIndex = stages.indexOf(getIntegrationTriggerStage());
     const stageIndex = stages.indexOf(stageName);

--- a/packages/cli/src/pipeline-registry.ts
+++ b/packages/cli/src/pipeline-registry.ts
@@ -1,0 +1,130 @@
+/**
+ * Pipeline registry for tracking worktrees through workflow stages.
+ *
+ * Stored in .git/ghp-pipeline.json (alongside swap state).
+ * Populated when ghp start --parallel creates a worktree.
+ * Updated by ghp wt ready, ghp wt next, ghp wt clean.
+ */
+
+import { existsSync, readFileSync, writeFileSync } from 'fs';
+import { join } from 'path';
+
+export type PipelineStage = 1 | 2 | 3;
+export type PipelineStageStatus = 'in_progress' | 'ready' | 'done';
+
+export interface PipelineEntry {
+    issueNumber: number;
+    issueTitle: string;
+    branch: string;
+    worktreePath: string;
+    stage: PipelineStage;
+    stageStatus: PipelineStageStatus;
+    /** ISO timestamp when stageStatus was set to 'ready' */
+    readyAt?: string;
+    /** ISO timestamp of initial registration */
+    registeredAt: string;
+}
+
+type PipelineRegistry = Record<string, PipelineEntry>;
+
+function getRegistryPath(repoRoot: string): string {
+    return join(repoRoot, '.git', 'ghp-pipeline.json');
+}
+
+function loadRegistry(repoRoot: string): PipelineRegistry {
+    const path = getRegistryPath(repoRoot);
+    if (!existsSync(path)) return {};
+    try {
+        return JSON.parse(readFileSync(path, 'utf-8')) as PipelineRegistry;
+    } catch {
+        return {};
+    }
+}
+
+function saveRegistry(repoRoot: string, registry: PipelineRegistry): void {
+    writeFileSync(getRegistryPath(repoRoot), JSON.stringify(registry, null, 2));
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/** Register a new worktree at stage 1 / in_progress. */
+export function registerWorktree(
+    repoRoot: string,
+    entry: Omit<PipelineEntry, 'stage' | 'stageStatus' | 'registeredAt'>
+): PipelineEntry {
+    const registry = loadRegistry(repoRoot);
+    const full: PipelineEntry = {
+        ...entry,
+        stage: 1,
+        stageStatus: 'in_progress',
+        registeredAt: new Date().toISOString(),
+    };
+    registry[String(entry.issueNumber)] = full;
+    saveRegistry(repoRoot, registry);
+    return full;
+}
+
+/** Mark the current stage as complete (ready to advance). */
+export function markWorktreeReady(repoRoot: string, issueNumber: number): PipelineEntry | null {
+    const registry = loadRegistry(repoRoot);
+    const entry = registry[String(issueNumber)];
+    if (!entry) return null;
+    entry.stageStatus = 'ready';
+    entry.readyAt = new Date().toISOString();
+    saveRegistry(repoRoot, registry);
+    return entry;
+}
+
+/** Advance a worktree to the next stage (1→2 or 2→3). */
+export function advanceWorktreeStage(repoRoot: string, issueNumber: number): PipelineEntry | null {
+    const registry = loadRegistry(repoRoot);
+    const entry = registry[String(issueNumber)];
+    if (!entry) return null;
+    if (entry.stage < 3) {
+        entry.stage = (entry.stage + 1) as PipelineStage;
+        entry.stageStatus = 'in_progress';
+        delete entry.readyAt;
+    }
+    saveRegistry(repoRoot, registry);
+    return entry;
+}
+
+/** Mark a worktree's stage as done (e.g. PR opened at end of stage 3). */
+export function markWorktreeDone(repoRoot: string, issueNumber: number): PipelineEntry | null {
+    const registry = loadRegistry(repoRoot);
+    const entry = registry[String(issueNumber)];
+    if (!entry) return null;
+    entry.stageStatus = 'done';
+    saveRegistry(repoRoot, registry);
+    return entry;
+}
+
+/** Remove a worktree from the pipeline (e.g. when worktree is deleted). */
+export function deregisterWorktree(repoRoot: string, issueNumber: number): void {
+    const registry = loadRegistry(repoRoot);
+    delete registry[String(issueNumber)];
+    saveRegistry(repoRoot, registry);
+}
+
+/** Get a single entry. */
+export function getPipelineEntry(repoRoot: string, issueNumber: number): PipelineEntry | null {
+    return loadRegistry(repoRoot)[String(issueNumber)] ?? null;
+}
+
+/** Get all entries. */
+export function getAllPipelineEntries(repoRoot: string): PipelineEntry[] {
+    return Object.values(loadRegistry(repoRoot));
+}
+
+/** Get all entries with stageStatus === 'ready', sorted FIFO by readyAt. */
+export function getReadyWorktrees(repoRoot: string): PipelineEntry[] {
+    return getAllPipelineEntries(repoRoot)
+        .filter(e => e.stageStatus === 'ready')
+        .sort((a, b) => {
+            if (!a.readyAt) return 1;
+            if (!b.readyAt) return -1;
+            return a.readyAt.localeCompare(b.readyAt);
+        });
+}

--- a/packages/cli/src/pipeline-registry.ts
+++ b/packages/cli/src/pipeline-registry.ts
@@ -8,6 +8,7 @@
  */
 
 import { existsSync, readFileSync, writeFileSync } from 'fs';
+import { execFileSync } from 'child_process';
 import { join } from 'path';
 import { getConfig } from './config.js';
 
@@ -73,6 +74,40 @@ export function getStageIndex(stageName: string): number {
 }
 
 // ---------------------------------------------------------------------------
+// Stage emoji mapping
+// ---------------------------------------------------------------------------
+
+const STAGE_EMOJIS: Record<string, string> = {
+    initiating: '⏳',
+    planning: '📋',
+    plan_ready: '📝',
+    building_tests: '🧪',
+    working: '🔨',
+    needs_attention: '🚨',
+    code_review: '👀',
+    ready_for_integration: '✅',
+    integration_testing: '🔄',
+    code_review_loop: '🔍',
+    writing_pr: '📤',
+    pr_submitted: '🏁',
+};
+
+/** Get the emoji for a pipeline stage. Returns empty string for unknown stages. */
+export function getStageEmoji(stage: string): string {
+    return STAGE_EMOJIS[stage] ?? '';
+}
+
+/** Rename the tmux window for an issue to reflect its current stage. */
+function renameWorktreeWindow(issueNumber: number, stage: string): void {
+    const emoji = getStageEmoji(stage);
+    const prefix = emoji ? `${emoji} ` : '';
+    const windowName = `ghp-${issueNumber}`;
+    try {
+        execFileSync('tmux', ['rename-window', '-t', windowName, `${prefix}${windowName}`], { stdio: 'ignore' });
+    } catch { /* not in tmux or window doesn't exist — fine */ }
+}
+
+// ---------------------------------------------------------------------------
 // Registry I/O
 // ---------------------------------------------------------------------------
 
@@ -114,6 +149,7 @@ export function registerWorktree(
     };
     registry[String(entry.issueNumber)] = full;
     saveRegistry(repoRoot, registry);
+    renameWorktreeWindow(entry.issueNumber, stages[0]);
     return full;
 }
 
@@ -130,6 +166,7 @@ export function advanceWorktreeStage(repoRoot: string, issueNumber: number): Pip
     entry.stage = stages[currentIndex + 1];
     entry.stageEnteredAt = new Date().toISOString();
     saveRegistry(repoRoot, registry);
+    renameWorktreeWindow(issueNumber, entry.stage);
     return entry;
 }
 
@@ -145,6 +182,7 @@ export function setWorktreeStage(repoRoot: string, issueNumber: number, stageNam
     entry.stage = stageName;
     entry.stageEnteredAt = new Date().toISOString();
     saveRegistry(repoRoot, registry);
+    renameWorktreeWindow(issueNumber, stageName);
     return entry;
 }
 

--- a/packages/cli/src/pipeline-registry.ts
+++ b/packages/cli/src/pipeline-registry.ts
@@ -1,31 +1,80 @@
 /**
- * Pipeline registry for tracking worktrees through workflow stages.
+ * Pipeline registry — configurable stage-based workflow for worktrees.
  *
- * Stored in .git/ghp-pipeline.json (alongside swap state).
- * Populated when ghp start --parallel creates a worktree.
- * Updated by ghp wt ready, ghp wt next, ghp wt clean.
+ * Stages are defined in ghp config under `pipeline.stages` as an ordered array
+ * of stage names. A worktree advances linearly through stages.
+ *
+ * Stored in .git/ghp-pipeline.json.
  */
 
 import { existsSync, readFileSync, writeFileSync } from 'fs';
 import { join } from 'path';
+import { getConfig } from './config.js';
 
-export type PipelineStage = 1 | 2 | 3;
-export type PipelineStageStatus = 'in_progress' | 'ready' | 'done';
+// ---------------------------------------------------------------------------
+// Default stages
+// ---------------------------------------------------------------------------
+
+const DEFAULT_STAGES = [
+    'initiating',
+    'planning',
+    'plan_ready',
+    'building_tests',
+    'working',
+    'needs_attention',
+    'code_review',
+    'ready_for_integration',
+    'integration_testing',
+    'code_review_loop',
+    'writing_pr',
+    'pr_submitted',
+];
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
 
 export interface PipelineEntry {
     issueNumber: number;
     issueTitle: string;
     branch: string;
     worktreePath: string;
-    stage: PipelineStage;
-    stageStatus: PipelineStageStatus;
-    /** ISO timestamp when stageStatus was set to 'ready' */
-    readyAt?: string;
+    /** Current stage name (from configured stages list) */
+    stage: string;
+    /** ISO timestamp of when the entry moved to the current stage */
+    stageEnteredAt: string;
     /** ISO timestamp of initial registration */
     registeredAt: string;
 }
 
 type PipelineRegistry = Record<string, PipelineEntry>;
+
+// ---------------------------------------------------------------------------
+// Stage configuration
+// ---------------------------------------------------------------------------
+
+/** Get the configured pipeline stages (or defaults). */
+export function getPipelineStages(): string[] {
+    const config = getConfig('pipeline') as any;
+    const stages = config?.stages;
+    if (Array.isArray(stages) && stages.length > 0) return stages;
+    return DEFAULT_STAGES;
+}
+
+/** Get the stage name after which integration testing (swap to main) is triggered. */
+export function getIntegrationTriggerStage(): string {
+    const config = getConfig('pipeline') as any;
+    return config?.integrationAfter ?? 'ready_for_integration';
+}
+
+/** Get the index of a stage in the pipeline (-1 if not found). */
+export function getStageIndex(stageName: string): number {
+    return getPipelineStages().indexOf(stageName);
+}
+
+// ---------------------------------------------------------------------------
+// Registry I/O
+// ---------------------------------------------------------------------------
 
 function getRegistryPath(repoRoot: string): string {
     return join(repoRoot, '.git', 'ghp-pipeline.json');
@@ -49,59 +98,57 @@ function saveRegistry(repoRoot: string, registry: PipelineRegistry): void {
 // Public API
 // ---------------------------------------------------------------------------
 
-/** Register a new worktree at stage 1 / in_progress. */
+/** Register a new worktree at the first stage (typically 'initiating'). */
 export function registerWorktree(
     repoRoot: string,
-    entry: Omit<PipelineEntry, 'stage' | 'stageStatus' | 'registeredAt'>
+    entry: Omit<PipelineEntry, 'stage' | 'stageEnteredAt' | 'registeredAt'>
 ): PipelineEntry {
     const registry = loadRegistry(repoRoot);
+    const stages = getPipelineStages();
+    const now = new Date().toISOString();
     const full: PipelineEntry = {
         ...entry,
-        stage: 1,
-        stageStatus: 'in_progress',
-        registeredAt: new Date().toISOString(),
+        stage: stages[0],
+        stageEnteredAt: now,
+        registeredAt: now,
     };
     registry[String(entry.issueNumber)] = full;
     saveRegistry(repoRoot, registry);
     return full;
 }
 
-/** Mark the current stage as complete (ready to advance). */
-export function markWorktreeReady(repoRoot: string, issueNumber: number): PipelineEntry | null {
-    const registry = loadRegistry(repoRoot);
-    const entry = registry[String(issueNumber)];
-    if (!entry) return null;
-    entry.stageStatus = 'ready';
-    entry.readyAt = new Date().toISOString();
-    saveRegistry(repoRoot, registry);
-    return entry;
-}
-
-/** Advance a worktree to the next stage (1→2 or 2→3). */
+/** Advance a worktree to the next stage in the pipeline. Returns null if not found or already at last stage. */
 export function advanceWorktreeStage(repoRoot: string, issueNumber: number): PipelineEntry | null {
     const registry = loadRegistry(repoRoot);
     const entry = registry[String(issueNumber)];
     if (!entry) return null;
-    if (entry.stage < 3) {
-        entry.stage = (entry.stage + 1) as PipelineStage;
-        entry.stageStatus = 'in_progress';
-        delete entry.readyAt;
-    }
+
+    const stages = getPipelineStages();
+    const currentIndex = stages.indexOf(entry.stage);
+    if (currentIndex < 0 || currentIndex >= stages.length - 1) return entry;
+
+    entry.stage = stages[currentIndex + 1];
+    entry.stageEnteredAt = new Date().toISOString();
     saveRegistry(repoRoot, registry);
     return entry;
 }
 
-/** Mark a worktree's stage as done (e.g. PR opened at end of stage 3). */
-export function markWorktreeDone(repoRoot: string, issueNumber: number): PipelineEntry | null {
+/** Set a worktree to a specific stage by name. */
+export function setWorktreeStage(repoRoot: string, issueNumber: number, stageName: string): PipelineEntry | null {
     const registry = loadRegistry(repoRoot);
     const entry = registry[String(issueNumber)];
     if (!entry) return null;
-    entry.stageStatus = 'done';
+
+    const stages = getPipelineStages();
+    if (!stages.includes(stageName)) return null;
+
+    entry.stage = stageName;
+    entry.stageEnteredAt = new Date().toISOString();
     saveRegistry(repoRoot, registry);
     return entry;
 }
 
-/** Remove a worktree from the pipeline (e.g. when worktree is deleted). */
+/** Remove a worktree from the pipeline. */
 export function deregisterWorktree(repoRoot: string, issueNumber: number): void {
     const registry = loadRegistry(repoRoot);
     delete registry[String(issueNumber)];
@@ -118,13 +165,26 @@ export function getAllPipelineEntries(repoRoot: string): PipelineEntry[] {
     return Object.values(loadRegistry(repoRoot));
 }
 
-/** Get all entries with stageStatus === 'ready', sorted FIFO by readyAt. */
-export function getReadyWorktrees(repoRoot: string): PipelineEntry[] {
+/** Get entries at a specific stage, sorted FIFO by stageEnteredAt. */
+export function getWorktreesAtStage(repoRoot: string, stageName: string): PipelineEntry[] {
     return getAllPipelineEntries(repoRoot)
-        .filter(e => e.stageStatus === 'ready')
-        .sort((a, b) => {
-            if (!a.readyAt) return 1;
-            if (!b.readyAt) return -1;
-            return a.readyAt.localeCompare(b.readyAt);
-        });
+        .filter(e => e.stage === stageName)
+        .sort((a, b) => a.stageEnteredAt.localeCompare(b.stageEnteredAt));
+}
+
+/**
+ * Get worktrees that have reached the integration trigger stage,
+ * sorted FIFO by stageEnteredAt.
+ */
+export function getReadyWorktrees(repoRoot: string): PipelineEntry[] {
+    const triggerStage = getIntegrationTriggerStage();
+    return getWorktreesAtStage(repoRoot, triggerStage);
+}
+
+/** Check if a stage is at or past the integration trigger point. */
+export function isAtOrPastIntegration(stageName: string): boolean {
+    const stages = getPipelineStages();
+    const triggerIndex = stages.indexOf(getIntegrationTriggerStage());
+    const stageIndex = stages.indexOf(stageName);
+    return stageIndex >= triggerIndex && triggerIndex >= 0;
 }

--- a/packages/cli/src/terminal-utils.ts
+++ b/packages/cli/src/terminal-utils.ts
@@ -1,4 +1,4 @@
-import { exec, execSync, spawn } from 'child_process';
+import { exec, execFile, execSync, spawn } from 'child_process';
 import { promisify } from 'util';
 import * as os from 'os';
 import * as path from 'path';
@@ -8,6 +8,7 @@ import { getConfig, getParallelWorkConfig, type TerminalMode, type ResolvedDashb
 import type { SubagentSpawnDirective } from './types.js';
 
 const execAsync = promisify(exec);
+const execFileAsync = promisify(execFile);
 
 /**
  * Convert a directory path to Claude's project directory name format.
@@ -61,8 +62,9 @@ export function isInsideTmux(): boolean {
  * Tmux configuration for spawning
  */
 interface TmuxConfig {
-    mode: 'window' | 'pane';
+    mode: 'window' | 'pane' | 'session';
     paneDirection?: 'horizontal' | 'vertical';
+    prefix: string;
 }
 
 /**
@@ -73,7 +75,103 @@ function getTmuxConfig(): TmuxConfig {
     return {
         mode: config?.tmux?.mode ?? 'window',
         paneDirection: config?.tmux?.paneDirection ?? 'horizontal',
+        prefix: config?.tmux?.prefix ?? 'ghp',
     };
+}
+
+// ---------------------------------------------------------------------------
+// Tmux naming helpers — all tmux names derive from the configured prefix
+// ---------------------------------------------------------------------------
+
+/**
+ * Get the configured tmux prefix (default: 'ghp').
+ */
+export function getTmuxPrefix(): string {
+    const config = getConfig('parallelWork');
+    return config?.tmux?.prefix ?? 'ghp';
+}
+
+/**
+ * Generate a tmux window name for an agent (e.g., 'ghp-86' or 'myproj-86').
+ */
+export function agentWindowName(issueNumber: number): string {
+    return `${getTmuxPrefix()}-${issueNumber}`;
+}
+
+/**
+ * Generate a tmux session name for an agent in session mode (e.g., 'ghp-agent-86').
+ */
+export function agentSessionName(issueNumber: number): string {
+    return `${getTmuxPrefix()}-agent-${issueNumber}`;
+}
+
+/**
+ * Generate the tmux admin/dashboard window name (e.g., 'ghp-admin').
+ */
+export function adminWindowName(): string {
+    return `${getTmuxPrefix()}-admin`;
+}
+
+// ---------------------------------------------------------------------------
+// Tmux session utilities (for session mode)
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a new tmux session for an agent (session mode).
+ * The session runs detached with status bar off for a clean nested experience.
+ */
+export async function openTmuxSession(
+    directory: string,
+    sessionName: string,
+    command?: string,
+): Promise<{ success: boolean; error?: string }> {
+    try {
+        const args = [
+            'new-session', '-d',
+            '-s', sessionName,
+            '-c', directory,
+        ];
+        if (command) {
+            args.push(command);
+        }
+        await execFileAsync('tmux', args);
+
+        // Turn off the status bar inside the agent session for a clean nested look
+        try {
+            await execFileAsync('tmux', ['set-option', '-t', `=${sessionName}`, 'status', 'off']);
+        } catch { /* best effort */ }
+
+        return { success: true };
+    } catch (err) {
+        return {
+            success: false,
+            error: `Failed to create tmux session "${sessionName}": ${err instanceof Error ? err.message : 'unknown'}`,
+        };
+    }
+}
+
+/**
+ * Kill a tmux session by name.
+ */
+export async function killTmuxSession(sessionName: string): Promise<{ success: boolean; error?: string }> {
+    try {
+        await execFileAsync('tmux', ['kill-session', '-t', `=${sessionName}`]);
+        return { success: true };
+    } catch {
+        return { success: false, error: `Session "${sessionName}" not found or tmux not available` };
+    }
+}
+
+/**
+ * Check if a tmux session exists.
+ */
+export async function tmuxSessionExists(sessionName: string): Promise<boolean> {
+    try {
+        await execFileAsync('tmux', ['has-session', '-t', `=${sessionName}`]);
+        return true;
+    } catch {
+        return false;
+    }
 }
 
 /**
@@ -86,10 +184,18 @@ export async function openTmuxTerminal(
     directory: string,
     command?: string,
     windowName?: string,
-    options?: { background?: boolean }
+    options?: { background?: boolean; issueNumber?: number }
 ): Promise<{ success: boolean; error?: string }> {
     const tmuxConfig = getTmuxConfig();
     const bg = options?.background ?? false;
+
+    // Session mode: create a detached tmux session instead of a window/pane
+    if (tmuxConfig.mode === 'session' && windowName) {
+        const sessionName = options?.issueNumber != null
+            ? agentSessionName(options.issueNumber)
+            : `${tmuxConfig.prefix}-agent-${windowName}`;
+        return openTmuxSession(directory, sessionName, command);
+    }
 
     return new Promise((resolve) => {
         let tmuxArgs: string[];
@@ -373,7 +479,7 @@ export async function openTerminal(
     directory: string,
     command?: string,
     windowName?: string,
-    options?: { background?: boolean }
+    options?: { background?: boolean; issueNumber?: number }
 ): Promise<{ success: boolean; error?: string }> {
     // Check if we should use tmux
     const parallelConfig = getConfig('parallelWork');
@@ -443,8 +549,8 @@ export async function openParallelWorkTerminal(
 
     // Terminal-only mode: just open the terminal, no Claude
     if (terminalMode === 'terminal') {
-        const windowName = `ghp-${issueNumber}`;
-        const result = await openTerminal(worktreePath, undefined, windowName, options);
+        const windowName = agentWindowName(issueNumber);
+        const result = await openTerminal(worktreePath, undefined, windowName, { ...options, issueNumber });
         return { ...result, resumed: false };
     }
 
@@ -473,8 +579,8 @@ export async function openParallelWorkTerminal(
     const fullCommand = `export GHP_SPAWN_CONTEXT='${envJson.replace(/'/g, "'\\''")}' && ${command}`;
 
     // Name the tmux window with the issue number for tracking/cleanup
-    const windowName = `ghp-${issueNumber}`;
-    const result = await openTerminal(worktreePath, fullCommand, windowName, options);
+    const windowName = agentWindowName(issueNumber);
+    const result = await openTerminal(worktreePath, fullCommand, windowName, { ...options, issueNumber });
     return { ...result, resumed: shouldResume };
 }
 
@@ -484,6 +590,7 @@ export async function openParallelWorkTerminal(
 export async function isDashboardOpen(): Promise<boolean> {
     if (!isInsideTmux()) return false;
 
+    const adminName = adminWindowName();
     return new Promise((resolve) => {
         // Check both panes (for pane mode) and windows (for window mode)
         const child = spawn('tmux', ['list-panes', '-a', '-F', '#{pane_current_command} #{window_name}'], {
@@ -497,8 +604,7 @@ export async function isDashboardOpen(): Promise<boolean> {
 
         child.on('close', () => {
             const lines = output.split('\n');
-            // Check for ghp-admin window name or ghp pipeline process
-            resolve(lines.some(l => l.includes('ghp-admin')));
+            resolve(lines.some(l => l.includes(adminName)));
         });
     });
 }
@@ -546,7 +652,7 @@ export async function openAdminPane(targetPaneId?: string | null): Promise<{ suc
 
         if (dashboardConfig.mode === 'window') {
             // Open dashboard in a new tmux window
-            tmuxArgs = ['new-window', '-d', '-n', 'ghp-admin', command];
+            tmuxArgs = ['new-window', '-d', '-n', adminWindowName(), command];
         } else {
             // Open dashboard as a split pane
             const dirFlag = dashboardConfig.direction === 'vertical' ? '-v' : '-h';

--- a/packages/cli/src/terminal-utils.ts
+++ b/packages/cli/src/terminal-utils.ts
@@ -85,9 +85,11 @@ function getTmuxConfig(): TmuxConfig {
 export async function openTmuxTerminal(
     directory: string,
     command?: string,
-    windowName?: string
+    windowName?: string,
+    options?: { background?: boolean }
 ): Promise<{ success: boolean; error?: string }> {
     const tmuxConfig = getTmuxConfig();
+    const bg = options?.background ?? false;
 
     return new Promise((resolve) => {
         let tmuxArgs: string[];
@@ -95,20 +97,12 @@ export async function openTmuxTerminal(
         if (tmuxConfig.mode === 'pane') {
             // Split current window into a new pane
             const splitFlag = tmuxConfig.paneDirection === 'vertical' ? '-v' : '-h';
-            tmuxArgs = command
-                ? ['split-window', splitFlag, '-c', directory, command]
-                : ['split-window', splitFlag, '-c', directory];
+            const baseArgs = ['split-window', splitFlag, ...(bg ? ['-d'] : []), '-c', directory];
+            tmuxArgs = command ? [...baseArgs, command] : baseArgs;
         } else {
             // Create a new window (default) with optional name
-            if (windowName) {
-                tmuxArgs = command
-                    ? ['new-window', '-n', windowName, '-c', directory, command]
-                    : ['new-window', '-n', windowName, '-c', directory];
-            } else {
-                tmuxArgs = command
-                    ? ['new-window', '-c', directory, command]
-                    : ['new-window', '-c', directory];
-            }
+            const baseArgs = ['new-window', ...(bg ? ['-d'] : []), ...(windowName ? ['-n', windowName] : []), '-c', directory];
+            tmuxArgs = command ? [...baseArgs, command] : baseArgs;
         }
 
         const child = spawn('tmux', tmuxArgs, {
@@ -360,7 +354,8 @@ export async function buildNvimClaudeCommand(
 export async function openTerminal(
     directory: string,
     command?: string,
-    windowName?: string
+    windowName?: string,
+    options?: { background?: boolean }
 ): Promise<{ success: boolean; error?: string }> {
     // Check if we should use tmux
     const parallelConfig = getConfig('parallelWork');
@@ -376,7 +371,7 @@ export async function openTerminal(
             };
         }
         console.log(chalk.dim('Using tmux for parallel terminal...'));
-        return openTmuxTerminal(directory, command, windowName);
+        return openTmuxTerminal(directory, command, windowName, options);
     }
 
     const terminal = await detectTerminal();
@@ -422,7 +417,8 @@ export async function openParallelWorkTerminal(
     issueNumber: number,
     issueTitle: string,
     spawnDirective: SubagentSpawnDirective,
-    modeOverride?: TerminalMode
+    modeOverride?: TerminalMode,
+    options?: { background?: boolean }
 ): Promise<{ success: boolean; error?: string; resumed?: boolean }> {
     const config = getParallelWorkConfig();
     const terminalMode = modeOverride ?? config.terminalMode;
@@ -430,7 +426,7 @@ export async function openParallelWorkTerminal(
     // Terminal-only mode: just open the terminal, no Claude
     if (terminalMode === 'terminal') {
         const windowName = `ghp-${issueNumber}`;
-        const result = await openTerminal(worktreePath, undefined, windowName);
+        const result = await openTerminal(worktreePath, undefined, windowName, options);
         return { ...result, resumed: false };
     }
 
@@ -460,18 +456,19 @@ export async function openParallelWorkTerminal(
 
     // Name the tmux window with the issue number for tracking/cleanup
     const windowName = `ghp-${issueNumber}`;
-    const result = await openTerminal(worktreePath, fullCommand, windowName);
+    const result = await openTerminal(worktreePath, fullCommand, windowName, options);
     return { ...result, resumed: shouldResume };
 }
 
 /**
- * Check if the admin pane (ghp agents watch) is already open
+ * Check if the pipeline dashboard is already open (as a pane or window).
  */
-export async function isAdminPaneOpen(): Promise<boolean> {
+export async function isDashboardOpen(): Promise<boolean> {
     if (!isInsideTmux()) return false;
 
     return new Promise((resolve) => {
-        const child = spawn('tmux', ['list-windows', '-F', '#{window_name}'], {
+        // Check both panes (for pane mode) and windows (for window mode)
+        const child = spawn('tmux', ['list-panes', '-a', '-F', '#{pane_current_command} #{window_name}'], {
             stdio: ['ignore', 'pipe', 'ignore'],
         });
 
@@ -481,35 +478,57 @@ export async function isAdminPaneOpen(): Promise<boolean> {
         });
 
         child.on('close', () => {
-            const windows = output.split('\n').map(w => w.trim());
-            resolve(windows.includes('ghp-admin'));
+            const lines = output.split('\n');
+            // Check for ghp-admin window name or ghp pipeline process
+            resolve(lines.some(l => l.includes('ghp-admin')));
         });
     });
 }
 
 /**
- * Open the admin pane (ghp agents watch) in a tmux window.
- * Only opens if not already open.
+ * Capture the current pane ID. Call this BEFORE spawning agent windows
+ * so openAdminPane can target the correct window even after focus has moved.
  */
-export async function openAdminPane(): Promise<{ success: boolean; alreadyOpen?: boolean; error?: string }> {
+export function captureOriginPane(): string | null {
+    if (!process.env.TMUX) return null;
+    try {
+        const { execFileSync } = require('child_process');
+        return (execFileSync('tmux', ['display-message', '-p', '#{pane_id}']) as Buffer)
+            .toString().trim() || null;
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * Open the pipeline dashboard as a split pane in the specified target pane
+ * (or current pane if no target). Always splits the caller's window, never
+ * the agent window, regardless of which has focus.
+ */
+export async function openAdminPane(targetPaneId?: string | null): Promise<{ success: boolean; alreadyOpen?: boolean; error?: string }> {
     if (!isInsideTmux()) {
         return { success: false, error: 'Not inside tmux session' };
     }
 
-    // Check if admin pane is already open
-    if (await isAdminPaneOpen()) {
+    if (await isDashboardOpen()) {
         return { success: true, alreadyOpen: true };
     }
 
-    // Open ghp agents watch in a new window named ghp-admin
-    const command = 'ghp agents watch';
+    const command = 'ghp pipeline dashboard';
+
     return new Promise((resolve) => {
-        const child = spawn('tmux', ['new-window', '-n', 'ghp-admin', command], {
+        // -h = horizontal split (side by side: claude left, dashboard right)
+        // -l 35% = dashboard gets 35% width
+        const tmuxArgs = targetPaneId
+            ? ['split-window', '-h', '-d', '-l', '50%', '-t', targetPaneId, command]
+            : ['split-window', '-h', '-d', '-l', '50%', command];
+
+        const child = spawn('tmux', tmuxArgs, {
             stdio: 'ignore',
         });
 
         child.on('error', (err) => {
-            resolve({ success: false, error: `Failed to open admin pane: ${err.message}` });
+            resolve({ success: false, error: `Failed to open dashboard: ${err.message}` });
         });
 
         child.on('close', (code) => {

--- a/packages/cli/src/terminal-utils.ts
+++ b/packages/cli/src/terminal-utils.ts
@@ -1,10 +1,10 @@
-import { exec, spawn } from 'child_process';
+import { exec, execSync, spawn } from 'child_process';
 import { promisify } from 'util';
 import * as os from 'os';
 import * as path from 'path';
 import * as fs from 'fs';
 import chalk from 'chalk';
-import { getConfig, getParallelWorkConfig, type TerminalMode } from './config.js';
+import { getConfig, getParallelWorkConfig, type TerminalMode, type ResolvedDashboardConfig } from './config.js';
 import type { SubagentSpawnDirective } from './types.js';
 
 const execAsync = promisify(exec);
@@ -130,34 +130,52 @@ export async function openTmuxTerminal(
 }
 
 /**
- * Kill a tmux window by name
- * @param windowName - The name of the window to kill (e.g., "ghp-39")
+ * Kill a tmux window by name.
+ *
+ * Handles renamed windows (e.g., the pipeline registry renames "ghp-86" to
+ * "📋 ghp-86"). Searches across ALL tmux sessions for a window whose name
+ * contains the given base name.
+ *
+ * Works even when the caller is not inside tmux — tmux just needs to be
+ * running on the system.
+ *
+ * @param windowName - The base name of the window to kill (e.g., "ghp-39")
  */
 export async function killTmuxWindow(windowName: string): Promise<{ success: boolean; error?: string }> {
-    return new Promise((resolve) => {
-        const child = spawn('tmux', ['kill-window', '-t', windowName], {
-            stdio: 'ignore',
-        });
+    try {
+        // List all windows across all sessions. Format: "session:index\twindow_name"
+        const { stdout } = await execAsync(
+            `tmux list-windows -a -F '#{session_name}:#{window_index}\t#{window_name}' 2>/dev/null`
+        );
 
-        child.on('error', (err) => {
-            resolve({
-                success: false,
-                error: `Failed to kill tmux window: ${err.message}`,
+        // Find windows whose name contains the base window name (handles emoji prefixes)
+        const matches = stdout
+            .trim()
+            .split('\n')
+            .filter((line) => {
+                const name = line.split('\t')[1];
+                return name && name.includes(windowName);
             });
-        });
 
-        child.on('close', (code) => {
-            if (code === 0) {
-                resolve({ success: true });
-            } else {
-                // Window might not exist - that's okay
-                resolve({
-                    success: false,
-                    error: `Window "${windowName}" not found`,
-                });
+        if (matches.length === 0) {
+            return { success: false, error: `Window "${windowName}" not found` };
+        }
+
+        // Kill all matching windows (there could be duplicates from re-starts)
+        for (const match of matches) {
+            const target = match.split('\t')[0]; // "session:index"
+            try {
+                await execAsync(`tmux kill-window -t '${target}'`);
+            } catch {
+                // Window may have already been killed
             }
-        });
-    });
+        }
+
+        return { success: true };
+    } catch {
+        // tmux not running or not installed
+        return { success: false, error: 'tmux not available' };
+    }
 }
 
 const TERMINALS: Record<string, Array<{ command: string; args: (dir: string, cmd?: string) => string[] }>> = {
@@ -501,9 +519,15 @@ export function captureOriginPane(): string | null {
 }
 
 /**
- * Open the pipeline dashboard as a split pane in the specified target pane
- * (or current pane if no target). Always splits the caller's window, never
- * the agent window, regardless of which has focus.
+ * Open the pipeline dashboard as a split pane or new window, based on config.
+ * Always splits the caller's window (or creates new window), never the agent window.
+ *
+ * Reads dashboard config from `parallelWork.dashboard`:
+ * - mode: 'pane' (split current window) or 'window' (new tmux window)
+ * - direction: 'horizontal' or 'vertical' (for pane mode)
+ * - size: pane/window size (e.g., '50%')
+ *
+ * After opening, fires `.ghp/hooks/dashboard-opened` user hook.
  */
 export async function openAdminPane(targetPaneId?: string | null): Promise<{ success: boolean; alreadyOpen?: boolean; error?: string }> {
     if (!isInsideTmux()) {
@@ -514,14 +538,22 @@ export async function openAdminPane(targetPaneId?: string | null): Promise<{ suc
         return { success: true, alreadyOpen: true };
     }
 
+    const dashboardConfig = getParallelWorkConfig().dashboard;
     const command = 'ghp pipeline dashboard';
 
     return new Promise((resolve) => {
-        // -h = horizontal split (side by side: claude left, dashboard right)
-        // -l 35% = dashboard gets 35% width
-        const tmuxArgs = targetPaneId
-            ? ['split-window', '-h', '-d', '-l', '50%', '-t', targetPaneId, command]
-            : ['split-window', '-h', '-d', '-l', '50%', command];
+        let tmuxArgs: string[];
+
+        if (dashboardConfig.mode === 'window') {
+            // Open dashboard in a new tmux window
+            tmuxArgs = ['new-window', '-d', '-n', 'ghp-admin', command];
+        } else {
+            // Open dashboard as a split pane
+            const dirFlag = dashboardConfig.direction === 'vertical' ? '-v' : '-h';
+            tmuxArgs = targetPaneId
+                ? ['split-window', dirFlag, '-d', '-l', dashboardConfig.size, '-t', targetPaneId, command]
+                : ['split-window', dirFlag, '-d', '-l', dashboardConfig.size, command];
+        }
 
         const child = spawn('tmux', tmuxArgs, {
             stdio: 'ignore',
@@ -533,6 +565,8 @@ export async function openAdminPane(targetPaneId?: string | null): Promise<{ suc
 
         child.on('close', (code) => {
             if (code === 0) {
+                // Hook is fired by ghp pipeline dashboard itself (dashboard-pipeline.ts)
+                // since it has direct access to its own TMUX_PANE.
                 resolve({ success: true });
             } else {
                 resolve({ success: false, error: `tmux exited with code ${code}` });

--- a/packages/cli/src/worktree-utils.ts
+++ b/packages/cli/src/worktree-utils.ts
@@ -6,7 +6,7 @@
 import chalk from 'chalk';
 import { exec } from 'child_process';
 import { promisify } from 'util';
-import { existsSync, copyFileSync, cpSync, lstatSync, mkdirSync } from 'fs';
+import { existsSync, copyFileSync, cpSync, lstatSync, mkdirSync, symlinkSync } from 'fs';
 import { join, dirname } from 'path';
 import { getWorktreeConfig, getConfig } from './config.js';
 import {
@@ -48,6 +48,21 @@ export async function setupWorktree(worktreePath: string, sourcePath: string): P
                 copyFileSync(srcFile, destFile);
             }
             console.log(chalk.dim(`  Copied ${file}`));
+        }
+    }
+
+    // Symlink configured files
+    for (const file of config.symlinkFiles) {
+        const srcFile = join(sourcePath, file);
+        const destFile = join(worktreePath, file);
+
+        if (existsSync(srcFile) && !existsSync(destFile)) {
+            const destDir = dirname(destFile);
+            if (!existsSync(destDir)) {
+                mkdirSync(destDir, { recursive: true });
+            }
+            symlinkSync(srcFile, destFile);
+            console.log(chalk.dim(`  Symlinked ${file}`));
         }
     }
 

--- a/packages/cli/src/worktree-utils.ts
+++ b/packages/cli/src/worktree-utils.ts
@@ -6,7 +6,7 @@
 import chalk from 'chalk';
 import { exec } from 'child_process';
 import { promisify } from 'util';
-import { existsSync, copyFileSync, cpSync, lstatSync, mkdirSync, symlinkSync } from 'fs';
+import { existsSync, copyFileSync, cpSync, lstatSync, mkdirSync, symlinkSync, unlinkSync, rmSync } from 'fs';
 import { join, dirname } from 'path';
 import { getWorktreeConfig, getConfig } from './config.js';
 import {
@@ -56,14 +56,27 @@ export async function setupWorktree(worktreePath: string, sourcePath: string): P
         const srcFile = join(sourcePath, file);
         const destFile = join(worktreePath, file);
 
-        if (existsSync(srcFile) && !existsSync(destFile)) {
-            const destDir = dirname(destFile);
-            if (!existsSync(destDir)) {
-                mkdirSync(destDir, { recursive: true });
+        if (!existsSync(srcFile)) continue;
+
+        // Remove existing file/dir if it's not already a symlink
+        try {
+            const stat = lstatSync(destFile);
+            if (stat.isSymbolicLink()) continue; // already symlinked
+            if (stat.isDirectory()) {
+                rmSync(destFile, { recursive: true });
+            } else {
+                unlinkSync(destFile);
             }
-            symlinkSync(srcFile, destFile);
-            console.log(chalk.dim(`  Symlinked ${file}`));
+        } catch {
+            // destFile doesn't exist — that's fine
         }
+
+        const destDir = dirname(destFile);
+        if (!existsSync(destDir)) {
+            mkdirSync(destDir, { recursive: true });
+        }
+        symlinkSync(srcFile, destFile);
+        console.log(chalk.dim(`  Symlinked ${file}`));
     }
 
     // Run setup command if enabled

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @bretwardjames/ghp-mcp
 
+## 0.7.0
+
+### Minor Changes
+
+- Add `--repo owner/name` flag to scope MCP server instances to a specific GitHub repo. The CLI's `ghp mcp --config --repo` generates per-repo config with unique server keys. Also includes pipeline dashboard enhancements, hook modes, and terminal utility improvements.
+
 ## 0.6.1
 
 ### Patch Changes

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bretwardjames/ghp-mcp",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "MCP server for ghp (GitHub Projects)",
   "publishConfig": {
     "access": "public"

--- a/packages/mcp/src/context/repo-context.ts
+++ b/packages/mcp/src/context/repo-context.ts
@@ -6,21 +6,38 @@ import {
 
 /**
  * Manages repository context detection for the MCP server.
- * Detects the current repository from the working directory.
+ * Detects the current repository from the working directory,
+ * or returns a hard-locked repo when created via `RepoContext.locked()`.
  */
 export class RepoContext {
     private cachedRepo: RepoInfo | null = null;
     private cwd: string;
+    private readonly lockedRepo?: RepoInfo;
 
     constructor(cwd?: string) {
         this.cwd = cwd ?? process.cwd();
     }
 
     /**
+     * Creates a RepoContext that is permanently locked to a specific repo.
+     * Git detection is skipped entirely — `getRepo()` always returns the locked value.
+     */
+    static locked(repo: RepoInfo): RepoContext {
+        const ctx = new RepoContext();
+        (ctx as { lockedRepo?: RepoInfo }).lockedRepo = repo;
+        ctx.cachedRepo = repo;
+        return ctx;
+    }
+
+    /**
      * Gets the current repository info, with caching.
-     * Returns null if not in a git repository or can't detect remote.
+     * Returns the locked repo immediately if set, otherwise detects from git.
      */
     async getRepo(): Promise<RepoInfo | null> {
+        if (this.lockedRepo) {
+            return this.lockedRepo;
+        }
+
         if (this.cachedRepo) {
             return this.cachedRepo;
         }
@@ -36,8 +53,12 @@ export class RepoContext {
 
     /**
      * Forces re-detection of the repository.
+     * No-op when locked to a specific repo.
      */
     async refresh(): Promise<RepoInfo | null> {
+        if (this.lockedRepo) {
+            return this.lockedRepo;
+        }
         this.cachedRepo = null;
         return this.getRepo();
     }
@@ -52,8 +73,12 @@ export class RepoContext {
 
     /**
      * Updates the working directory and clears the cache.
+     * No-op when locked to a specific repo.
      */
     setCwd(cwd: string): void {
+        if (this.lockedRepo) {
+            return;
+        }
         this.cwd = cwd;
         this.cachedRepo = null;
     }
@@ -63,5 +88,12 @@ export class RepoContext {
      */
     getCwd(): string {
         return this.cwd;
+    }
+
+    /**
+     * Returns true if this context is locked to a specific repo.
+     */
+    isLocked(): boolean {
+        return this.lockedRepo !== undefined;
     }
 }

--- a/packages/mcp/src/context/repo-context.ts
+++ b/packages/mcp/src/context/repo-context.ts
@@ -14,8 +14,19 @@ export class RepoContext {
     private cwd: string;
     private readonly lockedRepo?: RepoInfo;
 
-    constructor(cwd?: string) {
-        this.cwd = cwd ?? process.cwd();
+    private constructor(options: { cwd?: string; lockedRepo?: RepoInfo } = {}) {
+        this.cwd = options.cwd ?? process.cwd();
+        this.lockedRepo = options.lockedRepo;
+        if (this.lockedRepo) {
+            this.cachedRepo = this.lockedRepo;
+        }
+    }
+
+    /**
+     * Creates a RepoContext that auto-detects the repo from the working directory.
+     */
+    static auto(cwd?: string): RepoContext {
+        return new RepoContext({ cwd });
     }
 
     /**
@@ -23,10 +34,7 @@ export class RepoContext {
      * Git detection is skipped entirely — `getRepo()` always returns the locked value.
      */
     static locked(repo: RepoInfo): RepoContext {
-        const ctx = new RepoContext();
-        (ctx as { lockedRepo?: RepoInfo }).lockedRepo = repo;
-        ctx.cachedRepo = repo;
-        return ctx;
+        return new RepoContext({ lockedRepo: repo });
     }
 
     /**

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import type { RepoInfo } from '@bretwardjames/ghp-core';
 import { createServer } from './server.js';
 import { createTokenProvider } from './auth/token-provider.js';
 import { registerEnabledTools } from './tool-registry.js';
@@ -13,21 +14,31 @@ import { registerAllResources } from './resources/index.js';
  * Model Context Protocol.
  *
  * Usage:
- *   node dist/index.js
- *
- * Or configure in Claude Desktop:
- *   {
- *     "mcpServers": {
- *       "ghp": {
- *         "command": "node",
- *         "args": ["/path/to/ghp/packages/mcp/dist/index.js"]
- *       }
- *     }
- *   }
+ *   ghp-mcp                         # auto-detect repo from cwd
+ *   ghp-mcp --repo owner/name       # lock to a specific repo
  */
+
+function parseRepoArg(): RepoInfo | undefined {
+    const idx = process.argv.indexOf('--repo');
+    if (idx === -1) {
+        return undefined;
+    }
+
+    const value = process.argv[idx + 1];
+    if (!value || !value.includes('/')) {
+        console.error('Error: --repo requires owner/name format (e.g., --repo bretwardjames/ghp)');
+        process.exit(1);
+    }
+
+    const [owner, ...rest] = value.split('/');
+    const name = rest.join('/');
+    return { owner, name, fullName: `${owner}/${name}` };
+}
+
 async function main(): Promise<void> {
+    const lockedRepo = parseRepoArg();
     const tokenProvider = createTokenProvider();
-    const { server, context } = createServer(tokenProvider);
+    const { server, context } = createServer(tokenProvider, lockedRepo);
 
     // Register all tools and resources
     registerEnabledTools(server, context);

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -29,7 +29,7 @@ export function createServer(tokenProvider: TokenProvider, lockedRepo?: RepoInfo
     const api = new GitHubAPI({ tokenProvider });
     const repoContext = lockedRepo
         ? RepoContext.locked(lockedRepo)
-        : new RepoContext();
+        : RepoContext.auto();
 
     const context: ServerContext = {
         api,

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -15,8 +15,9 @@ export interface ServerContext {
 
 /**
  * Creates and configures the MCP server with all tools and resources.
+ * When `lockedRepo` is provided, the server is scoped to that repo only.
  */
-export function createServer(tokenProvider: TokenProvider): {
+export function createServer(tokenProvider: TokenProvider, lockedRepo?: RepoInfo): {
     server: McpServer;
     context: ServerContext;
 } {
@@ -26,7 +27,9 @@ export function createServer(tokenProvider: TokenProvider): {
     });
 
     const api = new GitHubAPI({ tokenProvider });
-    const repoContext = new RepoContext();
+    const repoContext = lockedRepo
+        ? RepoContext.locked(lockedRepo)
+        : new RepoContext();
 
     const context: ServerContext = {
         api,


### PR DESCRIPTION
## Summary

- **Worktree branch swapping**: `ghp wt move-to`, `ghp wt clean`, `ghp wt status` commands for managing worktree lifecycles
- **Pipeline management**: Configurable pipeline stages, dashboard with session/hook modes, queue commands, background terminals, and pane-pull integration
- **MCP repo scoping**: `ghp-mcp --repo owner/name` locks an MCP server instance to a specific GitHub repo (no ambient access). `ghp mcp --config --repo` generates per-repo config with unique server keys (`ghp-{owner}-{name}`)
- Various fixes: worktree registration, pipeline cleanup on done/stop, tmux pane handling

### Versions
- `@bretwardjames/ghp-cli@0.18.0`
- `@bretwardjames/ghp-mcp@0.7.0`

Relates to #269

## Test plan

- [ ] `pnpm build` passes across all packages
- [ ] `ghp-mcp --repo bretwardjames/ghp` locks to that repo
- [ ] `ghp mcp --config --repo bretwardjames/ghp` shows config with `ghp-bretwardjames-ghp` key
- [ ] `ghp-mcp` without `--repo` auto-detects as before
- [ ] Pipeline dashboard renders correctly with `ghp pipeline dashboard`
- [ ] `ghp wt move-to` / `ghp wt clean` / `ghp wt status` work end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)