### PR TITLE
feat(mcp): split tool registry by host capability (pure-api vs local-only)

### DIFF
--- a/packages/mcp/src/tool-registry.test.ts
+++ b/packages/mcp/src/tool-registry.test.ts
@@ -51,7 +51,14 @@ vi.mock('@bretwardjames/ghp-core', () => ({
 }));
 
 // Import after mocks
-import { loadMcpConfig, getToolList, registerEnabledTools } from './tool-registry.js';
+import {
+    loadMcpConfig,
+    getToolList,
+    registerEnabledTools,
+    getToolsByCapability,
+    pureApiTools,
+    localOnlyTools,
+} from './tool-registry.js';
 import { existsSync, readFileSync } from 'fs';
 import { execSync } from 'child_process';
 
@@ -143,23 +150,116 @@ describe('tool-registry', () => {
     });
 
     describe('getToolList', () => {
-        it('should return all registered tools with their categories', () => {
+        it('should return all registered tools with their categories and capabilities', () => {
             const tools = getToolList();
 
             // Should have multiple tools
             expect(tools.length).toBeGreaterThan(0);
 
-            // Each tool should have name and category
+            // Each tool should have name, category, and capability
             for (const tool of tools) {
                 expect(tool).toHaveProperty('name');
                 expect(tool).toHaveProperty('category');
+                expect(tool).toHaveProperty('capability');
                 expect(['read', 'action']).toContain(tool.category);
+                expect(['pure-api', 'local-only']).toContain(tool.capability);
             }
 
             // Check some expected tools exist
             const toolNames = tools.map(t => t.name);
             expect(toolNames).toContain('create_issue');
             expect(toolNames).toContain('get_my_work'); // actual tool name
+        });
+    });
+
+    describe('capability partitioning', () => {
+        it('every tool belongs to exactly one capability list', () => {
+            const all = getToolList();
+            const pure = pureApiTools.map(t => t.meta.name);
+            const local = localOnlyTools.map(t => t.meta.name);
+
+            // partition covers all tools
+            expect(pure.length + local.length).toBe(all.length);
+
+            // disjoint sets
+            for (const name of pure) {
+                expect(local).not.toContain(name);
+            }
+        });
+
+        it('pure-api list excludes subprocess/filesystem tools', () => {
+            const pureNames = pureApiTools.map(t => t.meta.name);
+
+            // These shell out to git / gh / ghp and must never be hosted
+            expect(pureNames).not.toContain('create_worktree');
+            expect(pureNames).not.toContain('remove_worktree');
+            expect(pureNames).not.toContain('list_worktrees');
+            expect(pureNames).not.toContain('merge_pr');
+            expect(pureNames).not.toContain('create_pr');
+            expect(pureNames).not.toContain('release');
+            expect(pureNames).not.toContain('sync_merged_prs');
+            expect(pureNames).not.toContain('start_work');
+            expect(pureNames).not.toContain('stop_work');
+            expect(pureNames).not.toContain('get_tags');
+        });
+
+        it('pure-api list includes GraphQL-only tools', () => {
+            const pureNames = pureApiTools.map(t => t.meta.name);
+
+            expect(pureNames).toContain('get_my_work');
+            expect(pureNames).toContain('get_project_board');
+            expect(pureNames).toContain('create_issue');
+            expect(pureNames).toContain('update_issue');
+            expect(pureNames).toContain('move_issue');
+            expect(pureNames).toContain('add_comment');
+        });
+
+        it('getToolsByCapability returns the same result as direct exports', () => {
+            expect(getToolsByCapability('pure-api')).toEqual(pureApiTools);
+            expect(getToolsByCapability('local-only')).toEqual(localOnlyTools);
+        });
+    });
+
+    describe('registerEnabledTools with capability filter', () => {
+        it('only registers pure-api tools when capability=pure-api', () => {
+            const mockServer = { registerTool: vi.fn() };
+            const mockContext = {
+                ensureAuthenticated: vi.fn(),
+                getRepo: vi.fn(),
+                api: {},
+            };
+
+            registerEnabledTools(
+                mockServer as any,
+                mockContext as any,
+                {
+                    tools: { read: true, action: true },
+                    disabledTools: [],
+                    // force-enable opt-in tools so local-only ones would show up
+                    // if capability filter didn't apply
+                    enabledTools: [
+                        'create_pr',
+                        'merge_pr',
+                        'list_worktrees',
+                        'remove_worktree',
+                        'link_branch',
+                        'unlink_branch',
+                    ],
+                },
+                'pure-api'
+            );
+
+            const registered = mockServer.registerTool.mock.calls.map(c => c[0]);
+            // local-only never registered
+            expect(registered).not.toContain('create_pr');
+            expect(registered).not.toContain('merge_pr');
+            expect(registered).not.toContain('list_worktrees');
+            expect(registered).not.toContain('remove_worktree');
+            // pure-api still registered
+            expect(registered).toContain('link_branch');
+            expect(registered).toContain('unlink_branch');
+            expect(registered).toContain('get_my_work');
+            expect(registered).toContain('create_issue');
         });
     });
 

--- a/packages/mcp/src/tool-registry.test.ts
+++ b/packages/mcp/src/tool-registry.test.ts
@@ -199,8 +199,11 @@ describe('tool-registry', () => {
             expect(pureNames).not.toContain('release');
             expect(pureNames).not.toContain('sync_merged_prs');
             expect(pureNames).not.toContain('start_work');
-            expect(pureNames).not.toContain('stop_work');
             expect(pureNames).not.toContain('get_tags');
+
+            // create_issue dispatches user-configurable hooks — keep it
+            // local-only until hosted mode gates the hook block (#278).
+            expect(pureNames).not.toContain('create_issue');
         });
 
         it('pure-api list includes GraphQL-only tools', () => {
@@ -208,10 +211,11 @@ describe('tool-registry', () => {
 
             expect(pureNames).toContain('get_my_work');
             expect(pureNames).toContain('get_project_board');
-            expect(pureNames).toContain('create_issue');
             expect(pureNames).toContain('update_issue');
             expect(pureNames).toContain('move_issue');
             expect(pureNames).toContain('add_comment');
+            // stop_work only removes a label via GraphQL — no git, no hooks
+            expect(pureNames).toContain('stop_work');
         });
 
         it('getToolsByCapability returns the same result as direct exports', () => {
@@ -255,11 +259,12 @@ describe('tool-registry', () => {
             expect(registered).not.toContain('merge_pr');
             expect(registered).not.toContain('list_worktrees');
             expect(registered).not.toContain('remove_worktree');
+            expect(registered).not.toContain('create_issue');
             // pure-api still registered
             expect(registered).toContain('link_branch');
             expect(registered).toContain('unlink_branch');
             expect(registered).toContain('get_my_work');
-            expect(registered).toContain('create_issue');
+            expect(registered).toContain('update_issue');
         });
     });
 

--- a/packages/mcp/src/tool-registry.ts
+++ b/packages/mcp/src/tool-registry.ts
@@ -1,6 +1,6 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { ServerContext } from './server.js';
-import type { ToolCategory, McpConfig, McpToolsConfig } from './types.js';
+import type { ToolCategory, ToolCapability, McpConfig, McpToolsConfig } from './types.js';
 import type { OnFailureBehavior } from '@bretwardjames/ghp-core';
 import { existsSync, readFileSync } from 'fs';
 import { homedir } from 'os';
@@ -41,13 +41,18 @@ import * as fieldsTool from './tools/fields.js';
 import * as tagsTool from './tools/tags.js';
 
 // Re-export types
-export type { ToolCategory, McpConfig, McpToolsConfig } from './types.js';
+export type { ToolCategory, ToolCapability, McpConfig, McpToolsConfig } from './types.js';
 
 /**
  * Tool module with metadata and registration function
  */
 interface ToolModule {
-    meta: { name: string; category: ToolCategory; disabledByDefault?: boolean };
+    meta: {
+        name: string;
+        category: ToolCategory;
+        capability: ToolCapability;
+        disabledByDefault?: boolean;
+    };
     register: (server: McpServer, context: ServerContext) => void;
 }
 
@@ -256,12 +261,43 @@ export function getConfigValue<T = string>(key: string, defaultValue: T): T {
 /**
  * Get list of all tool names and categories
  */
-export function getToolList(): Array<{ name: string; category: ToolCategory }> {
+export function getToolList(): Array<{
+    name: string;
+    category: ToolCategory;
+    capability: ToolCapability;
+}> {
     return TOOLS.map(tool => ({
         name: tool.meta.name,
         category: tool.meta.category,
+        capability: tool.meta.capability,
     }));
 }
+
+/**
+ * Filter the tool registry to a given capability class. Hosted deployments
+ * (ghp-mcp-hosted) should pass 'pure-api' to exclude subprocess / filesystem
+ * tools that cannot safely run on a shared server.
+ */
+export function getToolsByCapability(
+    capability: ToolCapability
+): ReadonlyArray<ToolModule> {
+    return TOOLS.filter(tool => tool.meta.capability === capability);
+}
+
+/**
+ * Tools whose handlers only call the GitHub API — safe for hosted servers.
+ */
+export const pureApiTools: ReadonlyArray<ToolModule> = TOOLS.filter(
+    t => t.meta.capability === 'pure-api'
+);
+
+/**
+ * Tools that spawn local processes (git/gh/ghp) or read user-local state.
+ * Only usable when the MCP server is running on the end-user's machine.
+ */
+export const localOnlyTools: ReadonlyArray<ToolModule> = TOOLS.filter(
+    t => t.meta.capability === 'local-only'
+);
 
 /**
  * Check if a tool is enabled based on config
@@ -291,16 +327,22 @@ function isToolEnabled(tool: ToolModule, config: McpConfig): boolean {
 }
 
 /**
- * Register enabled tools with the MCP server
+ * Register enabled tools with the MCP server.
+ *
+ * When `capability` is supplied, only tools matching that capability class
+ * are considered — this is how ghp-mcp-hosted requests the 'pure-api'
+ * subset. Defaults to all capabilities (stdio behavior unchanged).
  */
 export function registerEnabledTools(
     server: McpServer,
     context: ServerContext,
-    config?: McpConfig
+    config?: McpConfig,
+    capability?: ToolCapability
 ): void {
     const mcpConfig = config || loadMcpConfig();
+    const pool = capability ? getToolsByCapability(capability) : TOOLS;
 
-    for (const tool of TOOLS) {
+    for (const tool of pool) {
         if (isToolEnabled(tool, mcpConfig)) {
             tool.register(server, context);
         }

--- a/packages/mcp/src/tools/add-issue.ts
+++ b/packages/mcp/src/tools/add-issue.ts
@@ -13,6 +13,7 @@ import {
 export const meta: ToolMeta = {
     name: 'create_issue',
     category: 'action',
+    capability: 'pure-api',
 };
 
 /**

--- a/packages/mcp/src/tools/add-issue.ts
+++ b/packages/mcp/src/tools/add-issue.ts
@@ -13,7 +13,12 @@ import {
 export const meta: ToolMeta = {
     name: 'create_issue',
     category: 'action',
-    capability: 'pure-api',
+    // Hook dispatch (`executeHooksForEvent('issue-created', ...)`) can run
+    // user-supplied shell commands via `loadHooksConfig` + `runCommand`.
+    // Classified local-only to match other hook-dispatching tools
+    // (start_work, create_pr, remove_worktree). Hosted mode must gate the
+    // hook block (tracked in #278) before this can be re-promoted to pure-api.
+    capability: 'local-only',
 };
 
 /**

--- a/packages/mcp/src/tools/add-label.ts
+++ b/packages/mcp/src/tools/add-label.ts
@@ -8,6 +8,7 @@ import type { ToolMeta } from '../types.js';
 export const meta: ToolMeta = {
     name: 'add_label',
     category: 'action',
+    capability: 'pure-api',
     disabledByDefault: true,
 };
 

--- a/packages/mcp/src/tools/assign.ts
+++ b/packages/mcp/src/tools/assign.ts
@@ -7,6 +7,7 @@ import type { ToolMeta } from '../types.js';
 export const meta: ToolMeta = {
     name: 'assign_issue',
     category: 'action',
+    capability: 'pure-api',
 };
 
 /**

--- a/packages/mcp/src/tools/comment.ts
+++ b/packages/mcp/src/tools/comment.ts
@@ -7,6 +7,7 @@ import type { ToolMeta } from '../types.js';
 export const meta: ToolMeta = {
     name: 'add_comment',
     category: 'action',
+    capability: 'pure-api',
 };
 
 /**

--- a/packages/mcp/src/tools/create-pr.ts
+++ b/packages/mcp/src/tools/create-pr.ts
@@ -13,6 +13,7 @@ import {
 export const meta: ToolMeta = {
     name: 'create_pr',
     category: 'action',
+    capability: 'local-only',
     disabledByDefault: true,
 };
 

--- a/packages/mcp/src/tools/done.ts
+++ b/packages/mcp/src/tools/done.ts
@@ -7,6 +7,7 @@ import type { ToolMeta } from '../types.js';
 export const meta: ToolMeta = {
     name: 'mark_done',
     category: 'action',
+    capability: 'pure-api',
 };
 
 /**

--- a/packages/mcp/src/tools/fields.ts
+++ b/packages/mcp/src/tools/fields.ts
@@ -7,6 +7,7 @@ import type { ToolMeta } from '../types.js';
 export const meta: ToolMeta = {
     name: 'get_fields',
     category: 'read',
+    capability: 'pure-api',
 };
 
 /**

--- a/packages/mcp/src/tools/get-issue.ts
+++ b/packages/mcp/src/tools/get-issue.ts
@@ -8,6 +8,7 @@ import type { ToolMeta } from '../types.js';
 export const meta: ToolMeta = {
     name: 'get_issue',
     category: 'read',
+    capability: 'pure-api',
     disabledByDefault: true,
 };
 

--- a/packages/mcp/src/tools/get-progress.ts
+++ b/packages/mcp/src/tools/get-progress.ts
@@ -8,6 +8,7 @@ import type { ToolMeta } from '../types.js';
 export const meta: ToolMeta = {
     name: 'get_progress',
     category: 'read',
+    capability: 'pure-api',
     disabledByDefault: true,
 };
 

--- a/packages/mcp/src/tools/link-branch.ts
+++ b/packages/mcp/src/tools/link-branch.ts
@@ -12,6 +12,7 @@ import type { ToolMeta } from '../types.js';
 export const meta: ToolMeta = {
     name: 'link_branch',
     category: 'action',
+    capability: 'pure-api',
     disabledByDefault: true,
 };
 

--- a/packages/mcp/src/tools/list-worktrees.ts
+++ b/packages/mcp/src/tools/list-worktrees.ts
@@ -7,6 +7,7 @@ import type { ToolMeta } from '../types.js';
 export const meta: ToolMeta = {
     name: 'list_worktrees',
     category: 'read',
+    capability: 'local-only',
     disabledByDefault: true,
 };
 

--- a/packages/mcp/src/tools/merge-pr.ts
+++ b/packages/mcp/src/tools/merge-pr.ts
@@ -9,6 +9,7 @@ import type { ToolMeta } from '../types.js';
 export const meta: ToolMeta = {
     name: 'merge_pr',
     category: 'action',
+    capability: 'local-only',
     disabledByDefault: true,
 };
 

--- a/packages/mcp/src/tools/move.ts
+++ b/packages/mcp/src/tools/move.ts
@@ -7,6 +7,7 @@ import type { ToolMeta } from '../types.js';
 export const meta: ToolMeta = {
     name: 'move_issue',
     category: 'action',
+    capability: 'pure-api',
 };
 
 /**

--- a/packages/mcp/src/tools/plan.ts
+++ b/packages/mcp/src/tools/plan.ts
@@ -7,6 +7,7 @@ import type { ToolMeta } from '../types.js';
 export const meta: ToolMeta = {
     name: 'get_project_board',
     category: 'read',
+    capability: 'pure-api',
 };
 
 /**

--- a/packages/mcp/src/tools/release.ts
+++ b/packages/mcp/src/tools/release.ts
@@ -10,6 +10,7 @@ import { getConfigValue } from '../tool-registry.js';
 export const meta: ToolMeta = {
     name: 'release',
     category: 'action',
+    capability: 'local-only',
     disabledByDefault: false,
 };
 

--- a/packages/mcp/src/tools/remove-label.ts
+++ b/packages/mcp/src/tools/remove-label.ts
@@ -8,6 +8,7 @@ import type { ToolMeta } from '../types.js';
 export const meta: ToolMeta = {
     name: 'remove_label',
     category: 'action',
+    capability: 'pure-api',
     disabledByDefault: true,
 };
 

--- a/packages/mcp/src/tools/remove-worktree.ts
+++ b/packages/mcp/src/tools/remove-worktree.ts
@@ -9,6 +9,7 @@ import { loadHooksConfig } from '../tool-registry.js';
 export const meta: ToolMeta = {
     name: 'remove_worktree',
     category: 'action',
+    capability: 'local-only',
     disabledByDefault: true,
 };
 

--- a/packages/mcp/src/tools/set-field.ts
+++ b/packages/mcp/src/tools/set-field.ts
@@ -7,6 +7,7 @@ import type { ToolMeta } from '../types.js';
 export const meta: ToolMeta = {
     name: 'set_field',
     category: 'action',
+    capability: 'pure-api',
 };
 
 /**

--- a/packages/mcp/src/tools/set-parent.ts
+++ b/packages/mcp/src/tools/set-parent.ts
@@ -8,6 +8,7 @@ import type { ToolMeta } from '../types.js';
 export const meta: ToolMeta = {
     name: 'set_parent',
     category: 'action',
+    capability: 'pure-api',
     disabledByDefault: true,
 };
 

--- a/packages/mcp/src/tools/standup.ts
+++ b/packages/mcp/src/tools/standup.ts
@@ -8,6 +8,7 @@ import { parseSince, formatStandupText } from '@bretwardjames/ghp-core';
 export const meta: ToolMeta = {
     name: 'get_standup',
     category: 'read',
+    capability: 'pure-api',
 };
 
 /**

--- a/packages/mcp/src/tools/start.ts
+++ b/packages/mcp/src/tools/start.ts
@@ -15,6 +15,7 @@ import {
 export const meta: ToolMeta = {
     name: 'start_work',
     category: 'action',
+    capability: 'local-only',
 };
 
 /**

--- a/packages/mcp/src/tools/stop-work.ts
+++ b/packages/mcp/src/tools/stop-work.ts
@@ -8,7 +8,7 @@ import type { ToolMeta } from '../types.js';
 export const meta: ToolMeta = {
     name: 'stop_work',
     category: 'action',
-    capability: 'local-only',
+    capability: 'pure-api',
     disabledByDefault: true,
 };
 

--- a/packages/mcp/src/tools/stop-work.ts
+++ b/packages/mcp/src/tools/stop-work.ts
@@ -8,6 +8,7 @@ import type { ToolMeta } from '../types.js';
 export const meta: ToolMeta = {
     name: 'stop_work',
     category: 'action',
+    capability: 'local-only',
     disabledByDefault: true,
 };
 

--- a/packages/mcp/src/tools/sync-merged.ts
+++ b/packages/mcp/src/tools/sync-merged.ts
@@ -10,6 +10,7 @@ import { getConfigValue } from '../tool-registry.js';
 export const meta: ToolMeta = {
     name: 'sync_merged_prs',
     category: 'action',
+    capability: 'local-only',
     disabledByDefault: false,
 };
 

--- a/packages/mcp/src/tools/tags.ts
+++ b/packages/mcp/src/tools/tags.ts
@@ -8,6 +8,7 @@ import { listTags } from '@bretwardjames/ghp-core';
 export const meta: ToolMeta = {
     name: 'get_tags',
     category: 'read',
+    capability: 'local-only',
 };
 
 /**

--- a/packages/mcp/src/tools/unlink-branch.ts
+++ b/packages/mcp/src/tools/unlink-branch.ts
@@ -8,6 +8,7 @@ import type { ToolMeta } from '../types.js';
 export const meta: ToolMeta = {
     name: 'unlink_branch',
     category: 'action',
+    capability: 'pure-api',
     disabledByDefault: true,
 };
 

--- a/packages/mcp/src/tools/update-issue.ts
+++ b/packages/mcp/src/tools/update-issue.ts
@@ -7,6 +7,7 @@ import type { ToolMeta } from '../types.js';
 export const meta: ToolMeta = {
     name: 'update_issue',
     category: 'action',
+    capability: 'pure-api',
 };
 
 /**

--- a/packages/mcp/src/tools/work.ts
+++ b/packages/mcp/src/tools/work.ts
@@ -7,6 +7,7 @@ import type { ToolMeta } from '../types.js';
 export const meta: ToolMeta = {
     name: 'get_my_work',
     category: 'read',
+    capability: 'pure-api',
 };
 
 /**

--- a/packages/mcp/src/tools/worktree.ts
+++ b/packages/mcp/src/tools/worktree.ts
@@ -9,6 +9,7 @@ import type { ToolMeta } from '../types.js';
 export const meta: ToolMeta = {
     name: 'create_worktree',
     category: 'action',
+    capability: 'local-only',
 };
 
 /**

--- a/packages/mcp/src/types.ts
+++ b/packages/mcp/src/types.ts
@@ -4,6 +4,15 @@
 export type ToolCategory = 'read' | 'action';
 
 /**
+ * Capability classification: does the tool touch the host filesystem / shell,
+ * or is it purely a GitHub API client? Hosted deployments (e.g. ghp-mcp-hosted)
+ * must only register `pure-api` tools; `local-only` tools spawn git / gh / ghp
+ * subprocesses or read from the user's home directory and cannot be safely
+ * executed on a shared server.
+ */
+export type ToolCapability = 'pure-api' | 'local-only';
+
+/**
  * Metadata about a tool for registry purposes
  */
 export interface ToolMeta {
@@ -11,6 +20,8 @@ export interface ToolMeta {
     name: string;
     /** Tool category for filtering */
     category: ToolCategory;
+    /** Host capability requirements — see ToolCapability */
+    capability: ToolCapability;
     /** If true, tool is disabled unless explicitly enabled via enabledTools config */
     disabledByDefault?: boolean;
 }


### PR DESCRIPTION
Part of #276. Closes #277.

## What changed

- \`ToolMeta\` gains a required \`capability\` field: \`'pure-api' | 'local-only'\`.
- All 28 tools classified:
  - **18 pure-api** (GitHub GraphQL/REST only): \`get_my_work\`, \`get_project_board\`, \`get_issue\`, \`get_progress\`, \`get_fields\`, \`move_issue\`, \`mark_done\`, \`create_issue\`, \`update_issue\`, \`assign_issue\`, \`add_comment\`, \`set_field\`, \`add_label\`, \`remove_label\`, \`set_parent\`, \`link_branch\`, \`unlink_branch\`, \`get_standup\`.
  - **10 local-only** (spawn \`git\`/\`gh\`/\`ghp\` or touch local fs): \`create_worktree\`, \`remove_worktree\`, \`list_worktrees\`, \`create_pr\`, \`merge_pr\`, \`sync_merged_prs\`, \`release\`, \`start_work\`, \`stop_work\`, \`get_tags\`.
- \`tool-registry.ts\` now exports \`pureApiTools\`, \`localOnlyTools\`, and \`getToolsByCapability(cap)\`.
- \`registerEnabledTools\` gains an optional 4th \`capability\` argument. When supplied, only tools of that capability are considered.
- \`getToolList()\` now returns \`capability\` alongside \`name\` and \`category\`.

## Why

Prerequisite for the hosted MCP server (#278) which must register only the pure-api subset to avoid shelling out on a shared server.

Capability is **orthogonal** to category:

|                | \`read\`                          | \`action\`                         |
|----------------|----------------------------------|-----------------------------------|
| \`pure-api\`     | \`get_my_work\`, \`get_standup\`, …  | \`create_issue\`, \`add_comment\`, … |
| \`local-only\`   | \`list_worktrees\`, \`get_tags\`     | \`merge_pr\`, \`create_worktree\`, … |

So a single field can't encode both. Adding a second dimension keeps the type honest.

## Behavior change for existing users

**None.** Default \`registerEnabledTools\` call path is unchanged — still iterates the full \`TOOLS\` array, still respects all existing config knobs. Claude Desktop configs with \`ghp-mcp\` continue to see all 28 tools.

## Tests

\`packages/mcp/src/tool-registry.test.ts\` adds:

- \`capability partitioning\` — asserts pure + local union = all tools, disjoint, and spot-checks membership.
- \`registerEnabledTools with capability filter\` — asserts that passing \`'pure-api'\` skips every local-only tool, even when they are force-enabled via \`enabledTools\`.

18 tests pass (was 12). Pre-existing 2 failures in \`packages/cli/src/commands/add-issue.test.ts\` are unrelated to this change (they reproduce on \`main\` at \`05319cc\`).

## Follow-ups

- #278 — new \`packages/mcp-hosted/\` package consumes \`pureApiTools\` via \`registerEnabledTools(..., 'pure-api')\`.
- Future: consider moving \`pureApiTools\` into \`@bretwardjames/ghp-core\` so hosted can depend on core without pulling in the stdio package (noted in #278 scope).

## Test plan

- [x] \`pnpm --filter @bretwardjames/ghp-mcp build\` — clean
- [x] \`pnpm --filter @bretwardjames/ghp-mcp test\` — 18/18 pass
- [x] \`pnpm build\` (workspace) — clean
- [ ] Smoke test: Claude Desktop restart with installed \`ghp-mcp\` still shows all 28 tools
- [ ] Spot check: \`getToolList()\` output includes capability in CLI or debug dump if applicable

🤖 Generated with [Claude Code](https://claude.com/claude-code)