### PR TITLE
Hosted GHP MCP: HTTP transport + Bearer auth

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,7 +113,8 @@ gh ssh-key ...    # SSH key management
 
 - `packages/core/` - Shared library (@bretwardjames/ghp-core)
 - `packages/cli/` - CLI tool (@bretwardjames/ghp-cli)
-- `packages/mcp/` - MCP server (@bretwardjames/ghp-mcp)
+- `packages/mcp/` - Stdio MCP server for local use (@bretwardjames/ghp-mcp)
+- `packages/mcp-hosted/` - HTTP MCP server for hosted multi-tenant platforms (@bretwardjames/ghp-mcp-hosted)
 - `apps/vscode/` - VS Code extension (gh-projects)
 
 ## Publishing

--- a/packages/mcp-hosted/README.md
+++ b/packages/mcp-hosted/README.md
@@ -28,6 +28,10 @@ PORT=3000 \
   node packages/mcp-hosted/dist/bin.js
 ```
 
+`GHP_REPO` is required — the hosted server is scoped to a single GitHub
+repo per instance. Spin up multiple instances (one per repo) to serve
+multiple projects.
+
 Probe:
 
 ```bash
@@ -43,15 +47,15 @@ curl -X POST http://localhost:3000/mcp \
 
 ## Environment
 
-| Var                    | Required | Default         | Purpose                                             |
-|------------------------|----------|-----------------|-----------------------------------------------------|
-| `GHP_MCP_MODE`         | yes      | —               | Must be `hosted`. Refuses to start otherwise.       |
-| `PORT`                 | no       | `3000`          | HTTP listen port. Railway / Fly inject this.        |
-| `GHP_HOSTED_BASE_URL`  | prod     | —               | Public https URL. Required if `NODE_ENV=production`.|
-| `GHP_REPO`             | no       | —               | Lock every session to `owner/name`.                 |
-| `GHP_ALLOWED_ORIGINS`  | no       | `*`             | CORS allowlist.                                     |
-| `GHP_LOG_LEVEL`        | no       | `info`          | `trace` / `debug` / `info` / `warn` / `error`.      |
-| `NODE_ENV`             | no       | `development`   |                                                     |
+| Var                    | Required | Default         | Purpose                                                                       |
+|------------------------|----------|-----------------|-------------------------------------------------------------------------------|
+| `GHP_MCP_MODE`         | yes      | —               | Must be `hosted`. Refuses to start otherwise.                                 |
+| `GHP_REPO`             | yes      | —               | Locks every session to `owner/name`. Without it the server would attempt to  |
+|                        |          |                 | auto-detect via `git remote`, which is meaningless in a hosted context.       |
+| `PORT`                 | no       | `3000`          | HTTP listen port. Railway / Fly inject this.                                  |
+| `GHP_HOSTED_BASE_URL`  | prod     | —               | Public https URL. Required if `NODE_ENV=production`.                          |
+| `GHP_ALLOWED_ORIGINS`  | no       | `*`             | CORS allowlist.                                                               |
+| `NODE_ENV`             | no       | `development`   |                                                                               |
 
 ## Endpoints
 

--- a/packages/mcp-hosted/README.md
+++ b/packages/mcp-hosted/README.md
@@ -1,0 +1,102 @@
+# @bretwardjames/ghp-mcp-hosted
+
+Hosted (HTTP) MCP server for [ghp](https://github.com/bretwardjames/ghp) — multi-tenant GitHub Projects tooling for AI platforms like [runtight](https://github.com/bretwardjames/runtight).
+
+This package is the **sibling** of `@bretwardjames/ghp-mcp`:
+
+|                     | `@bretwardjames/ghp-mcp`          | `@bretwardjames/ghp-mcp-hosted`      |
+|---------------------|------------------------------------|--------------------------------------|
+| Transport           | stdio                              | MCP Streamable HTTP                  |
+| Auth                | `GITHUB_TOKEN` / `gh auth token`   | per-request `Authorization: Bearer`  |
+| Tools exposed       | 28 (full)                          | 18 pure-api (local-only disabled)    |
+| Deployment target   | Claude Desktop / local CLI         | Railway / Fly / any PaaS             |
+| Tenancy             | single user, single machine        | multi-tenant                         |
+
+The stdio server is **not replaced** — power users and local agents keep it. This package is additive.
+
+## Status
+
+**Early.** Implements the HTTP transport + Bearer auth only. OAuth 2.1 + PKCE + RFC 9728 discovery land in #279. Dockerfile + Railway config land in #280.
+
+## Quickstart (local dev with a PAT)
+
+```bash
+pnpm build
+GHP_MCP_MODE=hosted \
+GHP_REPO=bretwardjames/ghp \
+PORT=3000 \
+  node packages/mcp-hosted/dist/bin.js
+```
+
+Probe:
+
+```bash
+curl http://localhost:3000/healthz
+# ok
+
+curl -X POST http://localhost:3000/mcp \
+  -H "Authorization: Bearer $(gh auth token)" \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json, text/event-stream' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"curl","version":"1"}}}'
+```
+
+## Environment
+
+| Var                    | Required | Default         | Purpose                                             |
+|------------------------|----------|-----------------|-----------------------------------------------------|
+| `GHP_MCP_MODE`         | yes      | —               | Must be `hosted`. Refuses to start otherwise.       |
+| `PORT`                 | no       | `3000`          | HTTP listen port. Railway / Fly inject this.        |
+| `GHP_HOSTED_BASE_URL`  | prod     | —               | Public https URL. Required if `NODE_ENV=production`.|
+| `GHP_REPO`             | no       | —               | Lock every session to `owner/name`.                 |
+| `GHP_ALLOWED_ORIGINS`  | no       | `*`             | CORS allowlist.                                     |
+| `GHP_LOG_LEVEL`        | no       | `info`          | `trace` / `debug` / `info` / `warn` / `error`.      |
+| `NODE_ENV`             | no       | `development`   |                                                     |
+
+## Endpoints
+
+| Method | Path                                         | Purpose                                          |
+|--------|----------------------------------------------|--------------------------------------------------|
+| GET    | `/healthz`                                   | Plaintext `ok` — Railway / Fly healthcheck.      |
+| GET    | `/.well-known/oauth-protected-resource`      | RFC 9728 metadata. Stub returning 501 until #279.|
+| GET    | `/.well-known/oauth-authorization-server`    | RFC 8414 metadata. Stub returning 501 until #279.|
+| POST   | `/mcp`                                       | MCP Streamable HTTP endpoint.                    |
+
+## Security model
+
+- **No persistent token storage.** Each request's Bearer is wrapped in a request-scoped `BearerTokenProvider` and discarded when the response ends.
+- **Capability filter at registration.** Only `pureApiTools` from `@bretwardjames/ghp-mcp` are ever registered. Local-only tools (`create_worktree`, `merge_pr`, etc.) cannot be called.
+- **Belt + suspenders.** `assertHostedSafe()` re-validates every tool's capability at registration time. A future refactor that accidentally pulls in a local-only tool would fail loudly.
+- **Mode guard.** `GHP_MCP_MODE=hosted` is required. Prevents accidental launches on a dev machine where the HTTP surface would be unintended.
+- **Production TLS.** Refuses to start in production without `GHP_HOSTED_BASE_URL` starting with `https://`.
+
+## Tool surface (default build)
+
+17 tools registered by default:
+
+`get_my_work`, `get_project_board`, `get_standup`, `get_fields`, `move_issue`, `mark_done`, `update_issue`, `assign_issue`, `add_comment`, `set_field`, `add_label`*, `remove_label`*, `set_parent`*, `link_branch`*, `unlink_branch`*, `get_progress`*, `get_issue`*
+
+*\* opt-in via existing `enabledTools` config — ghp-mcp's `disabledByDefault` honoured here too.*
+
+Excluded (local-only, cannot run on hosted):
+
+`create_worktree`, `remove_worktree`, `list_worktrees`, `create_pr`, `merge_pr`, `sync_merged_prs`, `release`, `start_work`, `stop_work`*, `get_tags`, `create_issue`†
+
+*\* `stop_work` is classified `pure-api` but `disabledByDefault`; opt in to expose.*
+*† `create_issue` is gated `local-only` until #278 adds the hook-block guard. See [tool classification](../mcp/src/tools/).*
+
+## Development
+
+```bash
+pnpm --filter @bretwardjames/ghp-mcp-hosted build
+pnpm --filter @bretwardjames/ghp-mcp-hosted test
+pnpm --filter @bretwardjames/ghp-mcp-hosted dev
+```
+
+## Related issues
+
+- #276 — Epic: Hosted GHP MCP server for runtight integration
+- #278 — **This package** (skeleton + HTTP + Bearer)
+- #279 — OAuth 2.1 + well-known discovery
+- #280 — Docker + Railway deploy
+- #281 — runtight registration + E2E

--- a/packages/mcp-hosted/package.json
+++ b/packages/mcp-hosted/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@bretwardjames/ghp-mcp",
-  "version": "0.7.0",
-  "description": "MCP server for ghp (GitHub Projects)",
+  "name": "@bretwardjames/ghp-mcp-hosted",
+  "version": "0.1.0",
+  "description": "Hosted (HTTP) MCP server for ghp — multi-tenant GitHub Projects tooling for platforms like runtight",
   "publishConfig": {
     "access": "public"
   },
@@ -9,7 +9,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "bin": {
-    "ghp-mcp": "dist/bin.js"
+    "ghp-mcp-hosted": "dist/bin.js"
   },
   "exports": {
     ".": {
@@ -20,6 +20,7 @@
   "scripts": {
     "build": "tsup src/bin.ts src/index.ts --format esm --dts",
     "dev": "tsup src/bin.ts src/index.ts --format esm --dts --watch",
+    "start": "GHP_MCP_MODE=hosted node dist/bin.js",
     "clean": "rm -rf dist",
     "test": "vitest run",
     "test:watch": "vitest"
@@ -28,21 +29,27 @@
     "mcp",
     "github",
     "projects",
-    "claude",
-    "ai"
+    "hosted",
+    "http",
+    "oauth"
   ],
   "author": "Bret Ward James",
   "license": "MIT",
   "dependencies": {
     "@bretwardjames/ghp-core": "workspace:*",
+    "@bretwardjames/ghp-mcp": "workspace:*",
     "@modelcontextprotocol/sdk": "^1.0.0",
+    "express": "^4.21.1",
     "zod": "^3.22.0"
   },
   "devDependencies": {
+    "@types/express": "^4.17.21",
     "@types/node": "^20.10.0",
     "tsup": "^8.0.0",
     "typescript": "^5.3.2",
-    "vitest": "^3.0.5"
+    "vitest": "^3.0.5",
+    "supertest": "^7.0.0",
+    "@types/supertest": "^6.0.2"
   },
   "engines": {
     "node": ">=18"

--- a/packages/mcp-hosted/src/auth/bearer-token-provider.test.ts
+++ b/packages/mcp-hosted/src/auth/bearer-token-provider.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { BearerTokenProvider, extractBearer } from './bearer-token-provider.js';
+
+describe('extractBearer', () => {
+    it('extracts token from well-formed header', () => {
+        expect(extractBearer('Bearer ghp_somelongtokenvalue123')).toBe(
+            'ghp_somelongtokenvalue123'
+        );
+    });
+
+    it('is case-insensitive on the scheme', () => {
+        expect(extractBearer('bearer ghp_somelongtokenvalue123')).toBe(
+            'ghp_somelongtokenvalue123'
+        );
+        expect(extractBearer('BEARER ghp_somelongtokenvalue123')).toBe(
+            'ghp_somelongtokenvalue123'
+        );
+    });
+
+    it('returns null for missing header', () => {
+        expect(extractBearer(undefined)).toBeNull();
+        expect(extractBearer('')).toBeNull();
+    });
+
+    it('returns null for wrong scheme', () => {
+        expect(extractBearer('Basic dXNlcjpwYXNz')).toBeNull();
+    });
+
+    it('returns null for too-short tokens', () => {
+        expect(extractBearer('Bearer short')).toBeNull();
+    });
+
+    it('returns null for bearer with no token', () => {
+        expect(extractBearer('Bearer ')).toBeNull();
+        expect(extractBearer('Bearer')).toBeNull();
+    });
+});
+
+describe('BearerTokenProvider', () => {
+    it('returns the wrapped token', async () => {
+        const p = new BearerTokenProvider('ghp_abc123');
+        expect(await p.getToken()).toBe('ghp_abc123');
+    });
+
+    it('refuses to construct with empty token (multi-tenancy guard)', () => {
+        expect(() => new BearerTokenProvider('')).toThrow();
+    });
+});

--- a/packages/mcp-hosted/src/auth/bearer-token-provider.ts
+++ b/packages/mcp-hosted/src/auth/bearer-token-provider.ts
@@ -1,0 +1,38 @@
+import type { TokenProvider } from '@bretwardjames/ghp-core';
+
+/**
+ * Request-scoped TokenProvider that wraps a static Bearer token extracted
+ * from an HTTP `Authorization: Bearer <token>` header.
+ *
+ * One instance per HTTP request — NEVER cache across requests. The hosted
+ * server is multi-tenant; reusing a provider would leak one user's token
+ * into another user's tool call.
+ */
+export class BearerTokenProvider implements TokenProvider {
+    constructor(private readonly token: string) {
+        if (!token) {
+            throw new Error('BearerTokenProvider requires a non-empty token');
+        }
+    }
+
+    async getToken(): Promise<string | null> {
+        return this.token;
+    }
+}
+
+/**
+ * Parse a raw Authorization header and return the bearer token, or null
+ * when the header is missing/malformed.
+ *
+ * Accepts "Bearer <token>" (case-insensitive scheme). Rejects token strings
+ * shorter than 8 chars as a cheap sanity check — a real GitHub token is
+ * always much longer.
+ */
+export function extractBearer(header: string | undefined): string | null {
+    if (!header) return null;
+    const match = /^Bearer\s+(\S+)$/i.exec(header.trim());
+    if (!match) return null;
+    const token = match[1];
+    if (token.length < 8) return null;
+    return token;
+}

--- a/packages/mcp-hosted/src/bin.ts
+++ b/packages/mcp-hosted/src/bin.ts
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+
+import { createApp } from './http-server.js';
+import { loadConfig } from './config.js';
+import { assertHostedMode } from './mode-guard.js';
+
+/**
+ * ghp-mcp-hosted — HTTP-transport MCP server for hosted / multi-tenant
+ * platforms (runtight, custom AI products).
+ *
+ * Env:
+ *   GHP_MCP_MODE           (required) must be 'hosted'
+ *   PORT                   (default 3000)
+ *   GHP_HOSTED_BASE_URL    (required in production) public https URL
+ *   GHP_REPO               (optional) lock all sessions to owner/name
+ *   GHP_ALLOWED_ORIGINS    (default '*') comma-separated CORS allowlist
+ *   GHP_LOG_LEVEL          (default 'info')
+ *   NODE_ENV               (default 'development')
+ */
+async function main(): Promise<void> {
+    assertHostedMode();
+    const config = loadConfig();
+    const app = createApp(config);
+
+    const server = app.listen(config.port, () => {
+        console.log(
+            JSON.stringify({
+                level: 'info',
+                msg: 'ghp-mcp-hosted listening',
+                port: config.port,
+                baseUrl: config.baseUrl ?? null,
+                lockedRepo: config.lockedRepo ?? null,
+                nodeEnv: config.nodeEnv,
+            })
+        );
+    });
+
+    const shutdown = (signal: string): void => {
+        console.log(JSON.stringify({ level: 'info', msg: 'shutting down', signal }));
+        server.close(() => process.exit(0));
+        setTimeout(() => process.exit(1), 10_000).unref();
+    };
+    process.on('SIGTERM', () => shutdown('SIGTERM'));
+    process.on('SIGINT', () => shutdown('SIGINT'));
+}
+
+main().catch((err) => {
+    console.error(
+        JSON.stringify({
+            level: 'fatal',
+            msg: 'failed to start ghp-mcp-hosted',
+            error: err instanceof Error ? err.message : String(err),
+        })
+    );
+    process.exit(1);
+});

--- a/packages/mcp-hosted/src/config.test.ts
+++ b/packages/mcp-hosted/src/config.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import { loadConfig, parseRepoInfo } from './config.js';
+
+describe('loadConfig', () => {
+    const base = {
+        GHP_MCP_MODE: 'hosted',
+        PORT: '3000',
+    };
+
+    it('accepts a minimal dev config', () => {
+        const cfg = loadConfig({ ...base });
+        expect(cfg.mode).toBe('hosted');
+        expect(cfg.port).toBe(3000);
+        expect(cfg.nodeEnv).toBe('development');
+    });
+
+    it('refuses to start when GHP_MCP_MODE is not hosted', () => {
+        expect(() => loadConfig({ GHP_MCP_MODE: 'local', PORT: '3000' })).toThrow();
+    });
+
+    it('refuses to start when GHP_MCP_MODE is missing', () => {
+        expect(() => loadConfig({ PORT: '3000' })).toThrow();
+    });
+
+    it('requires https baseUrl in production', () => {
+        expect(() =>
+            loadConfig({ ...base, NODE_ENV: 'production' })
+        ).toThrow(/GHP_HOSTED_BASE_URL/);
+
+        expect(() =>
+            loadConfig({
+                ...base,
+                NODE_ENV: 'production',
+                GHP_HOSTED_BASE_URL: 'http://insecure.example.com',
+            })
+        ).toThrow(/https/);
+
+        expect(() =>
+            loadConfig({
+                ...base,
+                NODE_ENV: 'production',
+                GHP_HOSTED_BASE_URL: 'https://ghp.example.com',
+            })
+        ).not.toThrow();
+    });
+
+    it('validates GHP_REPO format', () => {
+        expect(() =>
+            loadConfig({ ...base, GHP_REPO: 'owner/name' })
+        ).not.toThrow();
+
+        expect(() => loadConfig({ ...base, GHP_REPO: 'no-slash' })).toThrow();
+    });
+});
+
+describe('parseRepoInfo', () => {
+    it('splits owner/name', () => {
+        expect(parseRepoInfo('bretwardjames/ghp')).toEqual({
+            owner: 'bretwardjames',
+            name: 'ghp',
+            fullName: 'bretwardjames/ghp',
+        });
+    });
+
+    it('handles repo names containing slashes', () => {
+        // GitHub repo names cannot contain slashes, but guard against regression
+        // in the parser if this ever changes.
+        expect(parseRepoInfo('org/nested/repo')).toEqual({
+            owner: 'org',
+            name: 'nested/repo',
+            fullName: 'org/nested/repo',
+        });
+    });
+});

--- a/packages/mcp-hosted/src/config.test.ts
+++ b/packages/mcp-hosted/src/config.test.ts
@@ -5,21 +5,26 @@ describe('loadConfig', () => {
     const base = {
         GHP_MCP_MODE: 'hosted',
         PORT: '3000',
+        GHP_REPO: 'bretwardjames/ghp',
     };
 
     it('accepts a minimal dev config', () => {
         const cfg = loadConfig({ ...base });
         expect(cfg.mode).toBe('hosted');
         expect(cfg.port).toBe(3000);
+        expect(cfg.lockedRepo).toBe('bretwardjames/ghp');
         expect(cfg.nodeEnv).toBe('development');
     });
 
     it('refuses to start when GHP_MCP_MODE is not hosted', () => {
-        expect(() => loadConfig({ GHP_MCP_MODE: 'local', PORT: '3000' })).toThrow();
+        expect(() =>
+            loadConfig({ ...base, GHP_MCP_MODE: 'local' })
+        ).toThrow();
     });
 
     it('refuses to start when GHP_MCP_MODE is missing', () => {
-        expect(() => loadConfig({ PORT: '3000' })).toThrow();
+        const { GHP_MCP_MODE: _omit, ...without } = base;
+        expect(() => loadConfig(without)).toThrow();
     });
 
     it('requires https baseUrl in production', () => {
@@ -44,11 +49,12 @@ describe('loadConfig', () => {
         ).not.toThrow();
     });
 
-    it('validates GHP_REPO format', () => {
-        expect(() =>
-            loadConfig({ ...base, GHP_REPO: 'owner/name' })
-        ).not.toThrow();
+    it('requires GHP_REPO', () => {
+        const { GHP_REPO: _omit, ...without } = base;
+        expect(() => loadConfig(without)).toThrow();
+    });
 
+    it('validates GHP_REPO format', () => {
         expect(() => loadConfig({ ...base, GHP_REPO: 'no-slash' })).toThrow();
     });
 });

--- a/packages/mcp-hosted/src/config.ts
+++ b/packages/mcp-hosted/src/config.ts
@@ -26,21 +26,18 @@ const configSchema = z
         baseUrl: z.string().url().optional(),
 
         /**
-         * Lock every session to a single GitHub repo. When set, every
-         * McpServer instance is created with this repo in RepoContext,
-         * skipping git remote detection (which wouldn't work server-side
-         * anyway). Format: "owner/name".
+         * Lock every session to a single GitHub repo. REQUIRED — without
+         * it, RepoContext would attempt to auto-detect by running
+         * `git remote get-url origin` in the server's cwd, which is
+         * meaningless and spawns a subprocess in a multi-tenant hosted
+         * deployment. Format: "owner/name".
          */
         lockedRepo: z
             .string()
-            .regex(/^[^/]+\/[^/]+$/, 'GHP_REPO must be owner/name')
-            .optional(),
+            .regex(/^[^/]+\/[^/]+$/, 'GHP_REPO is required and must be owner/name'),
 
         /** Comma-separated CORS origin allowlist. '*' for dev. */
         allowedOrigins: z.string().default('*'),
-
-        /** pino log level */
-        logLevel: z.enum(['trace', 'debug', 'info', 'warn', 'error', 'fatal']).default('info'),
 
         nodeEnv: z.enum(['development', 'production', 'test']).default('development'),
     })
@@ -62,7 +59,6 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): HostedConfig {
         baseUrl: env.GHP_HOSTED_BASE_URL,
         lockedRepo: env.GHP_REPO,
         allowedOrigins: env.GHP_ALLOWED_ORIGINS,
-        logLevel: env.GHP_LOG_LEVEL,
         nodeEnv: env.NODE_ENV,
     });
 }

--- a/packages/mcp-hosted/src/config.ts
+++ b/packages/mcp-hosted/src/config.ts
@@ -1,0 +1,78 @@
+import { z } from 'zod';
+
+/**
+ * Runtime config for the hosted GHP MCP server.
+ *
+ * All fields come from process.env. This module is the single source of
+ * truth — every other module should accept a resolved HostedConfig rather
+ * than reading process.env directly, so tests can inject fake configs.
+ */
+const configSchema = z
+    .object({
+        /** Port to bind the HTTP server. Railway / Fly inject this. */
+        port: z.coerce.number().int().positive().default(3000),
+
+        /**
+         * Mode guard. Must be exactly 'hosted' — any other value refuses to
+         * start. Prevents the hosted bin from being accidentally launched on
+         * a developer machine where it would expose network endpoints.
+         */
+        mode: z.literal('hosted'),
+
+        /**
+         * Public HTTPS base URL of this server. Used in OAuth metadata and
+         * callback redirects. Required in production; optional in dev.
+         */
+        baseUrl: z.string().url().optional(),
+
+        /**
+         * Lock every session to a single GitHub repo. When set, every
+         * McpServer instance is created with this repo in RepoContext,
+         * skipping git remote detection (which wouldn't work server-side
+         * anyway). Format: "owner/name".
+         */
+        lockedRepo: z
+            .string()
+            .regex(/^[^/]+\/[^/]+$/, 'GHP_REPO must be owner/name')
+            .optional(),
+
+        /** Comma-separated CORS origin allowlist. '*' for dev. */
+        allowedOrigins: z.string().default('*'),
+
+        /** pino log level */
+        logLevel: z.enum(['trace', 'debug', 'info', 'warn', 'error', 'fatal']).default('info'),
+
+        nodeEnv: z.enum(['development', 'production', 'test']).default('development'),
+    })
+    .refine(
+        (c) => c.nodeEnv !== 'production' || (c.baseUrl !== undefined && c.baseUrl.startsWith('https://')),
+        {
+            message:
+                'GHP_HOSTED_BASE_URL is required in production and must start with https://',
+            path: ['baseUrl'],
+        }
+    );
+
+export type HostedConfig = z.infer<typeof configSchema>;
+
+export function loadConfig(env: NodeJS.ProcessEnv = process.env): HostedConfig {
+    return configSchema.parse({
+        port: env.PORT,
+        mode: env.GHP_MCP_MODE,
+        baseUrl: env.GHP_HOSTED_BASE_URL,
+        lockedRepo: env.GHP_REPO,
+        allowedOrigins: env.GHP_ALLOWED_ORIGINS,
+        logLevel: env.GHP_LOG_LEVEL,
+        nodeEnv: env.NODE_ENV,
+    });
+}
+
+export function parseRepoInfo(lockedRepo: string): {
+    owner: string;
+    name: string;
+    fullName: string;
+} {
+    const [owner, ...rest] = lockedRepo.split('/');
+    const name = rest.join('/');
+    return { owner, name, fullName: `${owner}/${name}` };
+}

--- a/packages/mcp-hosted/src/http-server.test.ts
+++ b/packages/mcp-hosted/src/http-server.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Integration tests for the hosted MCP HTTP server.
+ *
+ * These exercise the Express app in-process via supertest. They do NOT
+ * require any network access or a real GitHub token:
+ *   - `/healthz` and `/.well-known/*` are pure responses.
+ *   - `/mcp` `initialize` + `tools/list` route through the MCP SDK but
+ *     never touch GitHub (tools are only invoked via `tools/call`).
+ *
+ * A fake bearer satisfies the Authorization extraction; the downstream
+ * TokenProvider is only read when a tool handler actually calls the API.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import request from 'supertest';
+import { createApp } from './http-server.js';
+import type { HostedConfig } from './config.js';
+
+const FAKE_TOKEN = 'ghp_faketoken_for_tests_1234567890';
+
+function buildConfig(overrides: Partial<HostedConfig> = {}): HostedConfig {
+    return {
+        port: 0,
+        mode: 'hosted',
+        baseUrl: undefined,
+        lockedRepo: 'bretwardjames/ghp',
+        allowedOrigins: '*',
+        logLevel: 'error',
+        nodeEnv: 'test',
+        ...overrides,
+    };
+}
+
+function mcpHeaders(token: string = FAKE_TOKEN) {
+    return {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+        Accept: 'application/json, text/event-stream',
+    };
+}
+
+describe('hosted http server', () => {
+    let app: ReturnType<typeof createApp>;
+    beforeEach(() => {
+        app = createApp(buildConfig());
+    });
+
+    describe('/healthz', () => {
+        it('returns 200 and "ok"', async () => {
+            const res = await request(app).get('/healthz');
+            expect(res.status).toBe(200);
+            expect(res.text).toBe('ok');
+        });
+    });
+
+    describe('/.well-known/oauth-protected-resource', () => {
+        it('returns 501 stub until OAuth ships in #279', async () => {
+            const res = await request(app).get('/.well-known/oauth-protected-resource');
+            expect(res.status).toBe(501);
+            expect(res.body.error).toBe('not_implemented');
+        });
+    });
+
+    describe('POST /mcp without auth', () => {
+        it('returns 401 with WWW-Authenticate pointing at resource metadata', async () => {
+            const res = await request(app)
+                .post('/mcp')
+                .set('Content-Type', 'application/json')
+                .send({ jsonrpc: '2.0', id: 1, method: 'initialize', params: {} });
+
+            expect(res.status).toBe(401);
+            expect(res.headers['www-authenticate']).toMatch(/^Bearer /);
+            expect(res.headers['www-authenticate']).toContain(
+                'resource_metadata="/.well-known/oauth-protected-resource"'
+            );
+            expect(res.body.error.code).toBe(-32001);
+        });
+
+        it('rejects malformed Authorization (scheme missing)', async () => {
+            const res = await request(app)
+                .post('/mcp')
+                .set('Authorization', 'not-a-bearer-header')
+                .set('Content-Type', 'application/json')
+                .send({ jsonrpc: '2.0', id: 1, method: 'initialize', params: {} });
+            expect(res.status).toBe(401);
+        });
+
+        it('rejects too-short tokens', async () => {
+            const res = await request(app)
+                .post('/mcp')
+                .set('Authorization', 'Bearer short')
+                .set('Content-Type', 'application/json')
+                .send({ jsonrpc: '2.0', id: 1, method: 'initialize', params: {} });
+            expect(res.status).toBe(401);
+        });
+    });
+
+    describe('POST /mcp with auth — MCP protocol', () => {
+        it('initializes successfully', async () => {
+            const res = await request(app)
+                .post('/mcp')
+                .set(mcpHeaders())
+                .send({
+                    jsonrpc: '2.0',
+                    id: 1,
+                    method: 'initialize',
+                    params: {
+                        protocolVersion: '2025-06-18',
+                        capabilities: {},
+                        clientInfo: { name: 'vitest', version: '1' },
+                    },
+                });
+
+            expect(res.status).toBe(200);
+            // StreamableHTTP returns SSE-framed JSON; parse the data line.
+            const parsed = parseMcpResponse(res.text);
+            expect(parsed.result.serverInfo.name).toBe('ghp');
+            expect(parsed.result.protocolVersion).toBeDefined();
+        });
+
+        it('tools/list contains only pure-api tools', async () => {
+            const res = await request(app)
+                .post('/mcp')
+                .set(mcpHeaders())
+                .send({
+                    jsonrpc: '2.0',
+                    id: 1,
+                    method: 'tools/list',
+                    params: {},
+                });
+
+            expect(res.status).toBe(200);
+            const parsed = parseMcpResponse(res.text);
+            const names: string[] = parsed.result.tools.map((t: { name: string }) => t.name);
+
+            // Pure-api sample — must be present (these are enabled by default)
+            expect(names).toContain('get_my_work');
+            expect(names).toContain('get_project_board');
+            expect(names).toContain('move_issue');
+            expect(names).toContain('update_issue');
+            // stop_work is pure-api but disabledByDefault — not registered here,
+            // which is fine. Hosted deployments that want it can opt in via
+            // the existing enabledTools config surface.
+            expect(names).not.toContain('stop_work');
+
+            // Local-only — must NEVER be exposed on the hosted server
+            expect(names).not.toContain('create_worktree');
+            expect(names).not.toContain('remove_worktree');
+            expect(names).not.toContain('list_worktrees');
+            expect(names).not.toContain('merge_pr');
+            expect(names).not.toContain('create_pr');
+            expect(names).not.toContain('release');
+            expect(names).not.toContain('sync_merged_prs');
+            expect(names).not.toContain('start_work');
+            expect(names).not.toContain('get_tags');
+            // create_issue is local-only until #278 hook gate lands
+            expect(names).not.toContain('create_issue');
+        });
+    });
+});
+
+/**
+ * StreamableHTTPServerTransport responds with an SSE-framed single event
+ * `event: message\ndata: {json}\n\n`. This tiny parser pulls the JSON out
+ * so tests can make assertions on the payload without pulling in an SSE
+ * client.
+ */
+function parseMcpResponse(text: string): { result: any } {
+    const line = text
+        .split('\n')
+        .map((l) => l.trim())
+        .find((l) => l.startsWith('data:'));
+    if (!line) throw new Error(`No data: line in response: ${text}`);
+    return JSON.parse(line.slice('data:'.length).trim());
+}

--- a/packages/mcp-hosted/src/http-server.test.ts
+++ b/packages/mcp-hosted/src/http-server.test.ts
@@ -25,7 +25,6 @@ function buildConfig(overrides: Partial<HostedConfig> = {}): HostedConfig {
         baseUrl: undefined,
         lockedRepo: 'bretwardjames/ghp',
         allowedOrigins: '*',
-        logLevel: 'error',
         nodeEnv: 'test',
         ...overrides,
     };
@@ -95,6 +94,19 @@ describe('hosted http server', () => {
         });
     });
 
+    describe('CORS', () => {
+        it('responds 204 to OPTIONS preflight so browsers can POST', async () => {
+            const res = await request(app)
+                .options('/mcp')
+                .set('Origin', 'https://example.com')
+                .set('Access-Control-Request-Method', 'POST')
+                .set('Access-Control-Request-Headers', 'Authorization, Content-Type');
+            expect(res.status).toBe(204);
+            expect(res.headers['access-control-allow-methods']).toContain('POST');
+            expect(res.headers['access-control-allow-headers']).toContain('Authorization');
+        });
+    });
+
     describe('POST /mcp with auth — MCP protocol', () => {
         it('initializes successfully', async () => {
             const res = await request(app)
@@ -116,6 +128,41 @@ describe('hosted http server', () => {
             const parsed = parseMcpResponse(res.text);
             expect(parsed.result.serverInfo.name).toBe('ghp');
             expect(parsed.result.protocolVersion).toBeDefined();
+        });
+
+        it('concurrent requests with different tokens do not share state', async () => {
+            // Fire two tools/list requests with different bearers in parallel.
+            // If any module-level state (token provider, repo context, tool
+            // registration) leaked across requests, we'd see inconsistent tool
+            // lists or error/success asymmetry. Both should return identical
+            // pure-api tool sets.
+            const tokenA = 'ghp_tenant_A_fake_token_000000001';
+            const tokenB = 'ghp_tenant_B_fake_token_000000002';
+
+            const [resA, resB] = await Promise.all([
+                request(app)
+                    .post('/mcp')
+                    .set(mcpHeaders(tokenA))
+                    .send({ jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} }),
+                request(app)
+                    .post('/mcp')
+                    .set(mcpHeaders(tokenB))
+                    .send({ jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} }),
+            ]);
+
+            expect(resA.status).toBe(200);
+            expect(resB.status).toBe(200);
+
+            const namesA = parseMcpResponse(resA.text)
+                .result.tools.map((t: { name: string }) => t.name)
+                .sort();
+            const namesB = parseMcpResponse(resB.text)
+                .result.tools.map((t: { name: string }) => t.name)
+                .sort();
+
+            expect(namesA).toEqual(namesB);
+            expect(namesA).toContain('get_my_work');
+            expect(namesA).not.toContain('create_worktree');
         });
 
         it('tools/list contains only pure-api tools', async () => {

--- a/packages/mcp-hosted/src/http-server.ts
+++ b/packages/mcp-hosted/src/http-server.ts
@@ -4,6 +4,7 @@ import {
     createServer as createMcpServer,
     registerEnabledTools,
     pureApiTools,
+    type McpConfig,
 } from '@bretwardjames/ghp-mcp';
 import type { RepoInfo } from '@bretwardjames/ghp-core';
 import { BearerTokenProvider, extractBearer } from './auth/bearer-token-provider.js';
@@ -25,6 +26,31 @@ import { assertHostedSafe } from './mode-guard.js';
  * hosted-safe subset is ever exposed.
  */
 export function createApp(config: HostedConfig): Application {
+    // One-time capability audit at startup. pureApiTools is already filtered
+    // by capability === 'pure-api', but re-asserting here catches the case
+    // where the list is ever regenerated in a future refactor and something
+    // local-only slips in. Doing this at createApp time rather than per
+    // request avoids paying the cost on every tool call.
+    for (const tool of pureApiTools) {
+        assertHostedSafe(tool.meta);
+    }
+
+    // Pre-resolve the locked repo once. Hosted mode requires GHP_REPO (the
+    // config schema enforces this), so this never branches into the auto
+    // detect path that would shell out to `git remote get-url origin` on
+    // the host machine — something we never want in a multi-tenant server.
+    const lockedRepo: RepoInfo = parseRepoInfo(config.lockedRepo);
+
+    // Pre-build a deterministic McpConfig for every request. Passing this
+    // explicitly prevents registerEnabledTools from falling back to
+    // loadMcpConfig(), which reads ~/.config/ghp-cli/config.json and runs
+    // `git rev-parse --show-toplevel` — behavior that is wrong for a
+    // multi-tenant server and would spawn a subprocess per request.
+    const mcpConfig: McpConfig = {
+        tools: { read: true, action: true },
+        disabledTools: [],
+    };
+
     const app = express();
     app.disable('x-powered-by');
 
@@ -45,6 +71,14 @@ export function createApp(config: HostedConfig): Application {
             'Content-Type, Authorization, MCP-Protocol-Version'
         );
         next();
+    });
+
+    // CORS preflight: browsers issue OPTIONS before any cross-origin POST
+    // that carries Authorization or non-simple Content-Type. Without this
+    // handler, the preflight would 404 and the POST would be blocked
+    // client-side.
+    app.options('/mcp', (_req, res) => {
+        res.sendStatus(204);
     });
 
     app.get('/healthz', (_req, res) => {
@@ -69,35 +103,33 @@ export function createApp(config: HostedConfig): Application {
         });
     });
 
-    app.post('/mcp', (req, res) => handleMcpRequest(req, res, config));
+    app.post('/mcp', (req, res) =>
+        handleMcpRequest(req, res, { config, lockedRepo, mcpConfig })
+    );
 
     return app;
+}
+
+interface RequestDeps {
+    config: HostedConfig;
+    lockedRepo: RepoInfo;
+    mcpConfig: McpConfig;
 }
 
 async function handleMcpRequest(
     req: Request,
     res: Response,
-    config: HostedConfig
+    deps: RequestDeps
 ): Promise<void> {
     const token = extractBearer(req.header('authorization'));
     if (!token) {
-        sendUnauthorized(res, config);
+        sendUnauthorized(res, deps.config);
         return;
     }
 
     const tokenProvider = new BearerTokenProvider(token);
-    const lockedRepo: RepoInfo | undefined = config.lockedRepo
-        ? parseRepoInfo(config.lockedRepo)
-        : undefined;
-
-    const { server, context } = createMcpServer(tokenProvider, lockedRepo);
-
-    // Defence-in-depth: every pure-api tool passes assertHostedSafe;
-    // a local-only tool sneaking in would throw before register().
-    for (const tool of pureApiTools) {
-        assertHostedSafe(tool.meta);
-    }
-    registerEnabledTools(server, context, undefined, 'pure-api');
+    const { server, context } = createMcpServer(tokenProvider, deps.lockedRepo);
+    registerEnabledTools(server, context, deps.mcpConfig, 'pure-api');
 
     const transport = new StreamableHTTPServerTransport({
         // Stateless per-request mode: no session IDs, no cross-request state.
@@ -106,16 +138,16 @@ async function handleMcpRequest(
         sessionIdGenerator: undefined,
     });
 
-    // When the client closes the stream we also close our handle so the
-    // request never dangles. Without this, long-running tool calls that
-    // the client abandons would keep the McpServer alive.
-    res.on('close', () => {
-        void transport.close();
-        void server.close();
-    });
-
     try {
         await server.connect(transport);
+
+        // Register cleanup after connect so we never try to close an
+        // uninitialized transport if the client disconnects during connect.
+        res.on('close', () => {
+            void transport.close();
+            void server.close();
+        });
+
         await transport.handleRequest(req, res, req.body);
     } catch (err) {
         // If connect/handleRequest throws before any response was sent,

--- a/packages/mcp-hosted/src/http-server.ts
+++ b/packages/mcp-hosted/src/http-server.ts
@@ -1,0 +1,160 @@
+import express, { type Application, type Request, type Response } from 'express';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import {
+    createServer as createMcpServer,
+    registerEnabledTools,
+    pureApiTools,
+} from '@bretwardjames/ghp-mcp';
+import type { RepoInfo } from '@bretwardjames/ghp-core';
+import { BearerTokenProvider, extractBearer } from './auth/bearer-token-provider.js';
+import type { HostedConfig } from './config.js';
+import { parseRepoInfo } from './config.js';
+import { assertHostedSafe } from './mode-guard.js';
+
+/**
+ * Build the Express app for the hosted GHP MCP server.
+ *
+ * The app has three kinds of routes:
+ *   - GET  /healthz                 — plaintext probe for Railway / Fly
+ *   - GET  /.well-known/oauth-*     — OAuth discovery stubs (#279 fills in)
+ *   - POST /mcp                     — MCP Streamable HTTP endpoint
+ *
+ * /mcp creates a fresh McpServer + transport per request. The request's
+ * Bearer token is bound to a request-scoped TokenProvider. Tools are
+ * registered via `registerEnabledTools(..., 'pure-api')` so only the
+ * hosted-safe subset is ever exposed.
+ */
+export function createApp(config: HostedConfig): Application {
+    const app = express();
+    app.disable('x-powered-by');
+
+    app.use(
+        express.json({
+            limit: '1mb',
+            // MCP Streamable HTTP expects the raw JSON-RPC body to be
+            // available on req.body. 1MB is generous for tool calls.
+        })
+    );
+
+    // Permissive CORS for dev; real allowlist handled in #279 alongside OAuth.
+    app.use((_req, res, next) => {
+        res.setHeader('Access-Control-Allow-Origin', config.allowedOrigins);
+        res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
+        res.setHeader(
+            'Access-Control-Allow-Headers',
+            'Content-Type, Authorization, MCP-Protocol-Version'
+        );
+        next();
+    });
+
+    app.get('/healthz', (_req, res) => {
+        res.type('text/plain').send('ok');
+    });
+
+    // OAuth discovery stubs — filled in by #279. Returning 501 here keeps
+    // the routes documented without silently 404-ing clients that probe.
+    app.get('/.well-known/oauth-protected-resource', (_req, res) => {
+        res.status(501).json({
+            error: 'not_implemented',
+            error_description:
+                'OAuth discovery is not implemented in this build. Use a PAT via Authorization: Bearer <token>.',
+        });
+    });
+
+    app.get('/.well-known/oauth-authorization-server', (_req, res) => {
+        res.status(501).json({
+            error: 'not_implemented',
+            error_description:
+                'OAuth authorization server metadata is not implemented in this build.',
+        });
+    });
+
+    app.post('/mcp', (req, res) => handleMcpRequest(req, res, config));
+
+    return app;
+}
+
+async function handleMcpRequest(
+    req: Request,
+    res: Response,
+    config: HostedConfig
+): Promise<void> {
+    const token = extractBearer(req.header('authorization'));
+    if (!token) {
+        sendUnauthorized(res, config);
+        return;
+    }
+
+    const tokenProvider = new BearerTokenProvider(token);
+    const lockedRepo: RepoInfo | undefined = config.lockedRepo
+        ? parseRepoInfo(config.lockedRepo)
+        : undefined;
+
+    const { server, context } = createMcpServer(tokenProvider, lockedRepo);
+
+    // Defence-in-depth: every pure-api tool passes assertHostedSafe;
+    // a local-only tool sneaking in would throw before register().
+    for (const tool of pureApiTools) {
+        assertHostedSafe(tool.meta);
+    }
+    registerEnabledTools(server, context, undefined, 'pure-api');
+
+    const transport = new StreamableHTTPServerTransport({
+        // Stateless per-request mode: no session IDs, no cross-request state.
+        // Matches the multi-tenant requirement — each request is a fresh
+        // tenant boundary.
+        sessionIdGenerator: undefined,
+    });
+
+    // When the client closes the stream we also close our handle so the
+    // request never dangles. Without this, long-running tool calls that
+    // the client abandons would keep the McpServer alive.
+    res.on('close', () => {
+        void transport.close();
+        void server.close();
+    });
+
+    try {
+        await server.connect(transport);
+        await transport.handleRequest(req, res, req.body);
+    } catch (err) {
+        // If connect/handleRequest throws before any response was sent,
+        // return a JSON-RPC-shaped error so the client sees it as a
+        // protocol failure rather than a connection reset.
+        if (!res.headersSent) {
+            res.status(500).json({
+                jsonrpc: '2.0',
+                error: {
+                    code: -32603,
+                    message:
+                        err instanceof Error
+                            ? err.message
+                            : 'Internal error handling MCP request',
+                },
+                id: null,
+            });
+        }
+    }
+}
+
+function sendUnauthorized(res: Response, config: HostedConfig): void {
+    // Per MCP Authorization spec, surface a WWW-Authenticate header that
+    // points at the Protected Resource Metadata document. Even though
+    // that endpoint is a stub in this build, the header shape is
+    // correct so future MCP clients can discover OAuth once #279 lands.
+    const resourceMetadata = config.baseUrl
+        ? `${config.baseUrl}/.well-known/oauth-protected-resource`
+        : '/.well-known/oauth-protected-resource';
+    res.setHeader(
+        'WWW-Authenticate',
+        `Bearer realm="ghp-mcp-hosted", resource_metadata="${resourceMetadata}"`
+    );
+    res.status(401).json({
+        jsonrpc: '2.0',
+        error: {
+            code: -32001,
+            message: 'Missing or invalid Authorization header. Expected "Bearer <token>".',
+        },
+        id: null,
+    });
+}

--- a/packages/mcp-hosted/src/index.ts
+++ b/packages/mcp-hosted/src/index.ts
@@ -1,0 +1,17 @@
+/**
+ * Library exports for @bretwardjames/ghp-mcp-hosted.
+ *
+ * The default entry (the `ghp-mcp-hosted` binary) lives at `./bin.js`.
+ * This module re-exports the pieces consumers might want to embed in a
+ * larger Node process (for example, running the MCP endpoint as a route
+ * inside an existing Express app).
+ */
+
+export { createApp } from './http-server.js';
+export { loadConfig, parseRepoInfo } from './config.js';
+export type { HostedConfig } from './config.js';
+export {
+    BearerTokenProvider,
+    extractBearer,
+} from './auth/bearer-token-provider.js';
+export { assertHostedSafe, assertHostedMode } from './mode-guard.js';

--- a/packages/mcp-hosted/src/mode-guard.test.ts
+++ b/packages/mcp-hosted/src/mode-guard.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, afterEach, beforeEach } from 'vitest';
+import { assertHostedSafe, assertHostedMode } from './mode-guard.js';
+
+describe('assertHostedSafe', () => {
+    it('accepts pure-api tools', () => {
+        expect(() =>
+            assertHostedSafe({ name: 'get_my_work', capability: 'pure-api' })
+        ).not.toThrow();
+    });
+
+    it('rejects local-only tools with a loud error', () => {
+        expect(() =>
+            assertHostedSafe({ name: 'create_worktree', capability: 'local-only' })
+        ).toThrow(/create_worktree.*local-only.*hosted/s);
+    });
+});
+
+describe('assertHostedMode', () => {
+    const original = process.env.GHP_MCP_MODE;
+    beforeEach(() => {
+        delete process.env.GHP_MCP_MODE;
+    });
+    afterEach(() => {
+        if (original === undefined) {
+            delete process.env.GHP_MCP_MODE;
+        } else {
+            process.env.GHP_MCP_MODE = original;
+        }
+    });
+
+    it('accepts GHP_MCP_MODE=hosted', () => {
+        process.env.GHP_MCP_MODE = 'hosted';
+        expect(() => assertHostedMode()).not.toThrow();
+    });
+
+    it('refuses when GHP_MCP_MODE is anything else', () => {
+        process.env.GHP_MCP_MODE = 'local';
+        expect(() => assertHostedMode()).toThrow(/GHP_MCP_MODE=hosted/);
+    });
+
+    it('refuses when GHP_MCP_MODE is unset', () => {
+        expect(() => assertHostedMode()).toThrow(/GHP_MCP_MODE=hosted/);
+    });
+});

--- a/packages/mcp-hosted/src/mode-guard.ts
+++ b/packages/mcp-hosted/src/mode-guard.ts
@@ -1,0 +1,39 @@
+import type { ToolMeta } from '@bretwardjames/ghp-mcp';
+
+/**
+ * Belt-and-suspenders runtime assertion: refuse to run any tool that
+ * declares `capability: 'local-only'` on a hosted server.
+ *
+ * The primary defense is filtering at registration time
+ * (`pureApiTools` in @bretwardjames/ghp-mcp). This helper exists as a
+ * defence-in-depth check for codepaths that might bypass the registry —
+ * e.g. a future refactor that accidentally imports a tool directly.
+ *
+ * Throws so the failure is loud in logs, not silent.
+ */
+export function assertHostedSafe(meta: Pick<ToolMeta, 'name' | 'capability'>): void {
+    if (meta.capability !== 'pure-api') {
+        throw new Error(
+            `Tool '${meta.name}' has capability '${meta.capability}' and cannot run on a hosted server. ` +
+                `Only 'pure-api' tools may be registered. This is a programmer error — ` +
+                `filter tools via pureApiTools before registering.`
+        );
+    }
+}
+
+/**
+ * Assert the process was launched in hosted mode. Called at bin startup.
+ * Config schema already enforces this (mode: z.literal('hosted')), but
+ * this provides a clearer error message if the hosted runtime is ever
+ * imported and misused programmatically.
+ */
+export function assertHostedMode(): void {
+    if (process.env.GHP_MCP_MODE !== 'hosted') {
+        throw new Error(
+            `ghp-mcp-hosted requires GHP_MCP_MODE=hosted. ` +
+                `Current value: '${process.env.GHP_MCP_MODE ?? '<unset>'}'. ` +
+                `Refusing to start — this guard prevents the hosted HTTP surface ` +
+                `from being launched in a local dev context by accident.`
+        );
+    }
+}

--- a/packages/mcp-hosted/tsconfig.json
+++ b/packages/mcp-hosted/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/mcp/src/bin.ts
+++ b/packages/mcp/src/bin.ts
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import type { RepoInfo } from '@bretwardjames/ghp-core';
+import { createServer } from './server.js';
+import { createTokenProvider } from './auth/token-provider.js';
+import { registerEnabledTools } from './tool-registry.js';
+import { registerAllResources } from './resources/index.js';
+
+/**
+ * ghp MCP Server
+ *
+ * Exposes GitHub Projects functionality to AI assistants via the
+ * Model Context Protocol.
+ *
+ * Usage:
+ *   ghp-mcp                         # auto-detect repo from cwd
+ *   ghp-mcp --repo owner/name       # lock to a specific repo
+ */
+
+function parseRepoArg(): RepoInfo | undefined {
+    const idx = process.argv.indexOf('--repo');
+    if (idx === -1) {
+        return undefined;
+    }
+
+    const value = process.argv[idx + 1];
+    if (!value || !value.includes('/')) {
+        console.error('Error: --repo requires owner/name format (e.g., --repo bretwardjames/ghp)');
+        process.exit(1);
+    }
+
+    const [owner, ...rest] = value.split('/');
+    const name = rest.join('/');
+    return { owner, name, fullName: `${owner}/${name}` };
+}
+
+async function main(): Promise<void> {
+    const lockedRepo = parseRepoArg();
+    const tokenProvider = createTokenProvider();
+    const { server, context } = createServer(tokenProvider, lockedRepo);
+
+    // Register all tools and resources
+    registerEnabledTools(server, context);
+    registerAllResources(server, context);
+
+    // Connect via stdio
+    const transport = new StdioServerTransport();
+    await server.connect(transport);
+}
+
+main().catch((error) => {
+    console.error('Failed to start MCP server:', error);
+    process.exit(1);
+});

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -1,55 +1,33 @@
-#!/usr/bin/env node
-
-import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
-import type { RepoInfo } from '@bretwardjames/ghp-core';
-import { createServer } from './server.js';
-import { createTokenProvider } from './auth/token-provider.js';
-import { registerEnabledTools } from './tool-registry.js';
-import { registerAllResources } from './resources/index.js';
-
 /**
- * ghp MCP Server
+ * Library exports for @bretwardjames/ghp-mcp.
  *
- * Exposes GitHub Projects functionality to AI assistants via the
- * Model Context Protocol.
- *
- * Usage:
- *   ghp-mcp                         # auto-detect repo from cwd
- *   ghp-mcp --repo owner/name       # lock to a specific repo
+ * Consumers (including the sibling @bretwardjames/ghp-mcp-hosted package)
+ * can import the reusable runtime surface from here without triggering the
+ * stdio bin. The bin lives at `./bin.js` and is only invoked when the
+ * `ghp-mcp` command is run.
  */
 
-function parseRepoArg(): RepoInfo | undefined {
-    const idx = process.argv.indexOf('--repo');
-    if (idx === -1) {
-        return undefined;
-    }
+export { createServer } from './server.js';
+export type { ServerContext } from './server.js';
 
-    const value = process.argv[idx + 1];
-    if (!value || !value.includes('/')) {
-        console.error('Error: --repo requires owner/name format (e.g., --repo bretwardjames/ghp)');
-        process.exit(1);
-    }
+export {
+    registerEnabledTools,
+    loadMcpConfig,
+    loadHooksConfig,
+    getConfigValue,
+    getToolList,
+    getToolsByCapability,
+    pureApiTools,
+    localOnlyTools,
+} from './tool-registry.js';
+export type { HooksConfig } from './tool-registry.js';
 
-    const [owner, ...rest] = value.split('/');
-    const name = rest.join('/');
-    return { owner, name, fullName: `${owner}/${name}` };
-}
+export type {
+    ToolCategory,
+    ToolCapability,
+    ToolMeta,
+    McpConfig,
+    McpToolsConfig,
+} from './types.js';
 
-async function main(): Promise<void> {
-    const lockedRepo = parseRepoArg();
-    const tokenProvider = createTokenProvider();
-    const { server, context } = createServer(tokenProvider, lockedRepo);
-
-    // Register all tools and resources
-    registerEnabledTools(server, context);
-    registerAllResources(server, context);
-
-    // Connect via stdio
-    const transport = new StdioServerTransport();
-    await server.connect(transport);
-}
-
-main().catch((error) => {
-    console.error('Failed to start MCP server:', error);
-    process.exit(1);
-});
+export { registerAllResources } from './resources/index.js';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -115,6 +115,46 @@ importers:
         specifier: ^3.0.5
         version: 3.2.4(@types/node@20.19.30)
 
+  packages/mcp-hosted:
+    dependencies:
+      '@bretwardjames/ghp-core':
+        specifier: workspace:*
+        version: link:../core
+      '@bretwardjames/ghp-mcp':
+        specifier: workspace:*
+        version: link:../mcp
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.0.0
+        version: 1.25.3(hono@4.11.4)(zod@3.25.76)
+      express:
+        specifier: ^4.21.1
+        version: 4.22.1
+      zod:
+        specifier: ^3.22.0
+        version: 3.25.76
+    devDependencies:
+      '@types/express':
+        specifier: ^4.17.21
+        version: 4.17.25
+      '@types/node':
+        specifier: ^20.10.0
+        version: 20.19.30
+      '@types/supertest':
+        specifier: ^6.0.2
+        version: 6.0.3
+      supertest:
+        specifier: ^7.0.0
+        version: 7.2.2
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.1(postcss@8.5.6)(typescript@5.9.3)
+      typescript:
+        specifier: ^5.3.2
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.5
+        version: 3.2.4(@types/node@20.19.30)
+
 packages:
 
   '@anthropic-ai/sdk@0.71.2':
@@ -416,6 +456,10 @@ packages:
       '@cfworker/json-schema':
         optional: true
 
+  '@noble/hashes@1.8.0':
+    resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
+    engines: {node: ^14.21.3 || >=16}
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -471,6 +515,9 @@ packages:
 
   '@octokit/types@16.0.0':
     resolution: {integrity: sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==}
+
+  '@paralleldrive/cuid2@2.3.1':
+    resolution: {integrity: sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==}
 
   '@rollup/rollup-android-arm-eabi@4.55.2':
     resolution: {integrity: sha512-21J6xzayjy3O6NdnlO6aXi/urvSRjm6nCI6+nF6ra2YofKruGixN9kfT+dt55HVNwfDmpDHJcaS3JuP/boNnlA==}
@@ -597,8 +644,17 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@types/body-parser@1.19.6':
+    resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
+
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/connect@3.4.38':
+    resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
+
+  '@types/cookiejar@2.1.5':
+    resolution: {integrity: sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==}
 
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
@@ -606,8 +662,23 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/express-serve-static-core@4.19.8':
+    resolution: {integrity: sha512-02S5fmqeoKzVZCHPZid4b8JH2eM5HzQLZWN2FohQEy/0eXTq8VXZfSN6Pcr3F6N9R/vNrj7cpgbhjie6m/1tCA==}
+
+  '@types/express@4.17.25':
+    resolution: {integrity: sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==}
+
+  '@types/http-errors@2.0.5':
+    resolution: {integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==}
+
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  '@types/methods@1.1.4':
+    resolution: {integrity: sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==}
+
+  '@types/mime@1.3.5':
+    resolution: {integrity: sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==}
 
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
@@ -615,8 +686,29 @@ packages:
   '@types/node@20.19.30':
     resolution: {integrity: sha512-WJtwWJu7UdlvzEAUm484QNg5eAoq5QR08KDNx7g45Usrs2NtOPiX8ugDqmKdXkyL03rBqU5dYNYVQetEpBHq2g==}
 
+  '@types/qs@6.15.0':
+    resolution: {integrity: sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow==}
+
+  '@types/range-parser@1.2.7':
+    resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
+
   '@types/semver@7.7.1':
     resolution: {integrity: sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==}
+
+  '@types/send@0.17.6':
+    resolution: {integrity: sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og==}
+
+  '@types/send@1.2.1':
+    resolution: {integrity: sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==}
+
+  '@types/serve-static@1.15.10':
+    resolution: {integrity: sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw==}
+
+  '@types/superagent@8.1.9':
+    resolution: {integrity: sha512-pTVjI73witn+9ILmoJdajHGW2jkSaOzhiFYF1Rd3EQ94kymLqB9PjD9ISg7WaALC7+dCHT0FGe9T2LktLq/3GQ==}
+
+  '@types/supertest@6.0.3':
+    resolution: {integrity: sha512-8WzXq62EXFhJ7QsH3Ocb/iKQ/Ty9ZVWnVzoTKc9tyyFRRF3a74Tk2+TLFgaFFw364Ere+npzHKEJ6ga2LzIL7w==}
 
   '@types/vscode@1.108.1':
     resolution: {integrity: sha512-DerV0BbSzt87TbrqmZ7lRDIYaMiqvP8tmJTzW2p49ZBVtGUnGAu2RGQd1Wv4XMzEVUpaHbsemVM5nfuQJj7H6w==}
@@ -711,6 +803,10 @@ packages:
   '@vitest/utils@3.2.4':
     resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
 
+  accepts@1.3.8:
+    resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
+    engines: {node: '>= 0.6'}
+
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
@@ -760,13 +856,22 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
+  array-flatten@1.1.1:
+    resolution: {integrity: sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==}
+
   array-union@2.1.0:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
     engines: {node: '>=8'}
 
+  asap@2.0.6:
+    resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
+
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
@@ -774,6 +879,10 @@ packages:
   better-path-resolve@1.0.0:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
+
+  body-parser@1.20.4:
+    resolution: {integrity: sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==}
+    engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
 
   body-parser@2.2.2:
     resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
@@ -849,6 +958,10 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
+
   commander@12.1.0:
     resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
     engines: {node: '>=18'}
@@ -856,6 +969,9 @@ packages:
   commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
     engines: {node: '>= 6'}
+
+  component-emitter@1.3.1:
+    resolution: {integrity: sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==}
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
@@ -867,6 +983,10 @@ packages:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
     engines: {node: ^14.18.0 || >=16.10.0}
 
+  content-disposition@0.5.4:
+    resolution: {integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==}
+    engines: {node: '>= 0.6'}
+
   content-disposition@1.0.1:
     resolution: {integrity: sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==}
     engines: {node: '>=18'}
@@ -874,6 +994,9 @@ packages:
   content-type@1.0.5:
     resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
     engines: {node: '>= 0.6'}
+
+  cookie-signature@1.0.7:
+    resolution: {integrity: sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==}
 
   cookie-signature@1.2.2:
     resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
@@ -883,6 +1006,9 @@ packages:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
 
+  cookiejar@2.1.4:
+    resolution: {integrity: sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==}
+
   cors@2.8.5:
     resolution: {integrity: sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==}
     engines: {node: '>= 0.10'}
@@ -890,6 +1016,14 @@ packages:
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
+
+  debug@2.6.9:
+    resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -907,6 +1041,10 @@ packages:
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
+
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
@@ -914,9 +1052,16 @@ packages:
   deprecation@2.3.1:
     resolution: {integrity: sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==}
 
+  destroy@1.2.0:
+    resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
+    engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
+
   detect-indent@6.1.0:
     resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
     engines: {node: '>=8'}
+
+  dezalgo@1.0.4:
+    resolution: {integrity: sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==}
 
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
@@ -954,6 +1099,10 @@ packages:
 
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
+
+  es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
     engines: {node: '>= 0.4'}
 
   esbuild@0.27.2:
@@ -1032,6 +1181,10 @@ packages:
     peerDependencies:
       express: '>= 4.11'
 
+  express@4.22.1:
+    resolution: {integrity: sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==}
+    engines: {node: '>= 0.10.0'}
+
   express@5.2.1:
     resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
     engines: {node: '>= 18'}
@@ -1054,6 +1207,9 @@ packages:
 
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  fast-safe-stringify@2.1.1:
+    resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
 
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
@@ -1078,6 +1234,10 @@ packages:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
 
+  finalhandler@1.3.2:
+    resolution: {integrity: sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==}
+    engines: {node: '>= 0.8'}
+
   finalhandler@2.1.1:
     resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
     engines: {node: '>= 18.0.0'}
@@ -1100,8 +1260,20 @@ packages:
   flatted@3.3.3:
     resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
 
+  form-data@4.0.5:
+    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+    engines: {node: '>= 6'}
+
+  formidable@3.5.4:
+    resolution: {integrity: sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==}
+    engines: {node: '>=14.0.0'}
+
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
+  fresh@0.5.2:
+    resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
     engines: {node: '>= 0.6'}
 
   fresh@2.0.0:
@@ -1173,6 +1345,10 @@ packages:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
     engines: {node: '>= 0.4'}
 
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
+    engines: {node: '>= 0.4'}
+
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
@@ -1188,6 +1364,10 @@ packages:
   human-id@4.1.3:
     resolution: {integrity: sha512-tsYlhAYpjCKa//8rXZ9DqKEawhPoSytweBC2eNvcaDK+57RZLHGqNs3PZTQO6yekLFSuvA6AlnAfrw1uBvtb+Q==}
     hasBin: true
+
+  iconv-lite@0.4.24:
+    resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
+    engines: {node: '>=0.10.0'}
 
   iconv-lite@0.7.2:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
@@ -1328,9 +1508,16 @@ packages:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
+  media-typer@0.3.0:
+    resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
+    engines: {node: '>= 0.6'}
+
   media-typer@1.1.0:
     resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
     engines: {node: '>= 0.8'}
+
+  merge-descriptors@1.0.3:
+    resolution: {integrity: sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==}
 
   merge-descriptors@2.0.0:
     resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
@@ -1340,17 +1527,39 @@ packages:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
 
+  methods@1.1.2:
+    resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
+    engines: {node: '>= 0.6'}
+
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
+
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
 
   mime-db@1.54.0:
     resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
     engines: {node: '>= 0.6'}
 
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+
   mime-types@3.0.2:
     resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
     engines: {node: '>=18'}
+
+  mime@1.6.0:
+    resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==}
+    engines: {node: '>=4'}
+    hasBin: true
+
+  mime@2.6.0:
+    resolution: {integrity: sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==}
+    engines: {node: '>=4.0.0'}
+    hasBin: true
 
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
@@ -1366,6 +1575,9 @@ packages:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
     engines: {node: '>=4'}
 
+  ms@2.0.0:
+    resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -1379,6 +1591,10 @@ packages:
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  negotiator@0.6.3:
+    resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
+    engines: {node: '>= 0.6'}
 
   negotiator@1.0.0:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
@@ -1456,6 +1672,9 @@ packages:
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
+
+  path-to-regexp@0.1.13:
+    resolution: {integrity: sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==}
 
   path-to-regexp@8.3.0:
     resolution: {integrity: sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==}
@@ -1550,6 +1769,10 @@ packages:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
     engines: {node: '>= 0.6'}
 
+  raw-body@2.5.3:
+    resolution: {integrity: sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==}
+    engines: {node: '>= 0.8'}
+
   raw-body@3.0.2:
     resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
     engines: {node: '>= 0.10'}
@@ -1595,6 +1818,9 @@ packages:
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
@@ -1603,9 +1829,17 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  send@0.19.2:
+    resolution: {integrity: sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==}
+    engines: {node: '>= 0.8.0'}
+
   send@1.2.1:
     resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
     engines: {node: '>= 18'}
+
+  serve-static@1.16.3:
+    resolution: {integrity: sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==}
+    engines: {node: '>= 0.8.0'}
 
   serve-static@2.2.1:
     resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
@@ -1692,6 +1926,14 @@ packages:
     resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
     engines: {node: '>=16 || 14 >=14.17'}
     hasBin: true
+
+  superagent@10.3.0:
+    resolution: {integrity: sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ==}
+    engines: {node: '>=14.18.0'}
+
+  supertest@7.2.2:
+    resolution: {integrity: sha512-oK8WG9diS3DlhdUkcFn4tkNIiIbBx9lI2ClF8K+b2/m8Eyv47LSawxUzZQSNKUrVb2KsqeTDCcjAAVPYaSLVTA==}
+    engines: {node: '>=14.18.0'}
 
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
@@ -1818,6 +2060,10 @@ packages:
     resolution: {integrity: sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==}
     engines: {node: '>=10'}
 
+  type-is@1.6.18:
+    resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
+    engines: {node: '>= 0.6'}
+
   type-is@2.0.1:
     resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
     engines: {node: '>= 0.6'}
@@ -1849,6 +2095,10 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  utils-merge@1.0.1:
+    resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
+    engines: {node: '>= 0.4.0'}
 
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
@@ -2286,6 +2536,8 @@ snapshots:
       - hono
       - supports-color
 
+  '@noble/hashes@1.8.0': {}
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -2356,6 +2608,10 @@ snapshots:
   '@octokit/types@16.0.0':
     dependencies:
       '@octokit/openapi-types': 27.0.0
+
+  '@paralleldrive/cuid2@2.3.1':
+    dependencies:
+      '@noble/hashes': 1.8.0
 
   '@rollup/rollup-android-arm-eabi@4.55.2':
     optional: true
@@ -2432,16 +2688,47 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.55.2':
     optional: true
 
+  '@types/body-parser@1.19.6':
+    dependencies:
+      '@types/connect': 3.4.38
+      '@types/node': 20.19.30
+
   '@types/chai@5.2.3':
     dependencies:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
+  '@types/connect@3.4.38':
+    dependencies:
+      '@types/node': 20.19.30
+
+  '@types/cookiejar@2.1.5': {}
+
   '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.8': {}
 
+  '@types/express-serve-static-core@4.19.8':
+    dependencies:
+      '@types/node': 20.19.30
+      '@types/qs': 6.15.0
+      '@types/range-parser': 1.2.7
+      '@types/send': 1.2.1
+
+  '@types/express@4.17.25':
+    dependencies:
+      '@types/body-parser': 1.19.6
+      '@types/express-serve-static-core': 4.19.8
+      '@types/qs': 6.15.0
+      '@types/serve-static': 1.15.10
+
+  '@types/http-errors@2.0.5': {}
+
   '@types/json-schema@7.0.15': {}
+
+  '@types/methods@1.1.4': {}
+
+  '@types/mime@1.3.5': {}
 
   '@types/node@12.20.55': {}
 
@@ -2449,7 +2736,38 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  '@types/qs@6.15.0': {}
+
+  '@types/range-parser@1.2.7': {}
+
   '@types/semver@7.7.1': {}
+
+  '@types/send@0.17.6':
+    dependencies:
+      '@types/mime': 1.3.5
+      '@types/node': 20.19.30
+
+  '@types/send@1.2.1':
+    dependencies:
+      '@types/node': 20.19.30
+
+  '@types/serve-static@1.15.10':
+    dependencies:
+      '@types/http-errors': 2.0.5
+      '@types/node': 20.19.30
+      '@types/send': 0.17.6
+
+  '@types/superagent@8.1.9':
+    dependencies:
+      '@types/cookiejar': 2.1.5
+      '@types/methods': 1.1.4
+      '@types/node': 20.19.30
+      form-data: 4.0.5
+
+  '@types/supertest@6.0.3':
+    dependencies:
+      '@types/methods': 1.1.4
+      '@types/superagent': 8.1.9
 
   '@types/vscode@1.108.1': {}
 
@@ -2583,6 +2901,11 @@ snapshots:
       loupe: 3.2.1
       tinyrainbow: 2.0.0
 
+  accepts@1.3.8:
+    dependencies:
+      mime-types: 2.1.35
+      negotiator: 0.6.3
+
   accepts@2.0.0:
     dependencies:
       mime-types: 3.0.2
@@ -2628,15 +2951,38 @@ snapshots:
 
   argparse@2.0.1: {}
 
+  array-flatten@1.1.1: {}
+
   array-union@2.1.0: {}
 
+  asap@2.0.6: {}
+
   assertion-error@2.0.1: {}
+
+  asynckit@0.4.0: {}
 
   balanced-match@1.0.2: {}
 
   better-path-resolve@1.0.0:
     dependencies:
       is-windows: 1.0.2
+
+  body-parser@1.20.4:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 2.6.9
+      depd: 2.0.0
+      destroy: 1.2.0
+      http-errors: 2.0.1
+      iconv-lite: 0.4.24
+      on-finished: 2.4.1
+      qs: 6.14.1
+      raw-body: 2.5.3
+      type-is: 1.6.18
+      unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
 
   body-parser@2.2.2:
     dependencies:
@@ -2717,9 +3063,15 @@ snapshots:
 
   color-name@1.1.4: {}
 
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
+
   commander@12.1.0: {}
 
   commander@4.1.1: {}
+
+  component-emitter@1.3.1: {}
 
   concat-map@0.0.1: {}
 
@@ -2727,13 +3079,21 @@ snapshots:
 
   consola@3.4.2: {}
 
+  content-disposition@0.5.4:
+    dependencies:
+      safe-buffer: 5.2.1
+
   content-disposition@1.0.1: {}
 
   content-type@1.0.5: {}
 
+  cookie-signature@1.0.7: {}
+
   cookie-signature@1.2.2: {}
 
   cookie@0.7.2: {}
+
+  cookiejar@2.1.4: {}
 
   cors@2.8.5:
     dependencies:
@@ -2746,6 +3106,10 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  debug@2.6.9:
+    dependencies:
+      ms: 2.0.0
+
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
@@ -2754,11 +3118,20 @@ snapshots:
 
   deep-is@0.1.4: {}
 
+  delayed-stream@1.0.0: {}
+
   depd@2.0.0: {}
 
   deprecation@2.3.1: {}
 
+  destroy@1.2.0: {}
+
   detect-indent@6.1.0: {}
+
+  dezalgo@1.0.4:
+    dependencies:
+      asap: 2.0.6
+      wrappy: 1.0.2
 
   dir-glob@3.0.1:
     dependencies:
@@ -2792,6 +3165,13 @@ snapshots:
   es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
+
+  es-set-tostringtag@2.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.2
 
   esbuild@0.27.2:
     optionalDependencies:
@@ -2914,6 +3294,42 @@ snapshots:
     dependencies:
       express: 5.2.1
 
+  express@4.22.1:
+    dependencies:
+      accepts: 1.3.8
+      array-flatten: 1.1.1
+      body-parser: 1.20.4
+      content-disposition: 0.5.4
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.0.7
+      debug: 2.6.9
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 1.3.2
+      fresh: 0.5.2
+      http-errors: 2.0.1
+      merge-descriptors: 1.0.3
+      methods: 1.1.2
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      path-to-regexp: 0.1.13
+      proxy-addr: 2.0.7
+      qs: 6.14.1
+      range-parser: 1.2.1
+      safe-buffer: 5.2.1
+      send: 0.19.2
+      serve-static: 1.16.3
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      type-is: 1.6.18
+      utils-merge: 1.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+
   express@5.2.1:
     dependencies:
       accepts: 2.0.0
@@ -2965,6 +3381,8 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fast-safe-stringify@2.1.1: {}
+
   fast-uri@3.1.0: {}
 
   fastq@1.20.1:
@@ -2982,6 +3400,18 @@ snapshots:
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
+
+  finalhandler@1.3.2:
+    dependencies:
+      debug: 2.6.9
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+      unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
 
   finalhandler@2.1.1:
     dependencies:
@@ -3018,7 +3448,23 @@ snapshots:
 
   flatted@3.3.3: {}
 
+  form-data@4.0.5:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.2
+      mime-types: 2.1.35
+
+  formidable@3.5.4:
+    dependencies:
+      '@paralleldrive/cuid2': 2.3.1
+      dezalgo: 1.0.4
+      once: 1.4.0
+
   forwarded@0.2.0: {}
+
+  fresh@0.5.2: {}
 
   fresh@2.0.0: {}
 
@@ -3099,6 +3545,10 @@ snapshots:
 
   has-symbols@1.1.0: {}
 
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.1.0
+
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
@@ -3114,6 +3564,10 @@ snapshots:
       toidentifier: 1.0.1
 
   human-id@4.1.3: {}
+
+  iconv-lite@0.4.24:
+    dependencies:
+      safer-buffer: 2.1.2
 
   iconv-lite@0.7.2:
     dependencies:
@@ -3226,22 +3680,38 @@ snapshots:
 
   math-intrinsics@1.1.0: {}
 
+  media-typer@0.3.0: {}
+
   media-typer@1.1.0: {}
+
+  merge-descriptors@1.0.3: {}
 
   merge-descriptors@2.0.0: {}
 
   merge2@1.4.1: {}
+
+  methods@1.1.2: {}
 
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
       picomatch: 2.3.1
 
+  mime-db@1.52.0: {}
+
   mime-db@1.54.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
 
   mime-types@3.0.2:
     dependencies:
       mime-db: 1.54.0
+
+  mime@1.6.0: {}
+
+  mime@2.6.0: {}
 
   minimatch@3.1.2:
     dependencies:
@@ -3260,6 +3730,8 @@ snapshots:
 
   mri@1.2.0: {}
 
+  ms@2.0.0: {}
+
   ms@2.1.3: {}
 
   mz@2.7.0:
@@ -3271,6 +3743,8 @@ snapshots:
   nanoid@3.3.11: {}
 
   natural-compare@1.4.0: {}
+
+  negotiator@0.6.3: {}
 
   negotiator@1.0.0: {}
 
@@ -3337,6 +3811,8 @@ snapshots:
 
   path-key@3.1.1: {}
 
+  path-to-regexp@0.1.13: {}
+
   path-to-regexp@8.3.0: {}
 
   path-type@4.0.0: {}
@@ -3395,6 +3871,13 @@ snapshots:
   queue-microtask@1.2.3: {}
 
   range-parser@1.2.1: {}
+
+  raw-body@2.5.3:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.4.24
+      unpipe: 1.0.0
 
   raw-body@3.0.2:
     dependencies:
@@ -3469,9 +3952,29 @@ snapshots:
     dependencies:
       queue-microtask: 1.2.3
 
+  safe-buffer@5.2.1: {}
+
   safer-buffer@2.1.2: {}
 
   semver@7.7.3: {}
+
+  send@0.19.2:
+    dependencies:
+      debug: 2.6.9
+      depd: 2.0.0
+      destroy: 1.2.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 0.5.2
+      http-errors: 2.0.1
+      mime: 1.6.0
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   send@1.2.1:
     dependencies:
@@ -3486,6 +3989,15 @@ snapshots:
       on-finished: 2.4.1
       range-parser: 1.2.1
       statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@1.16.3:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 0.19.2
     transitivePeerDependencies:
       - supports-color
 
@@ -3578,6 +4090,28 @@ snapshots:
       pirates: 4.0.7
       tinyglobby: 0.2.15
       ts-interface-checker: 0.1.13
+
+  superagent@10.3.0:
+    dependencies:
+      component-emitter: 1.3.1
+      cookiejar: 2.1.4
+      debug: 4.4.3
+      fast-safe-stringify: 2.1.1
+      form-data: 4.0.5
+      formidable: 3.5.4
+      methods: 1.1.2
+      mime: 2.6.0
+      qs: 6.14.1
+    transitivePeerDependencies:
+      - supports-color
+
+  supertest@7.2.2:
+    dependencies:
+      cookie-signature: 1.2.2
+      methods: 1.1.2
+      superagent: 10.3.0
+    transitivePeerDependencies:
+      - supports-color
 
   supports-color@7.2.0:
     dependencies:
@@ -3687,6 +4221,11 @@ snapshots:
 
   type-fest@0.20.2: {}
 
+  type-is@1.6.18:
+    dependencies:
+      media-typer: 0.3.0
+      mime-types: 2.1.35
+
   type-is@2.0.1:
     dependencies:
       content-type: 1.0.5
@@ -3710,6 +4249,8 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  utils-merge@1.0.1: {}
 
   vary@1.1.2: {}
 


### PR DESCRIPTION
Part of #276. Closes #278.

## Summary

Adds `@bretwardjames/ghp-mcp-hosted` — an HTTP-transport sibling of the stdio `@bretwardjames/ghp-mcp` — so that multi-tenant AI platforms (runtight first) can expose GHP tools over the network with per-request Bearer auth.

## What's in the new package

- **Express app** with MCP Streamable HTTP at `POST /mcp`.
- **Per-request isolation:** each request creates its own `McpServer` + `BearerTokenProvider` + transport. No cross-request state.
- **Capability filter:** only `pureApiTools` from `@bretwardjames/ghp-mcp` are registered. Local-only tools (worktree, merge-pr, release, etc.) cannot be invoked.
- **Defense in depth:** `assertHostedSafe()` re-validates every tool's capability at `createApp` startup; mode guard rejects startup unless `GHP_MCP_MODE=hosted`.
- **OAuth discovery stubs** at `/.well-known/oauth-protected-resource` and `/.well-known/oauth-authorization-server`, returning 501 until #279 lands. Keeps the spec surface visible to MCP clients probing for auth metadata.
- **Env schema** via zod. `GHP_REPO` and `GHP_MCP_MODE=hosted` required. HTTPS baseUrl enforced in production.

## Supporting change in `@bretwardjames/ghp-mcp`

Split the package to let the hosted sibling import the reusable runtime without triggering the stdio bootstrap:

- `src/bin.ts` — the shebang'd stdio CLI entry (unchanged behavior).
- `src/index.ts` — library exports (`createServer`, `registerEnabledTools`, `pureApiTools`, `localOnlyTools`, types).
- `package.json`: `bin` → `dist/bin.js`, `main` → `dist/index.js`. Both built from the same tsup invocation.

## Stdio behavior is unchanged

- `ghp-mcp` binary still has the same shebang, same 28-tool surface, same `RepoContext.auto()` behavior when no `--repo` is passed.
- Verified: `pnpm --filter @bretwardjames/ghp-mcp test` → 18/18 pass.
- No Claude Desktop config change required for existing users.

## Why

Runtight already supports `streamable-http` transport + `per_user` OAuth. The missing piece was on the GHP side — a hostable binary with HTTP + Bearer auth. This PR delivers that binary; #279 will add proper OAuth 2.1 + PKCE + RFC 9728 discovery to replace the PAT-via-Bearer flow used today; #280 packages it for Railway.

## Decisions made

- **Separate package, not a build-mode of `ghp-mcp`.** Lets us version/publish independently and keeps the local npm global install (`npm install -g @bretwardjames/ghp-mcp`) identical to what it is today. Zero risk of clobbering Claude Desktop users.
- **Require `GHP_REPO`.** Rejected the "optional, auto-detect via git remote" path because a hosted process has no meaningful cwd repo — auto-detection would shell out and silently serve the hoster's repo to all tenants.
- **No persistent token storage.** Tokens live in per-request `BearerTokenProvider` instances and are discarded when the response closes. Matches MCP spec intent and the "stateless hosted server" goal.
- **Pre-build `McpConfig` once.** Addresses a real issue where the default call path of `registerEnabledTools` would `loadMcpConfig()` per request (reading `~/.config/ghp-cli` + running `git rev-parse`).
- **`logLevel` removed.** Parsed but never consumed in this build; re-add in #279 alongside real pino logging.

## Code review applied

Two critical + four important findings from the `pr-review-toolkit:code-reviewer` agent:

| # | Severity | Finding | Fix |
|---|----------|---------|-----|
| C1 | critical | Per-request `execSync('git')` + homedir reads via `loadMcpConfig` | Pre-build `McpConfig` once at `createApp` |
| C2 | critical | Unset `lockedRepo` → `RepoContext.auto()` shells out | Make `GHP_REPO` required in schema |
| I1 | important | No OPTIONS preflight handler → browser CORS blocks POST | Added `app.options('/mcp')` returning 204 |
| I2 | important | `res.on('close')` registered before `server.connect` | Moved registration after `connect` |
| I3 | important | `GHP_LOG_LEVEL` advertised but unused | Removed from schema |
| I4 | important | Redundant per-request `assertHostedSafe` loop | Moved to one-shot at `createApp` |

Plus a new **cross-tenant isolation test** (two concurrent `tools/list` requests with different Bearer tokens must return identical pure-api-only tool sets) hardens the multi-tenancy claim.

## Tests

| Package | Tests |
|---------|-------|
| `@bretwardjames/ghp-mcp-hosted` | **30/30 pass** (4 test files: config, bearer, mode-guard, http integration via supertest) |
| `@bretwardjames/ghp-mcp` | 18/18 pass (unchanged) |
| `@bretwardjames/ghp-core` | 97/97 pass (unchanged) |
| `@bretwardjames/ghp-cli` | 111 pass, 2 pre-existing failures in `add-issue.test.ts` (reproduce on main, unrelated) |

Workspace build: clean.
Workspace lint: pre-existing failure on main (CLI eslint config missing). No change.

## Smoke test

```bash
pnpm build
GHP_MCP_MODE=hosted GHP_REPO=bretwardjames/ghp PORT=3199 \
  node packages/mcp-hosted/dist/bin.js &

curl http://localhost:3199/healthz
# → ok

curl -X POST http://localhost:3199/mcp \
  -H "Authorization: Bearer $(gh auth token)" \
  -H 'Content-Type: application/json' \
  -H 'Accept: application/json, text/event-stream' \
  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}'
# → event-stream containing only pure-api tools (get_my_work, move_issue, etc.)
#   and never create_worktree, merge_pr, etc.
```

## Follow-ups

- **#279** — OAuth 2.1 + PKCE + RFC 9728 discovery (replaces the PAT-via-Bearer dev path).
- **#280** — Dockerfile + Railway deploy config (produces the deployable image).
- **#281** — Register in runtight + E2E integration tests.
- **CI ticket (new)** — add a GitHub Actions workflow running build + tests on every PR. Agreed to land after this and before #279 since OAuth is where CI really starts earning its keep.

## Test plan

- [x] `pnpm --filter @bretwardjames/ghp-mcp-hosted build` clean
- [x] `pnpm --filter @bretwardjames/ghp-mcp-hosted test` — 30/30 pass
- [x] `pnpm --filter @bretwardjames/ghp-mcp build` clean, 18/18 tests pass
- [x] `pnpm build` (workspace) clean
- [x] Local smoke test: `ghp-mcp-hosted` binary starts, serves `/healthz`, 401s without auth, returns pure-api tool list with fake bearer
- [ ] Reviewer runs the smoke test above with their own `gh auth token`
- [ ] Claude Desktop sanity check: `ghp-mcp` still shows all 28 tools (bin path changed from `dist/index.js` to `dist/bin.js`, verify no regression for anyone who has `@bretwardjames/ghp-mcp` installed globally)

---
Generated with [Claude Code](https://claude.ai/code)