### PR TITLE
Hosted GHP MCP: OAuth 2.1 + PKCE + RFC 9728 discovery

### DIFF
--- a/packages/mcp-hosted/README.md
+++ b/packages/mcp-hosted/README.md
@@ -24,21 +24,37 @@ The stdio server is **not replaced** — power users and local agents keep it. T
 pnpm build
 GHP_MCP_MODE=hosted \
 GHP_REPO=bretwardjames/ghp \
-PORT=3000 \
+GHP_GITHUB_OAUTH_CLIENT_ID=<your-app-client-id> \
+GHP_GITHUB_OAUTH_CLIENT_SECRET=<your-app-client-secret> \
+GHP_ALLOWED_REDIRECT_URIS=https://runtight.example.com/oauth/callback \
+GHP_HOSTED_BASE_URL=https://your-tailscale-funnel.ts.net \
+PORT=8731 \
   node packages/mcp-hosted/dist/bin.js
 ```
 
-`GHP_REPO` is required — the hosted server is scoped to a single GitHub
-repo per instance. Spin up multiple instances (one per repo) to serve
-multiple projects.
+Required setup:
+
+1. **GitHub OAuth App.** Create one at https://github.com/settings/developers.
+   Callback URL: `<GHP_HOSTED_BASE_URL>/oauth/callback`. Scopes: `read:project`, `project`, `repo`.
+2. **Public HTTPS tunnel.** GitHub's consent page has to be able to redirect
+   back to your callback. For dev use Tailscale Funnel:
+   ```bash
+   tailscale funnel --bg --https=8443 http://localhost:8731
+   ```
+   Set `GHP_HOSTED_BASE_URL=https://<machine>.tail-xxx.ts.net:8443`.
+3. **Redirect URI allowlist.** `GHP_ALLOWED_REDIRECT_URIS` must include the
+   exact `redirect_uri` your MCP client (runtight, etc.) uses.
+
+`GHP_REPO` scopes the server to a single GitHub repo per instance — spin
+up multiple instances (one per repo) to serve multiple projects.
 
 Probe:
 
 ```bash
-curl http://localhost:3000/healthz
+curl http://localhost:8731/healthz
 # ok
 
-curl -X POST http://localhost:3000/mcp \
+curl -X POST http://localhost:8731/mcp \
   -H "Authorization: Bearer $(gh auth token)" \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json, text/event-stream' \
@@ -47,24 +63,64 @@ curl -X POST http://localhost:3000/mcp \
 
 ## Environment
 
-| Var                    | Required | Default         | Purpose                                                                       |
-|------------------------|----------|-----------------|-------------------------------------------------------------------------------|
-| `GHP_MCP_MODE`         | yes      | —               | Must be `hosted`. Refuses to start otherwise.                                 |
-| `GHP_REPO`             | yes      | —               | Locks every session to `owner/name`. Without it the server would attempt to  |
-|                        |          |                 | auto-detect via `git remote`, which is meaningless in a hosted context.       |
-| `PORT`                 | no       | `3000`          | HTTP listen port. Railway / Fly inject this.                                  |
-| `GHP_HOSTED_BASE_URL`  | prod     | —               | Public https URL. Required if `NODE_ENV=production`.                          |
-| `GHP_ALLOWED_ORIGINS`  | no       | `*`             | CORS allowlist.                                                               |
-| `NODE_ENV`             | no       | `development`   |                                                                               |
+| Var                              | Required | Default    | Purpose                                                                    |
+|----------------------------------|----------|------------|----------------------------------------------------------------------------|
+| `GHP_MCP_MODE`                   | yes      | —          | Must be `hosted`. Refuses to start otherwise.                              |
+| `GHP_REPO`                       | yes      | —          | Locks every session to `owner/name`.                                       |
+| `GHP_GITHUB_OAUTH_CLIENT_ID`     | yes      | —          | GitHub OAuth App client id (created at https://github.com/settings/developers). |
+| `GHP_GITHUB_OAUTH_CLIENT_SECRET` | yes      | —          | GitHub OAuth App client secret.                                            |
+| `GHP_ALLOWED_REDIRECT_URIS`      | yes      | —          | Comma-separated exact redirect_uri allowlist. MCP clients whose redirect_uri is not in this list are rejected. |
+| `PORT`                           | no       | `8731`     | HTTP listen port. Railway / Fly inject this. 8731 avoids common local collisions. |
+| `GHP_HOSTED_BASE_URL`            | prod     | —          | Public https URL. Required in production. Used to build OAuth metadata + the GitHub callback URL. |
+| `GHP_ALLOWED_ORIGINS`            | no       | `*`        | CORS allowlist.                                                            |
+| `GHP_OAUTH_STATE_TTL_SECONDS`    | no       | `600`      | Ephemeral TTL for authorize state + auth codes.                            |
+| `NODE_ENV`                       | no       | `development` |                                                                         |
 
 ## Endpoints
 
-| Method | Path                                         | Purpose                                          |
-|--------|----------------------------------------------|--------------------------------------------------|
-| GET    | `/healthz`                                   | Plaintext `ok` — Railway / Fly healthcheck.      |
-| GET    | `/.well-known/oauth-protected-resource`      | RFC 9728 metadata. Stub returning 501 until #279.|
-| GET    | `/.well-known/oauth-authorization-server`    | RFC 8414 metadata. Stub returning 501 until #279.|
-| POST   | `/mcp`                                       | MCP Streamable HTTP endpoint.                    |
+| Method | Path                                         | Purpose                                                                    |
+|--------|----------------------------------------------|----------------------------------------------------------------------------|
+| GET    | `/healthz`                                   | Plaintext `ok` — Railway / Fly healthcheck.                                |
+| GET    | `/.well-known/oauth-protected-resource`      | RFC 9728 metadata. Advertises ourselves as the authorization server.       |
+| GET    | `/.well-known/oauth-authorization-server`    | RFC 8414 metadata. Declares `code_challenge_methods_supported: ["S256"]`.  |
+| POST   | `/oauth/register`                            | Dynamic Client Registration (RFC 7591) — validates redirect_uri allowlist. |
+| GET    | `/oauth/authorize`                           | Start the flow. Redirects to GitHub consent with a server-side state.      |
+| GET    | `/oauth/callback`                            | GitHub redirects here. Exchanges code for token, mints our own auth code.  |
+| POST   | `/oauth/token`                               | Exchange our auth code + PKCE verifier for the GitHub access token.        |
+| POST   | `/mcp`                                       | MCP Streamable HTTP endpoint. `Authorization: Bearer <token>` required.    |
+
+## OAuth flow
+
+```
+  MCP client                  Hosted GHP                     GitHub
+      │                            │                            │
+      │ 1. GET .well-known/prm     │                            │
+      │───────────────────────────▶│                            │
+      │ 2. GET .well-known/as      │                            │
+      │───────────────────────────▶│                            │
+      │ 3. POST /oauth/register    │                            │
+      │───────────────────────────▶│                            │
+      │ 4. GET /oauth/authorize    │                            │
+      │    (PKCE challenge)        │                            │
+      │───────────────────────────▶│ 5. Redirect to github      │
+      │                            │───────────────────────────▶│
+      │                            │                            │ user consents
+      │                            │ 6. Callback with code      │
+      │                            │◀───────────────────────────│
+      │                            │ 7. Exchange code → token   │
+      │                            │───────────────────────────▶│
+      │                            │◀──── access_token ─────────│
+      │ 8. Redirect with our code  │                            │
+      │◀───────────────────────────│                            │
+      │ 9. POST /oauth/token       │                            │
+      │    (code + verifier)       │                            │
+      │───────────────────────────▶│ (verify PKCE, return token)│
+      │◀─── github access_token ───│                            │
+```
+
+PKCE is mediated on our side: GitHub OAuth Apps don't natively support PKCE, so the hosted server tracks the client's `code_challenge` in an ephemeral TTL map keyed by the server-side state it sent to GitHub. The client's original state is echoed back verbatim on final redirect.
+
+Token strategy in v1: **pass-through**. The client receives the GitHub Bearer token directly. Lifetime and revocation are GitHub-controlled. Wrapping tokens (where we'd issue an opaque token mapping to a GitHub token) is a possible future iteration if independent revocation is needed.
 
 ## Security model
 

--- a/packages/mcp-hosted/README.md
+++ b/packages/mcp-hosted/README.md
@@ -69,7 +69,7 @@ curl -X POST http://localhost:8731/mcp \
 | `GHP_REPO`                       | yes      | —          | Locks every session to `owner/name`.                                       |
 | `GHP_GITHUB_OAUTH_CLIENT_ID`     | yes      | —          | GitHub OAuth App client id (created at https://github.com/settings/developers). |
 | `GHP_GITHUB_OAUTH_CLIENT_SECRET` | yes      | —          | GitHub OAuth App client secret.                                            |
-| `GHP_ALLOWED_REDIRECT_URIS`      | yes      | —          | Comma-separated exact redirect_uri allowlist. MCP clients whose redirect_uri is not in this list are rejected. |
+| `GHP_ALLOWED_REDIRECT_URIS`      | yes      | —          | Comma-separated exact redirect_uri allowlist. **Exact binary match.** Trailing slash, host casing, and explicit default ports all count — `https://x/cb` ≠ `https://x/cb/` ≠ `https://X/cb` ≠ `https://x:443/cb`. |
 | `PORT`                           | no       | `8731`     | HTTP listen port. Railway / Fly inject this. 8731 avoids common local collisions. |
 | `GHP_HOSTED_BASE_URL`            | prod     | —          | Public https URL. Required in production. Used to build OAuth metadata + the GitHub callback URL. |
 | `GHP_ALLOWED_ORIGINS`            | no       | `*`        | CORS allowlist.                                                            |

--- a/packages/mcp-hosted/src/bin.ts
+++ b/packages/mcp-hosted/src/bin.ts
@@ -9,13 +9,16 @@ import { assertHostedMode } from './mode-guard.js';
  * platforms (runtight, custom AI products).
  *
  * Env:
- *   GHP_MCP_MODE           (required) must be 'hosted'
- *   PORT                   (default 3000)
- *   GHP_HOSTED_BASE_URL    (required in production) public https URL
- *   GHP_REPO               (optional) lock all sessions to owner/name
- *   GHP_ALLOWED_ORIGINS    (default '*') comma-separated CORS allowlist
- *   GHP_LOG_LEVEL          (default 'info')
- *   NODE_ENV               (default 'development')
+ *   GHP_MCP_MODE                      (required) must be 'hosted'
+ *   GHP_REPO                          (required) owner/name lock for every session
+ *   GHP_GITHUB_OAUTH_CLIENT_ID        (required) GitHub OAuth App client id
+ *   GHP_GITHUB_OAUTH_CLIENT_SECRET    (required) GitHub OAuth App client secret
+ *   GHP_ALLOWED_REDIRECT_URIS         (required) comma-separated client redirect_uri allowlist
+ *   PORT                              (default 8731)
+ *   GHP_HOSTED_BASE_URL               (required in production) public https URL
+ *   GHP_ALLOWED_ORIGINS               (default '*') CORS allowlist
+ *   GHP_OAUTH_STATE_TTL_SECONDS       (default 600)
+ *   NODE_ENV                          (default 'development')
  */
 async function main(): Promise<void> {
     assertHostedMode();

--- a/packages/mcp-hosted/src/config.test.ts
+++ b/packages/mcp-hosted/src/config.test.ts
@@ -6,14 +6,23 @@ describe('loadConfig', () => {
         GHP_MCP_MODE: 'hosted',
         PORT: '3000',
         GHP_REPO: 'bretwardjames/ghp',
+        GHP_GITHUB_OAUTH_CLIENT_ID: 'test-client-id',
+        GHP_GITHUB_OAUTH_CLIENT_SECRET: 'test-client-secret',
+        GHP_ALLOWED_REDIRECT_URIS: 'https://runtight.test/oauth/callback',
     };
 
     it('accepts a minimal dev config', () => {
         const cfg = loadConfig({ ...base });
         expect(cfg.mode).toBe('hosted');
-        expect(cfg.port).toBe(3000);
+        expect(cfg.port).toBe(3000); // coerced from the string '3000' in base
         expect(cfg.lockedRepo).toBe('bretwardjames/ghp');
         expect(cfg.nodeEnv).toBe('development');
+    });
+
+    it('defaults PORT to 8731 when unset', () => {
+        const { PORT: _omit, ...withoutPort } = base;
+        const cfg = loadConfig(withoutPort);
+        expect(cfg.port).toBe(8731);
     });
 
     it('refuses to start when GHP_MCP_MODE is not hosted', () => {
@@ -56,6 +65,26 @@ describe('loadConfig', () => {
 
     it('validates GHP_REPO format', () => {
         expect(() => loadConfig({ ...base, GHP_REPO: 'no-slash' })).toThrow();
+    });
+
+    it('requires GHP_GITHUB_OAUTH_CLIENT_ID', () => {
+        const { GHP_GITHUB_OAUTH_CLIENT_ID: _omit, ...without } = base;
+        expect(() => loadConfig(without)).toThrow();
+    });
+
+    it('requires GHP_GITHUB_OAUTH_CLIENT_SECRET', () => {
+        const { GHP_GITHUB_OAUTH_CLIENT_SECRET: _omit, ...without } = base;
+        expect(() => loadConfig(without)).toThrow();
+    });
+
+    it('requires GHP_ALLOWED_REDIRECT_URIS', () => {
+        const { GHP_ALLOWED_REDIRECT_URIS: _omit, ...without } = base;
+        expect(() => loadConfig(without)).toThrow();
+    });
+
+    it('oauthStateTtlSeconds defaults to 600', () => {
+        const cfg = loadConfig({ ...base });
+        expect(cfg.oauthStateTtlSeconds).toBe(600);
     });
 });
 

--- a/packages/mcp-hosted/src/config.ts
+++ b/packages/mcp-hosted/src/config.ts
@@ -9,8 +9,14 @@ import { z } from 'zod';
  */
 const configSchema = z
     .object({
-        /** Port to bind the HTTP server. Railway / Fly inject this. */
-        port: z.coerce.number().int().positive().default(3000),
+        /**
+         * Port to bind the HTTP server. Railway / Fly inject this.
+         * Default 8731 — chosen to avoid collisions with common local
+         * services (Node 3000, Vite 5173, Rails/http-server 8080). When
+         * fronted by Tailscale Funnel the public port is 443/8443/10000
+         * regardless of the local choice.
+         */
+        port: z.coerce.number().int().positive().default(8731),
 
         /**
          * Mode guard. Must be exactly 'hosted' — any other value refuses to
@@ -39,6 +45,30 @@ const configSchema = z
         /** Comma-separated CORS origin allowlist. '*' for dev. */
         allowedOrigins: z.string().default('*'),
 
+        /**
+         * GitHub OAuth App credentials. Required. The hosted server
+         * mediates PKCE between the MCP client and GitHub (which does
+         * not natively support PKCE on OAuth Apps), so the client_id
+         * and client_secret live here, NEVER on the MCP client.
+         */
+        githubOauthClientId: z.string().min(1, 'GHP_GITHUB_OAUTH_CLIENT_ID is required'),
+        githubOauthClientSecret: z
+            .string()
+            .min(1, 'GHP_GITHUB_OAUTH_CLIENT_SECRET is required'),
+
+        /**
+         * Comma-separated allowlist of redirect_uris MCP clients may
+         * use. Exact match. Required — refusing to accept an unknown
+         * redirect target is the primary defence against authorization
+         * code phishing.
+         */
+        allowedRedirectUris: z
+            .string()
+            .min(1, 'GHP_ALLOWED_REDIRECT_URIS is required (comma-separated list)'),
+
+        /** TTL (seconds) for ephemeral authorize state + auth codes. */
+        oauthStateTtlSeconds: z.coerce.number().int().positive().default(600),
+
         nodeEnv: z.enum(['development', 'production', 'test']).default('development'),
     })
     .refine(
@@ -59,8 +89,19 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): HostedConfig {
         baseUrl: env.GHP_HOSTED_BASE_URL,
         lockedRepo: env.GHP_REPO,
         allowedOrigins: env.GHP_ALLOWED_ORIGINS,
+        githubOauthClientId: env.GHP_GITHUB_OAUTH_CLIENT_ID,
+        githubOauthClientSecret: env.GHP_GITHUB_OAUTH_CLIENT_SECRET,
+        allowedRedirectUris: env.GHP_ALLOWED_REDIRECT_URIS,
+        oauthStateTtlSeconds: env.GHP_OAUTH_STATE_TTL_SECONDS,
         nodeEnv: env.NODE_ENV,
     });
+}
+
+export function parseAllowedRedirectUris(raw: string): string[] {
+    return raw
+        .split(',')
+        .map((s) => s.trim())
+        .filter((s) => s.length > 0);
 }
 
 export function parseRepoInfo(lockedRepo: string): {

--- a/packages/mcp-hosted/src/http-server.test.ts
+++ b/packages/mcp-hosted/src/http-server.test.ts
@@ -22,9 +22,13 @@ function buildConfig(overrides: Partial<HostedConfig> = {}): HostedConfig {
     return {
         port: 0,
         mode: 'hosted',
-        baseUrl: undefined,
+        baseUrl: 'https://ghp-mcp-hosted.test',
         lockedRepo: 'bretwardjames/ghp',
         allowedOrigins: '*',
+        githubOauthClientId: 'test-github-client-id',
+        githubOauthClientSecret: 'test-github-client-secret',
+        allowedRedirectUris: 'https://runtight.test/oauth/callback',
+        oauthStateTtlSeconds: 600,
         nodeEnv: 'test',
         ...overrides,
     };
@@ -53,10 +57,26 @@ describe('hosted http server', () => {
     });
 
     describe('/.well-known/oauth-protected-resource', () => {
-        it('returns 501 stub until OAuth ships in #279', async () => {
+        it('returns RFC 9728 metadata pointing at ourselves as the AS', async () => {
             const res = await request(app).get('/.well-known/oauth-protected-resource');
-            expect(res.status).toBe(501);
-            expect(res.body.error).toBe('not_implemented');
+            expect(res.status).toBe(200);
+            expect(res.body.resource).toBe('https://ghp-mcp-hosted.test');
+            expect(res.body.authorization_servers).toEqual([
+                'https://ghp-mcp-hosted.test',
+            ]);
+            expect(res.body.bearer_methods_supported).toContain('header');
+        });
+    });
+
+    describe('/.well-known/oauth-authorization-server', () => {
+        it('returns RFC 8414 metadata with PKCE S256 declared', async () => {
+            const res = await request(app).get('/.well-known/oauth-authorization-server');
+            expect(res.status).toBe(200);
+            expect(res.body.issuer).toBe('https://ghp-mcp-hosted.test');
+            expect(res.body.authorization_endpoint).toMatch(/\/oauth\/authorize$/);
+            expect(res.body.token_endpoint).toMatch(/\/oauth\/token$/);
+            expect(res.body.code_challenge_methods_supported).toEqual(['S256']);
+            expect(res.body.grant_types_supported).toContain('authorization_code');
         });
     });
 
@@ -70,7 +90,7 @@ describe('hosted http server', () => {
             expect(res.status).toBe(401);
             expect(res.headers['www-authenticate']).toMatch(/^Bearer /);
             expect(res.headers['www-authenticate']).toContain(
-                'resource_metadata="/.well-known/oauth-protected-resource"'
+                'resource_metadata="https://ghp-mcp-hosted.test/.well-known/oauth-protected-resource"'
             );
             expect(res.body.error.code).toBe(-32001);
         });

--- a/packages/mcp-hosted/src/http-server.ts
+++ b/packages/mcp-hosted/src/http-server.ts
@@ -9,8 +9,14 @@ import {
 import type { RepoInfo } from '@bretwardjames/ghp-core';
 import { BearerTokenProvider, extractBearer } from './auth/bearer-token-provider.js';
 import type { HostedConfig } from './config.js';
-import { parseRepoInfo } from './config.js';
+import { parseRepoInfo, parseAllowedRedirectUris } from './config.js';
 import { assertHostedSafe } from './mode-guard.js';
+import { mountOAuthRoutes, type OAuthDeps } from './oauth/routes.js';
+import { StateStore } from './oauth/state-store.js';
+import type {
+    AuthorizeContext,
+    AuthCodeContext,
+} from './oauth/state-store.js';
 
 /**
  * Build the Express app for the hosted GHP MCP server.
@@ -81,27 +87,28 @@ export function createApp(config: HostedConfig): Application {
         res.sendStatus(204);
     });
 
+    // Form-encoded body parsing for /oauth/token (application/x-www-form-urlencoded).
+    // Mounted narrowly so the /mcp endpoint continues to use JSON only.
+    app.use('/oauth/token', express.urlencoded({ extended: false, limit: '16kb' }));
+
     app.get('/healthz', (_req, res) => {
         res.type('text/plain').send('ok');
     });
 
-    // OAuth discovery stubs — filled in by #279. Returning 501 here keeps
-    // the routes documented without silently 404-ing clients that probe.
-    app.get('/.well-known/oauth-protected-resource', (_req, res) => {
-        res.status(501).json({
-            error: 'not_implemented',
-            error_description:
-                'OAuth discovery is not implemented in this build. Use a PAT via Authorization: Bearer <token>.',
-        });
-    });
-
-    app.get('/.well-known/oauth-authorization-server', (_req, res) => {
-        res.status(501).json({
-            error: 'not_implemented',
-            error_description:
-                'OAuth authorization server metadata is not implemented in this build.',
-        });
-    });
+    // Real OAuth 2.1 + PKCE + RFC 9728/8414 endpoints.
+    const oauthDeps: OAuthDeps = {
+        config,
+        githubClientId: config.githubOauthClientId,
+        githubClientSecret: config.githubOauthClientSecret,
+        allowedRedirectUris: parseAllowedRedirectUris(config.allowedRedirectUris),
+        authorizeStore: new StateStore<AuthorizeContext>(
+            config.oauthStateTtlSeconds * 1000
+        ),
+        authCodeStore: new StateStore<AuthCodeContext>(
+            config.oauthStateTtlSeconds * 1000
+        ),
+    };
+    mountOAuthRoutes(app, oauthDeps);
 
     app.post('/mcp', (req, res) =>
         handleMcpRequest(req, res, { config, lockedRepo, mcpConfig })

--- a/packages/mcp-hosted/src/oauth/github.ts
+++ b/packages/mcp-hosted/src/oauth/github.ts
@@ -79,14 +79,23 @@ export async function exchangeGithubCode(
     });
 
     if (!res.ok) {
-        throw new Error(
+        throw new GithubExchangeError(
             `GitHub token exchange failed: HTTP ${res.status} ${res.statusText}`
         );
     }
 
-    const payload = (await res.json()) as Record<string, unknown>;
+    let payload: Record<string, unknown>;
+    try {
+        payload = (await res.json()) as Record<string, unknown>;
+    } catch {
+        // Non-JSON body (HTML maintenance page, empty response, etc.)
+        throw new GithubExchangeError(
+            'Non-JSON response from GitHub token endpoint'
+        );
+    }
+
     if (payload.error) {
-        throw new Error(
+        throw new GithubExchangeError(
             `GitHub token exchange error: ${String(payload.error)} - ${String(
                 payload.error_description ?? ''
             )}`
@@ -95,7 +104,9 @@ export async function exchangeGithubCode(
 
     const accessToken = payload.access_token;
     if (typeof accessToken !== 'string' || accessToken.length === 0) {
-        throw new Error('GitHub token exchange returned no access_token');
+        throw new GithubExchangeError(
+            'GitHub token exchange returned no access_token'
+        );
     }
 
     return {
@@ -104,4 +115,17 @@ export async function exchangeGithubCode(
         tokenType:
             typeof payload.token_type === 'string' ? payload.token_type : 'bearer',
     };
+}
+
+/**
+ * Dedicated error type so callers can distinguish GitHub-exchange
+ * failures (which should surface a generic error_description to the
+ * client) from internal bugs (which should surface the real message
+ * server-side).
+ */
+export class GithubExchangeError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'GithubExchangeError';
+    }
 }

--- a/packages/mcp-hosted/src/oauth/github.ts
+++ b/packages/mcp-hosted/src/oauth/github.ts
@@ -1,0 +1,107 @@
+/**
+ * Thin client for GitHub's OAuth App endpoints. Deliberately minimal —
+ * we only need:
+ *
+ *   - build the authorize URL the user gets redirected to
+ *   - exchange the authorization code for a Bearer access token
+ *
+ * GitHub OAuth Apps do NOT support PKCE directly, so we mediate PKCE on
+ * our side (see state-store + token handler) and use only the
+ * client_id/client_secret/state flow at GitHub's endpoint.
+ */
+
+export interface GithubOauthConfig {
+    clientId: string;
+    clientSecret: string;
+}
+
+export interface GithubTokenResponse {
+    accessToken: string;
+    scope: string;
+    tokenType: string;
+}
+
+const GITHUB_AUTHORIZE_URL = 'https://github.com/login/oauth/authorize';
+const GITHUB_TOKEN_URL = 'https://github.com/login/oauth/access_token';
+
+/**
+ * Required scopes for the pure-api tool surface. `repo` is broad but
+ * required for issue mutations on private repos; narrower scopes
+ * (`public_repo`) work for OSS-only deployments — wire up an option if
+ * we ever need it.
+ */
+export const REQUIRED_GITHUB_SCOPES = ['read:project', 'project', 'repo'];
+
+export function buildGithubAuthorizeUrl(params: {
+    clientId: string;
+    redirectUri: string;
+    state: string;
+    scopes?: string[];
+}): string {
+    const url = new URL(GITHUB_AUTHORIZE_URL);
+    url.searchParams.set('client_id', params.clientId);
+    url.searchParams.set('redirect_uri', params.redirectUri);
+    url.searchParams.set('state', params.state);
+    url.searchParams.set(
+        'scope',
+        (params.scopes ?? REQUIRED_GITHUB_SCOPES).join(' ')
+    );
+    return url.toString();
+}
+
+/**
+ * Exchange a GitHub authorization code for an access token. Throws on
+ * non-2xx response or when GitHub returns an error body. Callers should
+ * surface the error upstream as an OAuth2 `invalid_grant` or
+ * `server_error` depending on shape.
+ */
+export async function exchangeGithubCode(
+    config: GithubOauthConfig,
+    code: string,
+    redirectUri: string,
+    fetchImpl: typeof fetch = fetch
+): Promise<GithubTokenResponse> {
+    const body = new URLSearchParams({
+        client_id: config.clientId,
+        client_secret: config.clientSecret,
+        code,
+        redirect_uri: redirectUri,
+    });
+
+    const res = await fetchImpl(GITHUB_TOKEN_URL, {
+        method: 'POST',
+        headers: {
+            Accept: 'application/json',
+            'Content-Type': 'application/x-www-form-urlencoded',
+            'User-Agent': 'ghp-mcp-hosted',
+        },
+        body: body.toString(),
+    });
+
+    if (!res.ok) {
+        throw new Error(
+            `GitHub token exchange failed: HTTP ${res.status} ${res.statusText}`
+        );
+    }
+
+    const payload = (await res.json()) as Record<string, unknown>;
+    if (payload.error) {
+        throw new Error(
+            `GitHub token exchange error: ${String(payload.error)} - ${String(
+                payload.error_description ?? ''
+            )}`
+        );
+    }
+
+    const accessToken = payload.access_token;
+    if (typeof accessToken !== 'string' || accessToken.length === 0) {
+        throw new Error('GitHub token exchange returned no access_token');
+    }
+
+    return {
+        accessToken,
+        scope: typeof payload.scope === 'string' ? payload.scope : '',
+        tokenType:
+            typeof payload.token_type === 'string' ? payload.token_type : 'bearer',
+    };
+}

--- a/packages/mcp-hosted/src/oauth/pkce.test.ts
+++ b/packages/mcp-hosted/src/oauth/pkce.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { createHash } from 'crypto';
-import { verifyPkce } from './pkce.js';
+import { verifyPkce, isValidChallenge } from './pkce.js';
 
 function computeChallenge(verifier: string): string {
     return createHash('sha256')
@@ -33,13 +33,37 @@ describe('verifyPkce', () => {
         expect(verifyPkce(long, computeChallenge(long))).toBe(false);
     });
 
-    it('rejects verifier with disallowed characters', () => {
-        const bad = 'a'.repeat(43) + '!';
-        expect(verifyPkce(bad.slice(0, 43), computeChallenge(bad.slice(0, 43)))).toBe(true);
+    it('rejects verifier containing a disallowed character (at a valid length)', () => {
+        // 43 chars, includes '!' which is NOT in the RFC 7636 unreserved set.
+        // Should fail purely on charset, not length.
+        const bad = 'a'.repeat(42) + '!';
+        expect(bad.length).toBe(43);
         expect(verifyPkce(bad, computeChallenge(bad))).toBe(false);
     });
 
     it('rejects when method is not S256', () => {
         expect(verifyPkce(VERIFIER, VERIFIER, 'plain')).toBe(false);
+    });
+});
+
+describe('isValidChallenge', () => {
+    it('accepts a base64url-encoded SHA-256 digest (43 chars)', () => {
+        expect(isValidChallenge(CHALLENGE)).toBe(true);
+    });
+
+    it('rejects wrong-length challenges', () => {
+        expect(isValidChallenge('a'.repeat(42))).toBe(false);
+        expect(isValidChallenge('a'.repeat(44))).toBe(false);
+    });
+
+    it('rejects challenges with non-base64url chars', () => {
+        // base64url alphabet does NOT include '+', '/', or '='
+        const invalid = 'a'.repeat(41) + '+/=';
+        expect(invalid.length).toBe(44);
+        expect(isValidChallenge(invalid)).toBe(false);
+    });
+
+    it('rejects empty string', () => {
+        expect(isValidChallenge('')).toBe(false);
     });
 });

--- a/packages/mcp-hosted/src/oauth/pkce.test.ts
+++ b/packages/mcp-hosted/src/oauth/pkce.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { createHash } from 'crypto';
+import { verifyPkce } from './pkce.js';
+
+function computeChallenge(verifier: string): string {
+    return createHash('sha256')
+        .update(verifier)
+        .digest('base64')
+        .replace(/=+$/, '')
+        .replace(/\+/g, '-')
+        .replace(/\//g, '_');
+}
+
+const VERIFIER = 'a'.repeat(64); // valid: 43..128 chars, unreserved
+const CHALLENGE = computeChallenge(VERIFIER);
+
+describe('verifyPkce', () => {
+    it('accepts a matching S256 verifier', () => {
+        expect(verifyPkce(VERIFIER, CHALLENGE)).toBe(true);
+    });
+
+    it('rejects a mismatched verifier', () => {
+        expect(verifyPkce('b'.repeat(64), CHALLENGE)).toBe(false);
+    });
+
+    it('rejects verifier that is too short (< 43 chars)', () => {
+        const short = 'a'.repeat(42);
+        expect(verifyPkce(short, computeChallenge(short))).toBe(false);
+    });
+
+    it('rejects verifier that is too long (> 128 chars)', () => {
+        const long = 'a'.repeat(129);
+        expect(verifyPkce(long, computeChallenge(long))).toBe(false);
+    });
+
+    it('rejects verifier with disallowed characters', () => {
+        const bad = 'a'.repeat(43) + '!';
+        expect(verifyPkce(bad.slice(0, 43), computeChallenge(bad.slice(0, 43)))).toBe(true);
+        expect(verifyPkce(bad, computeChallenge(bad))).toBe(false);
+    });
+
+    it('rejects when method is not S256', () => {
+        expect(verifyPkce(VERIFIER, VERIFIER, 'plain')).toBe(false);
+    });
+});

--- a/packages/mcp-hosted/src/oauth/pkce.ts
+++ b/packages/mcp-hosted/src/oauth/pkce.ts
@@ -1,0 +1,45 @@
+import { createHash, timingSafeEqual } from 'crypto';
+
+/**
+ * Verify a PKCE code_verifier against the code_challenge stored at
+ * authorize time.
+ *
+ * Only S256 is supported (plain is deprecated by OAuth 2.1). The
+ * comparison uses a constant-time equality check to avoid leaking
+ * timing information about the stored challenge.
+ */
+export function verifyPkce(
+    verifier: string,
+    challenge: string,
+    method: string = 'S256'
+): boolean {
+    if (method !== 'S256') return false;
+    if (!isValidVerifier(verifier)) return false;
+
+    const computed = base64UrlSha256(verifier);
+    const expectedBuf = Buffer.from(challenge);
+    const computedBuf = Buffer.from(computed);
+
+    if (expectedBuf.length !== computedBuf.length) return false;
+    return timingSafeEqual(expectedBuf, computedBuf);
+}
+
+/**
+ * RFC 7636 §4.1: code_verifier = 43..128 chars, unreserved URL chars.
+ * A short or non-conforming verifier is rejected outright — guards
+ * against a client sending garbage that would silently hash to
+ * something.
+ */
+function isValidVerifier(verifier: string): boolean {
+    if (verifier.length < 43 || verifier.length > 128) return false;
+    return /^[A-Za-z0-9\-._~]+$/.test(verifier);
+}
+
+function base64UrlSha256(input: string): string {
+    return createHash('sha256')
+        .update(input)
+        .digest('base64')
+        .replace(/=+$/, '')
+        .replace(/\+/g, '-')
+        .replace(/\//g, '_');
+}

--- a/packages/mcp-hosted/src/oauth/pkce.ts
+++ b/packages/mcp-hosted/src/oauth/pkce.ts
@@ -35,6 +35,17 @@ function isValidVerifier(verifier: string): boolean {
     return /^[A-Za-z0-9\-._~]+$/.test(verifier);
 }
 
+/**
+ * RFC 7636 §4.2: S256 code_challenge = base64url(SHA256(verifier)).
+ * The encoded output is always 43 chars, no padding, base64url alphabet.
+ * Validating at authorize time means verifyPkce's length check is
+ * defense-in-depth rather than the primary guarantee of correctness.
+ */
+export function isValidChallenge(challenge: string): boolean {
+    if (challenge.length !== 43) return false;
+    return /^[A-Za-z0-9_-]+$/.test(challenge);
+}
+
 function base64UrlSha256(input: string): string {
     return createHash('sha256')
         .update(input)

--- a/packages/mcp-hosted/src/oauth/routes.test.ts
+++ b/packages/mcp-hosted/src/oauth/routes.test.ts
@@ -317,4 +317,90 @@ describe('OAuth flow', () => {
             expect(res.body.error).toBe('unsupported_grant_type');
         });
     });
+
+    describe('TTL expiry', () => {
+        it('/oauth/callback rejects an expired server state', async () => {
+            vi.useFakeTimers({ now: Date.now() });
+            try {
+                const appWithShortTtl = createApp(
+                    buildConfig({ oauthStateTtlSeconds: 60 })
+                );
+
+                const authorizeRes = await request(appWithShortTtl)
+                    .get('/oauth/authorize')
+                    .query({
+                        response_type: 'code',
+                        client_id: 'public',
+                        redirect_uri: CLIENT_REDIRECT,
+                        state: 'client-state',
+                        code_challenge: CHALLENGE,
+                        code_challenge_method: 'S256',
+                    });
+                const serverState = new URL(
+                    authorizeRes.headers.location
+                ).searchParams.get('state')!;
+
+                vi.advanceTimersByTime(61_000); // past 60s TTL
+
+                const callbackRes = await request(appWithShortTtl)
+                    .get('/oauth/callback')
+                    .query({
+                        code: 'github-code-123',
+                        state: serverState,
+                    });
+                expect(callbackRes.status).toBe(400);
+            } finally {
+                vi.useRealTimers();
+            }
+        });
+
+        it('/oauth/token rejects an expired auth code', async () => {
+            vi.useFakeTimers({ now: Date.now() });
+            try {
+                const appWithShortTtl = createApp(
+                    buildConfig({ oauthStateTtlSeconds: 60 })
+                );
+
+                const authorizeRes = await request(appWithShortTtl)
+                    .get('/oauth/authorize')
+                    .query({
+                        response_type: 'code',
+                        client_id: 'public',
+                        redirect_uri: CLIENT_REDIRECT,
+                        state: 'client-state',
+                        code_challenge: CHALLENGE,
+                        code_challenge_method: 'S256',
+                    });
+                const serverState = new URL(
+                    authorizeRes.headers.location
+                ).searchParams.get('state')!;
+
+                const callbackRes = await request(appWithShortTtl)
+                    .get('/oauth/callback')
+                    .query({
+                        code: 'github-code-123',
+                        state: serverState,
+                    });
+                const authCode = new URL(
+                    callbackRes.headers.location
+                ).searchParams.get('code')!;
+
+                vi.advanceTimersByTime(61_000);
+
+                const tokenRes = await request(appWithShortTtl)
+                    .post('/oauth/token')
+                    .type('form')
+                    .send({
+                        grant_type: 'authorization_code',
+                        code: authCode,
+                        code_verifier: VERIFIER,
+                        redirect_uri: CLIENT_REDIRECT,
+                    });
+                expect(tokenRes.status).toBe(400);
+                expect(tokenRes.body.error).toBe('invalid_grant');
+            } finally {
+                vi.useRealTimers();
+            }
+        });
+    });
 });

--- a/packages/mcp-hosted/src/oauth/routes.test.ts
+++ b/packages/mcp-hosted/src/oauth/routes.test.ts
@@ -1,0 +1,320 @@
+/**
+ * Integration tests for the OAuth 2.1 + PKCE + RFC 9728 flow.
+ *
+ * The GitHub token endpoint is mocked via a fetch stub so these tests
+ * never hit github.com. The full 3-leg flow is exercised: authorize →
+ * redirect to GitHub → (fake) callback → token exchange.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import request from 'supertest';
+import { createHash } from 'crypto';
+import { createApp } from '../http-server.js';
+import type { HostedConfig } from '../config.js';
+
+const CLIENT_REDIRECT = 'https://runtight.test/oauth/callback';
+
+function buildConfig(overrides: Partial<HostedConfig> = {}): HostedConfig {
+    return {
+        port: 0,
+        mode: 'hosted',
+        baseUrl: 'https://ghp-mcp-hosted.test',
+        lockedRepo: 'bretwardjames/ghp',
+        allowedOrigins: '*',
+        githubOauthClientId: 'github-client-id',
+        githubOauthClientSecret: 'github-client-secret',
+        allowedRedirectUris: CLIENT_REDIRECT,
+        oauthStateTtlSeconds: 600,
+        nodeEnv: 'test',
+        ...overrides,
+    };
+}
+
+function base64UrlSha256(input: string): string {
+    return createHash('sha256')
+        .update(input)
+        .digest('base64')
+        .replace(/=+$/, '')
+        .replace(/\+/g, '-')
+        .replace(/\//g, '_');
+}
+
+// A legal PKCE verifier + its S256 challenge.
+const VERIFIER = 'A'.repeat(64);
+const CHALLENGE = base64UrlSha256(VERIFIER);
+
+describe('OAuth flow', () => {
+    let app: ReturnType<typeof createApp>;
+    let fetchMock: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+        // Mock the global fetch used inside exchangeGithubCode. The OAuth
+        // deps don't expose a fetchImpl hook through createApp yet, so
+        // overriding globalThis.fetch is the simplest path.
+        fetchMock = vi.fn(async () =>
+            new Response(
+                JSON.stringify({
+                    access_token: 'ghp_FAKE_GITHUB_TOKEN_0123456789',
+                    scope: 'read:project,project,repo',
+                    token_type: 'bearer',
+                }),
+                { status: 200, headers: { 'Content-Type': 'application/json' } }
+            )
+        );
+        vi.stubGlobal('fetch', fetchMock);
+
+        app = createApp(buildConfig());
+    });
+
+    describe('/oauth/register', () => {
+        it('returns a static client_id when redirect_uris are allowlisted', async () => {
+            const res = await request(app)
+                .post('/oauth/register')
+                .send({ redirect_uris: [CLIENT_REDIRECT] });
+            expect(res.status).toBe(201);
+            expect(res.body.client_id).toBeTruthy();
+            expect(res.body.token_endpoint_auth_method).toBe('none');
+        });
+
+        it('rejects non-allowlisted redirect_uris', async () => {
+            const res = await request(app)
+                .post('/oauth/register')
+                .send({ redirect_uris: ['https://evil.example.com/cb'] });
+            expect(res.status).toBe(400);
+            expect(res.body.error).toBe('invalid_redirect_uri');
+        });
+    });
+
+    describe('/oauth/authorize', () => {
+        it('redirects to GitHub with a server-side state', async () => {
+            const res = await request(app).get('/oauth/authorize').query({
+                response_type: 'code',
+                client_id: 'ghp-mcp-hosted-public-client',
+                redirect_uri: CLIENT_REDIRECT,
+                state: 'client-state',
+                code_challenge: CHALLENGE,
+                code_challenge_method: 'S256',
+            });
+
+            expect(res.status).toBe(302);
+            const location = res.headers.location;
+            expect(location).toMatch(/^https:\/\/github\.com\/login\/oauth\/authorize/);
+            const url = new URL(location);
+            expect(url.searchParams.get('client_id')).toBe('github-client-id');
+            expect(url.searchParams.get('redirect_uri')).toBe(
+                'https://ghp-mcp-hosted.test/oauth/callback'
+            );
+            // Must NOT leak the client's original state to GitHub —
+            // GitHub gets *our* state.
+            expect(url.searchParams.get('state')).not.toBe('client-state');
+            expect(url.searchParams.get('state')).toBeTruthy();
+        });
+
+        it('rejects a non-allowlisted redirect_uri with 400 (no redirect)', async () => {
+            const res = await request(app).get('/oauth/authorize').query({
+                response_type: 'code',
+                client_id: 'public',
+                redirect_uri: 'https://evil.example.com/cb',
+                state: 'x',
+                code_challenge: CHALLENGE,
+                code_challenge_method: 'S256',
+            });
+            expect(res.status).toBe(400);
+            expect(res.body.error).toBe('invalid_redirect_uri');
+        });
+
+        it('rejects response_type != code', async () => {
+            const res = await request(app).get('/oauth/authorize').query({
+                response_type: 'token',
+                client_id: 'public',
+                redirect_uri: CLIENT_REDIRECT,
+                state: 'x',
+                code_challenge: CHALLENGE,
+                code_challenge_method: 'S256',
+            });
+            // recoverable error bounces to client redirect
+            expect(res.status).toBe(302);
+            const loc = new URL(res.headers.location);
+            expect(loc.searchParams.get('error')).toBe('unsupported_response_type');
+        });
+
+        it('rejects missing PKCE challenge', async () => {
+            const res = await request(app).get('/oauth/authorize').query({
+                response_type: 'code',
+                client_id: 'public',
+                redirect_uri: CLIENT_REDIRECT,
+                state: 'x',
+                code_challenge_method: 'S256',
+            });
+            expect(res.status).toBe(302);
+            const loc = new URL(res.headers.location);
+            expect(loc.searchParams.get('error')).toBe('invalid_request');
+        });
+    });
+
+    describe('/oauth/callback', () => {
+        it('exchanges GitHub code, mints our own code, redirects to client', async () => {
+            // Seed an authorize request to produce a valid server state.
+            const authorizeRes = await request(app).get('/oauth/authorize').query({
+                response_type: 'code',
+                client_id: 'public',
+                redirect_uri: CLIENT_REDIRECT,
+                state: 'client-state',
+                code_challenge: CHALLENGE,
+                code_challenge_method: 'S256',
+            });
+            const githubUrl = new URL(authorizeRes.headers.location);
+            const serverState = githubUrl.searchParams.get('state');
+            expect(serverState).toBeTruthy();
+
+            const callbackRes = await request(app).get('/oauth/callback').query({
+                code: 'github-code-123',
+                state: serverState,
+            });
+            expect(callbackRes.status).toBe(302);
+            const redirect = new URL(callbackRes.headers.location);
+            expect(redirect.origin + redirect.pathname).toBe(CLIENT_REDIRECT);
+            expect(redirect.searchParams.get('state')).toBe('client-state');
+            expect(redirect.searchParams.get('code')).toBeTruthy();
+
+            // fetch to GitHub token endpoint was called exactly once
+            expect(fetchMock).toHaveBeenCalledTimes(1);
+            expect(fetchMock.mock.calls[0][0]).toBe(
+                'https://github.com/login/oauth/access_token'
+            );
+        });
+
+        it('rejects unknown state', async () => {
+            const res = await request(app).get('/oauth/callback').query({
+                code: 'github-code-123',
+                state: 'never-issued',
+            });
+            expect(res.status).toBe(400);
+        });
+
+        it('surfaces GitHub consent errors back to the client', async () => {
+            const res = await request(app).get('/oauth/callback').query({
+                error: 'access_denied',
+            });
+            expect(res.status).toBe(400);
+            expect(res.text).toContain('access_denied');
+        });
+    });
+
+    describe('/oauth/token — full flow', () => {
+        async function runThroughAuthorize(): Promise<string> {
+            // Authorize → extract server state
+            const authorizeRes = await request(app).get('/oauth/authorize').query({
+                response_type: 'code',
+                client_id: 'public',
+                redirect_uri: CLIENT_REDIRECT,
+                state: 'client-state',
+                code_challenge: CHALLENGE,
+                code_challenge_method: 'S256',
+            });
+            const serverState = new URL(authorizeRes.headers.location).searchParams.get(
+                'state'
+            )!;
+
+            // Callback → extract our auth code
+            const callbackRes = await request(app).get('/oauth/callback').query({
+                code: 'github-code-123',
+                state: serverState,
+            });
+            return new URL(callbackRes.headers.location).searchParams.get('code')!;
+        }
+
+        it('returns the GitHub token when PKCE + redirect_uri match', async () => {
+            const code = await runThroughAuthorize();
+
+            const res = await request(app)
+                .post('/oauth/token')
+                .type('form')
+                .send({
+                    grant_type: 'authorization_code',
+                    code,
+                    code_verifier: VERIFIER,
+                    redirect_uri: CLIENT_REDIRECT,
+                });
+
+            expect(res.status).toBe(200);
+            expect(res.body.access_token).toBe('ghp_FAKE_GITHUB_TOKEN_0123456789');
+            expect(res.body.token_type).toBe('Bearer');
+        });
+
+        it('rejects a bad PKCE verifier', async () => {
+            const code = await runThroughAuthorize();
+
+            const res = await request(app)
+                .post('/oauth/token')
+                .type('form')
+                .send({
+                    grant_type: 'authorization_code',
+                    code,
+                    code_verifier: 'X'.repeat(64),
+                    redirect_uri: CLIENT_REDIRECT,
+                });
+
+            expect(res.status).toBe(400);
+            expect(res.body.error).toBe('invalid_grant');
+        });
+
+        it('rejects a redirect_uri mismatch', async () => {
+            const code = await runThroughAuthorize();
+
+            const res = await request(app)
+                .post('/oauth/token')
+                .type('form')
+                .send({
+                    grant_type: 'authorization_code',
+                    code,
+                    code_verifier: VERIFIER,
+                    redirect_uri: 'https://runtight.test/wrong',
+                });
+
+            expect(res.status).toBe(400);
+            expect(res.body.error).toBe('invalid_grant');
+        });
+
+        it('rejects reuse of an auth code (single-use)', async () => {
+            const code = await runThroughAuthorize();
+
+            const first = await request(app)
+                .post('/oauth/token')
+                .type('form')
+                .send({
+                    grant_type: 'authorization_code',
+                    code,
+                    code_verifier: VERIFIER,
+                    redirect_uri: CLIENT_REDIRECT,
+                });
+            expect(first.status).toBe(200);
+
+            const second = await request(app)
+                .post('/oauth/token')
+                .type('form')
+                .send({
+                    grant_type: 'authorization_code',
+                    code,
+                    code_verifier: VERIFIER,
+                    redirect_uri: CLIENT_REDIRECT,
+                });
+            expect(second.status).toBe(400);
+            expect(second.body.error).toBe('invalid_grant');
+        });
+
+        it('rejects unsupported grant_type', async () => {
+            const res = await request(app)
+                .post('/oauth/token')
+                .type('form')
+                .send({
+                    grant_type: 'password',
+                    code: 'x',
+                    code_verifier: 'y',
+                    redirect_uri: CLIENT_REDIRECT,
+                });
+            expect(res.status).toBe(400);
+            expect(res.body.error).toBe('unsupported_grant_type');
+        });
+    });
+});

--- a/packages/mcp-hosted/src/oauth/routes.ts
+++ b/packages/mcp-hosted/src/oauth/routes.ts
@@ -1,0 +1,345 @@
+import { randomBytes } from 'crypto';
+import type { Request, Response, Application } from 'express';
+import type { HostedConfig } from '../config.js';
+import {
+    StateStore,
+    type AuthorizeContext,
+    type AuthCodeContext,
+} from './state-store.js';
+import { verifyPkce } from './pkce.js';
+import {
+    buildGithubAuthorizeUrl,
+    exchangeGithubCode,
+    REQUIRED_GITHUB_SCOPES,
+} from './github.js';
+import {
+    oauthProtectedResourceMetadata,
+    oauthAuthorizationServerMetadata,
+} from './well-known.js';
+
+/**
+ * Runtime config scoped to OAuth. Passed through from the top-level
+ * HostedConfig plus the two OAuth-App credentials, because those are
+ * sensitive enough that we want them explicit at every layer.
+ */
+export interface OAuthDeps {
+    config: HostedConfig;
+    githubClientId: string;
+    githubClientSecret: string;
+    /** Allowlist of exact redirect_uris accepted from MCP clients. */
+    allowedRedirectUris: readonly string[];
+    authorizeStore: StateStore<AuthorizeContext>;
+    authCodeStore: StateStore<AuthCodeContext>;
+    /** Overridable for tests; defaults to the global fetch. */
+    fetchImpl?: typeof fetch;
+}
+
+export function mountOAuthRoutes(app: Application, deps: OAuthDeps): void {
+    app.get('/.well-known/oauth-protected-resource', (_req, res) => {
+        res.json(oauthProtectedResourceMetadata(deps.config));
+    });
+
+    app.get('/.well-known/oauth-authorization-server', (_req, res) => {
+        res.json(oauthAuthorizationServerMetadata(deps.config));
+    });
+
+    app.post('/oauth/register', (req, res) => handleRegister(req, res, deps));
+    app.get('/oauth/authorize', (req, res) => handleAuthorize(req, res, deps));
+    app.get('/oauth/callback', (req, res) => handleCallback(req, res, deps));
+    app.post('/oauth/token', (req, res) => handleToken(req, res, deps));
+}
+
+/**
+ * RFC 7591 Dynamic Client Registration — v1 stub.
+ *
+ * We don't actually persist client records yet. The MCP client hands us
+ * a redirect_uri it intends to use; we validate it against the allowlist
+ * and echo back a stable client_id. When we move to multi-tenant with
+ * real client accounting this becomes a DB insert.
+ */
+function handleRegister(req: Request, res: Response, deps: OAuthDeps): void {
+    const body = req.body as { redirect_uris?: unknown } | undefined;
+    const rawRedirects = Array.isArray(body?.redirect_uris)
+        ? (body!.redirect_uris as unknown[])
+        : [];
+    const redirectUris = rawRedirects.filter(
+        (u): u is string => typeof u === 'string'
+    );
+
+    if (redirectUris.length === 0) {
+        res.status(400).json({
+            error: 'invalid_redirect_uri',
+            error_description: 'At least one redirect_uri is required.',
+        });
+        return;
+    }
+
+    for (const uri of redirectUris) {
+        if (!deps.allowedRedirectUris.includes(uri)) {
+            res.status(400).json({
+                error: 'invalid_redirect_uri',
+                error_description: `redirect_uri '${uri}' is not in the server allowlist.`,
+            });
+            return;
+        }
+    }
+
+    // Stable public-client id. No secret — PKCE is the client
+    // authentication mechanism.
+    res.status(201).json({
+        client_id: 'ghp-mcp-hosted-public-client',
+        client_id_issued_at: Math.floor(Date.now() / 1000),
+        redirect_uris: redirectUris,
+        token_endpoint_auth_method: 'none',
+        grant_types: ['authorization_code'],
+        response_types: ['code'],
+        scope: REQUIRED_GITHUB_SCOPES.join(' '),
+    });
+}
+
+/**
+ * /oauth/authorize — first leg of the flow. The MCP client (or user's
+ * browser acting on its behalf) lands here with PKCE and redirect info.
+ * We stash that into the authorize store keyed by a fresh server-side
+ * state and bounce the user to github.com for consent.
+ */
+function handleAuthorize(req: Request, res: Response, deps: OAuthDeps): void {
+    const {
+        client_id: clientId,
+        redirect_uri: clientRedirectUri,
+        state: clientState,
+        code_challenge: codeChallenge,
+        code_challenge_method: codeChallengeMethod,
+        response_type: responseType,
+    } = req.query as Record<string, string | undefined>;
+
+    if (responseType !== 'code') {
+        sendAuthorizeError(res, clientRedirectUri, clientState, {
+            error: 'unsupported_response_type',
+            error_description: 'Only response_type=code is supported.',
+        });
+        return;
+    }
+    if (!clientId) {
+        sendAuthorizeError(res, clientRedirectUri, clientState, {
+            error: 'invalid_request',
+            error_description: 'Missing client_id.',
+        });
+        return;
+    }
+    if (!clientRedirectUri || !deps.allowedRedirectUris.includes(clientRedirectUri)) {
+        // Do NOT redirect — the redirect target is itself untrusted.
+        // Surface the error in the response body instead.
+        res.status(400).json({
+            error: 'invalid_redirect_uri',
+            error_description:
+                'redirect_uri is missing or not in the server allowlist.',
+        });
+        return;
+    }
+    if (!codeChallenge) {
+        sendAuthorizeError(res, clientRedirectUri, clientState, {
+            error: 'invalid_request',
+            error_description: 'PKCE code_challenge is required.',
+        });
+        return;
+    }
+    if (codeChallengeMethod !== 'S256') {
+        sendAuthorizeError(res, clientRedirectUri, clientState, {
+            error: 'invalid_request',
+            error_description: 'Only code_challenge_method=S256 is supported.',
+        });
+        return;
+    }
+
+    const serverState = randomToken(32);
+    deps.authorizeStore.set(serverState, {
+        codeChallenge,
+        clientRedirectUri,
+        clientState: clientState ?? '',
+        clientId,
+        createdAt: Date.now(),
+    });
+
+    const githubCallback = `${baseUrl(deps.config)}/oauth/callback`;
+    const githubUrl = buildGithubAuthorizeUrl({
+        clientId: deps.githubClientId,
+        redirectUri: githubCallback,
+        state: serverState,
+    });
+
+    res.redirect(302, githubUrl);
+}
+
+/**
+ * /oauth/callback — GitHub sends the user here with ?code=...&state=...
+ * after consent. We recover the original client context by server-side
+ * state, exchange GitHub's code for an access token, mint our own auth
+ * code keyed to the client's PKCE challenge, and redirect the user
+ * back to the MCP client's redirect_uri.
+ */
+async function handleCallback(
+    req: Request,
+    res: Response,
+    deps: OAuthDeps
+): Promise<void> {
+    const { code, state, error } = req.query as Record<string, string | undefined>;
+
+    if (error) {
+        res.status(400).type('text/plain').send(
+            `GitHub returned an error during consent: ${error}. You may close this window.`
+        );
+        return;
+    }
+    if (!code || !state) {
+        res.status(400).type('text/plain').send(
+            'Missing code or state. You may close this window.'
+        );
+        return;
+    }
+
+    const authCtx = deps.authorizeStore.take(state);
+    if (!authCtx) {
+        res.status(400).type('text/plain').send(
+            'Unknown or expired state. Start the flow again.'
+        );
+        return;
+    }
+
+    let githubToken;
+    try {
+        githubToken = await exchangeGithubCode(
+            {
+                clientId: deps.githubClientId,
+                clientSecret: deps.githubClientSecret,
+            },
+            code,
+            `${baseUrl(deps.config)}/oauth/callback`,
+            deps.fetchImpl
+        );
+    } catch (err) {
+        // Bounce back to the client with an OAuth error per RFC 6749 §4.1.2.1.
+        sendAuthorizeError(res, authCtx.clientRedirectUri, authCtx.clientState, {
+            error: 'server_error',
+            error_description:
+                err instanceof Error ? err.message : 'GitHub token exchange failed.',
+        });
+        return;
+    }
+
+    const authCode = randomToken(32);
+    deps.authCodeStore.set(authCode, {
+        githubAccessToken: githubToken.accessToken,
+        scope: githubToken.scope,
+        codeChallenge: authCtx.codeChallenge,
+        clientRedirectUri: authCtx.clientRedirectUri,
+        createdAt: Date.now(),
+    });
+
+    const redirect = new URL(authCtx.clientRedirectUri);
+    redirect.searchParams.set('code', authCode);
+    if (authCtx.clientState) {
+        redirect.searchParams.set('state', authCtx.clientState);
+    }
+    res.redirect(302, redirect.toString());
+}
+
+/**
+ * /oauth/token — last leg. The MCP client POSTs the auth code back
+ * together with its PKCE code_verifier. We verify PKCE, verify the
+ * redirect_uri matches, consume the entry, and return the underlying
+ * GitHub Bearer token.
+ */
+function handleToken(req: Request, res: Response, deps: OAuthDeps): void {
+    const body = req.body as Record<string, unknown>;
+
+    if (body.grant_type !== 'authorization_code') {
+        res.status(400).json({
+            error: 'unsupported_grant_type',
+            error_description: 'Only authorization_code is supported.',
+        });
+        return;
+    }
+
+    const code = typeof body.code === 'string' ? body.code : '';
+    const verifier = typeof body.code_verifier === 'string' ? body.code_verifier : '';
+    const redirectUri = typeof body.redirect_uri === 'string' ? body.redirect_uri : '';
+
+    if (!code || !verifier || !redirectUri) {
+        res.status(400).json({
+            error: 'invalid_request',
+            error_description: 'code, code_verifier, and redirect_uri are required.',
+        });
+        return;
+    }
+
+    const entry = deps.authCodeStore.take(code);
+    if (!entry) {
+        res.status(400).json({
+            error: 'invalid_grant',
+            error_description: 'Authorization code is unknown, expired, or already used.',
+        });
+        return;
+    }
+
+    if (entry.clientRedirectUri !== redirectUri) {
+        res.status(400).json({
+            error: 'invalid_grant',
+            error_description: 'redirect_uri does not match the original authorization request.',
+        });
+        return;
+    }
+
+    if (!verifyPkce(verifier, entry.codeChallenge)) {
+        res.status(400).json({
+            error: 'invalid_grant',
+            error_description: 'PKCE code_verifier does not match the stored challenge.',
+        });
+        return;
+    }
+
+    // Pass-through strategy (v1): hand the GitHub access token
+    // straight to the MCP client. Revocation and rotation are
+    // therefore GitHub-controlled. Wrapping tokens would sit here in
+    // a future iteration.
+    res.json({
+        access_token: entry.githubAccessToken,
+        token_type: 'Bearer',
+        scope: entry.scope,
+    });
+}
+
+/**
+ * Redirect a recoverable error back to the client's redirect_uri per
+ * RFC 6749 §4.1.2.1. When the redirect_uri itself is untrusted, the
+ * caller must NOT use this helper — return a plain response instead.
+ */
+function sendAuthorizeError(
+    res: Response,
+    clientRedirectUri: string | undefined,
+    clientState: string | undefined,
+    err: { error: string; error_description: string }
+): void {
+    if (!clientRedirectUri) {
+        res.status(400).json(err);
+        return;
+    }
+    const url = new URL(clientRedirectUri);
+    url.searchParams.set('error', err.error);
+    url.searchParams.set('error_description', err.error_description);
+    if (clientState) url.searchParams.set('state', clientState);
+    res.redirect(302, url.toString());
+}
+
+function randomToken(bytes: number): string {
+    return randomBytes(bytes)
+        .toString('base64')
+        .replace(/=+$/, '')
+        .replace(/\+/g, '-')
+        .replace(/\//g, '_');
+}
+
+function baseUrl(config: HostedConfig): string {
+    if (config.baseUrl) return config.baseUrl.replace(/\/+$/, '');
+    return `http://localhost:${config.port}`;
+}

--- a/packages/mcp-hosted/src/oauth/routes.ts
+++ b/packages/mcp-hosted/src/oauth/routes.ts
@@ -3,13 +3,15 @@ import type { Request, Response, Application } from 'express';
 import type { HostedConfig } from '../config.js';
 import {
     StateStore,
+    StateStoreCapacityError,
     type AuthorizeContext,
     type AuthCodeContext,
 } from './state-store.js';
-import { verifyPkce } from './pkce.js';
+import { verifyPkce, isValidChallenge } from './pkce.js';
 import {
     buildGithubAuthorizeUrl,
     exchangeGithubCode,
+    GithubExchangeError,
     REQUIRED_GITHUB_SCOPES,
 } from './github.js';
 import {
@@ -137,10 +139,11 @@ function handleAuthorize(req: Request, res: Response, deps: OAuthDeps): void {
         });
         return;
     }
-    if (!codeChallenge) {
+    if (!codeChallenge || !isValidChallenge(codeChallenge)) {
         sendAuthorizeError(res, clientRedirectUri, clientState, {
             error: 'invalid_request',
-            error_description: 'PKCE code_challenge is required.',
+            error_description:
+                'PKCE code_challenge is required and must be a 43-char base64url-encoded SHA-256 digest.',
         });
         return;
     }
@@ -153,13 +156,26 @@ function handleAuthorize(req: Request, res: Response, deps: OAuthDeps): void {
     }
 
     const serverState = randomToken(32);
-    deps.authorizeStore.set(serverState, {
-        codeChallenge,
-        clientRedirectUri,
-        clientState: clientState ?? '',
-        clientId,
-        createdAt: Date.now(),
-    });
+    try {
+        deps.authorizeStore.set(serverState, {
+            codeChallenge,
+            clientRedirectUri,
+            clientState: clientState ?? '',
+            clientId,
+            createdAt: Date.now(),
+        });
+    } catch (err) {
+        if (err instanceof StateStoreCapacityError) {
+            res.setHeader('Retry-After', '60');
+            res.status(503).json({
+                error: 'server_error',
+                error_description:
+                    'Authorization server is temporarily at capacity. Retry shortly.',
+            });
+            return;
+        }
+        throw err;
+    }
 
     const githubCallback = `${baseUrl(deps.config)}/oauth/callback`;
     const githubUrl = buildGithubAuthorizeUrl({
@@ -218,11 +234,26 @@ async function handleCallback(
             deps.fetchImpl
         );
     } catch (err) {
-        // Bounce back to the client with an OAuth error per RFC 6749 §4.1.2.1.
+        // Log the real reason server-side; surface only a generic
+        // message to the client via the redirect. Echoing GitHub's
+        // error_description to an attacker-controlled redirect could
+        // leak operational detail about our OAuth App state.
+        console.error(
+            JSON.stringify({
+                level: 'warn',
+                msg: 'github_token_exchange_failed',
+                error:
+                    err instanceof GithubExchangeError
+                        ? err.message
+                        : err instanceof Error
+                          ? err.message
+                          : String(err),
+            })
+        );
         sendAuthorizeError(res, authCtx.clientRedirectUri, authCtx.clientState, {
             error: 'server_error',
             error_description:
-                err instanceof Error ? err.message : 'GitHub token exchange failed.',
+                'Upstream authorization server rejected the code exchange.',
         });
         return;
     }

--- a/packages/mcp-hosted/src/oauth/state-store.test.ts
+++ b/packages/mcp-hosted/src/oauth/state-store.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { StateStore } from './state-store.js';
+
+type Entry = { createdAt: number; payload: string };
+
+describe('StateStore', () => {
+    let store: StateStore<Entry>;
+
+    beforeEach(() => {
+        vi.useFakeTimers();
+        store = new StateStore<Entry>(10_000); // 10s TTL
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('stores and retrieves an entry', () => {
+        store.set('key1', { createdAt: Date.now(), payload: 'hello' });
+        const entry = store.take('key1');
+        expect(entry?.payload).toBe('hello');
+    });
+
+    it('take is single-use — second call returns null', () => {
+        store.set('key1', { createdAt: Date.now(), payload: 'hello' });
+        expect(store.take('key1')?.payload).toBe('hello');
+        expect(store.take('key1')).toBeNull();
+    });
+
+    it('expires entries older than the TTL', () => {
+        store.set('key1', { createdAt: Date.now(), payload: 'hello' });
+        vi.advanceTimersByTime(11_000);
+        expect(store.take('key1')).toBeNull();
+    });
+
+    it('sweeps expired entries on set/take/size', () => {
+        store.set('a', { createdAt: Date.now(), payload: 'x' });
+        store.set('b', { createdAt: Date.now(), payload: 'y' });
+        expect(store.size()).toBe(2);
+        vi.advanceTimersByTime(11_000);
+        expect(store.size()).toBe(0);
+    });
+
+    it('returns null for unknown keys', () => {
+        expect(store.take('nope')).toBeNull();
+    });
+});

--- a/packages/mcp-hosted/src/oauth/state-store.test.ts
+++ b/packages/mcp-hosted/src/oauth/state-store.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { StateStore } from './state-store.js';
+import { StateStore, StateStoreCapacityError } from './state-store.js';
 
 type Entry = { createdAt: number; payload: string };
 
@@ -43,5 +43,15 @@ describe('StateStore', () => {
 
     it('returns null for unknown keys', () => {
         expect(store.take('nope')).toBeNull();
+    });
+
+    it('throws StateStoreCapacityError once maxEntries is reached', () => {
+        const capped = new StateStore<Entry>(10_000, 3);
+        capped.set('a', { createdAt: Date.now(), payload: 'x' });
+        capped.set('b', { createdAt: Date.now(), payload: 'x' });
+        capped.set('c', { createdAt: Date.now(), payload: 'x' });
+        expect(() =>
+            capped.set('d', { createdAt: Date.now(), payload: 'x' })
+        ).toThrow(StateStoreCapacityError);
     });
 });

--- a/packages/mcp-hosted/src/oauth/state-store.ts
+++ b/packages/mcp-hosted/src/oauth/state-store.ts
@@ -46,10 +46,26 @@ export interface AuthCodeContext {
 export class StateStore<T extends { createdAt: number }> {
     private readonly entries = new Map<string, T>();
 
-    constructor(private readonly ttlMs: number) {}
+    /**
+     * `ttlMs` — entries older than this are treated as absent.
+     * `maxEntries` — hard cap to bound memory. When full, `set` throws
+     * rather than silently evicting; the expected upstream response is
+     * to return 503 or rate-limit the caller. Chosen at 100_000 so that
+     * an attacker flooding /oauth/authorize cannot unbounded-grow the
+     * store even if they outrun the sweep interval.
+     */
+    constructor(
+        private readonly ttlMs: number,
+        private readonly maxEntries: number = 100_000
+    ) {}
 
     set(key: string, value: T): void {
         this.sweep();
+        if (this.entries.size >= this.maxEntries) {
+            throw new StateStoreCapacityError(
+                `StateStore capacity reached (${this.maxEntries}); refusing new entries.`
+            );
+        }
         this.entries.set(key, value);
     }
 
@@ -82,5 +98,16 @@ export class StateStore<T extends { createdAt: number }> {
                 this.entries.delete(key);
             }
         }
+    }
+}
+
+/**
+ * Thrown when a set() would exceed the store's maxEntries cap.
+ * Callers should catch and surface a 503 / Retry-After response.
+ */
+export class StateStoreCapacityError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'StateStoreCapacityError';
     }
 }

--- a/packages/mcp-hosted/src/oauth/state-store.ts
+++ b/packages/mcp-hosted/src/oauth/state-store.ts
@@ -1,0 +1,86 @@
+/**
+ * Ephemeral in-memory TTL store for OAuth authorization state and issued
+ * auth codes. Used for:
+ *
+ *   - "state" tracking: when a client hits /oauth/authorize, we generate
+ *     our own server-side state key and stash the client's PKCE challenge,
+ *     redirect_uri, and original state under it. On /oauth/callback we
+ *     look up by our state key and recover the original context.
+ *
+ *   - "auth codes": after the GitHub token exchange succeeds we mint our
+ *     own opaque code, bind it to the GitHub access token plus the
+ *     client's PKCE challenge + redirect_uri, and return it to the
+ *     client. The client exchanges it at /oauth/token; we verify PKCE,
+ *     return the GitHub token, and delete the entry (single-use).
+ *
+ * Single-instance only. For horizontal scaling swap with Redis — the
+ * interface here is deliberately small so that's a straight replacement.
+ */
+
+export interface AuthorizeContext {
+    /** The client's PKCE code_challenge (method is always S256). */
+    codeChallenge: string;
+    /** The redirect_uri the client asked us to bounce back to. */
+    clientRedirectUri: string;
+    /** The client's original state value, echoed back unchanged on redirect. */
+    clientState: string;
+    /** Static client_id the client registered with (or the v1 default). */
+    clientId: string;
+    /** Epoch ms; record is garbage-collected after ttlMs elapses. */
+    createdAt: number;
+}
+
+export interface AuthCodeContext {
+    /** Bearer token received from GitHub's token endpoint. */
+    githubAccessToken: string;
+    /** Scopes GitHub granted (space-separated). */
+    scope: string;
+    /** Same PKCE challenge we stored at authorize time, verified on token exchange. */
+    codeChallenge: string;
+    /** Client redirect_uri — verified against the one sent on token exchange. */
+    clientRedirectUri: string;
+    /** Epoch ms. */
+    createdAt: number;
+}
+
+export class StateStore<T extends { createdAt: number }> {
+    private readonly entries = new Map<string, T>();
+
+    constructor(private readonly ttlMs: number) {}
+
+    set(key: string, value: T): void {
+        this.sweep();
+        this.entries.set(key, value);
+    }
+
+    /**
+     * Single-use: returns the entry and removes it in one step. Callers
+     * must not retry after consuming — both state keys and auth codes are
+     * specified as single-use.
+     */
+    take(key: string): T | null {
+        this.sweep();
+        const entry = this.entries.get(key);
+        if (!entry) return null;
+        this.entries.delete(key);
+        if (Date.now() - entry.createdAt > this.ttlMs) {
+            return null;
+        }
+        return entry;
+    }
+
+    /** Exposed for tests and potential admin endpoints. */
+    size(): number {
+        this.sweep();
+        return this.entries.size;
+    }
+
+    private sweep(): void {
+        const cutoff = Date.now() - this.ttlMs;
+        for (const [key, entry] of this.entries) {
+            if (entry.createdAt < cutoff) {
+                this.entries.delete(key);
+            }
+        }
+    }
+}

--- a/packages/mcp-hosted/src/oauth/well-known.ts
+++ b/packages/mcp-hosted/src/oauth/well-known.ts
@@ -1,0 +1,68 @@
+import type { HostedConfig } from '../config.js';
+import { REQUIRED_GITHUB_SCOPES } from './github.js';
+
+/**
+ * RFC 9728 "Protected Resource Metadata". MCP clients (like runtight)
+ * fetch this at the URL advertised via WWW-Authenticate to discover
+ * which authorization server guards this resource.
+ */
+export function oauthProtectedResourceMetadata(config: HostedConfig): {
+    resource: string;
+    authorization_servers: string[];
+    scopes_supported: string[];
+    bearer_methods_supported: string[];
+} {
+    const base = requireBaseUrl(config);
+    return {
+        resource: base,
+        authorization_servers: [base],
+        scopes_supported: REQUIRED_GITHUB_SCOPES,
+        bearer_methods_supported: ['header'],
+    };
+}
+
+/**
+ * RFC 8414 "Authorization Server Metadata". Describes our OAuth
+ * endpoints and the features we support. MCP clients use this to
+ * drive the authorization flow without hardcoding our URL shapes.
+ */
+export function oauthAuthorizationServerMetadata(config: HostedConfig): {
+    issuer: string;
+    authorization_endpoint: string;
+    token_endpoint: string;
+    registration_endpoint: string;
+    response_types_supported: string[];
+    grant_types_supported: string[];
+    code_challenge_methods_supported: string[];
+    token_endpoint_auth_methods_supported: string[];
+    scopes_supported: string[];
+} {
+    const base = requireBaseUrl(config);
+    return {
+        issuer: base,
+        authorization_endpoint: `${base}/oauth/authorize`,
+        token_endpoint: `${base}/oauth/token`,
+        registration_endpoint: `${base}/oauth/register`,
+        response_types_supported: ['code'],
+        grant_types_supported: ['authorization_code'],
+        code_challenge_methods_supported: ['S256'],
+        // 'none' = public client (PKCE-only). We don't accept client secrets
+        // from the MCP client — the only secret in play is the GitHub
+        // OAuth App client_secret, which is server-side.
+        token_endpoint_auth_methods_supported: ['none'],
+        scopes_supported: REQUIRED_GITHUB_SCOPES,
+    };
+}
+
+/**
+ * Both metadata docs embed absolute URLs, so the server must know its
+ * public origin. In development this can fall back to a localhost URL,
+ * but for any real client interaction baseUrl must be set.
+ */
+function requireBaseUrl(config: HostedConfig): string {
+    if (config.baseUrl) return config.baseUrl.replace(/\/+$/, '');
+    // Dev fallback — authorize flow still won't round-trip against
+    // GitHub without a reachable baseUrl, but /.well-known returning
+    // *something* is better than 500 during local smoke tests.
+    return `http://localhost:${config.port}`;
+}


### PR DESCRIPTION
Part of #276. Closes #279.

## Summary

Implements end-to-end OAuth 2.1 on the hosted GHP MCP server so MCP clients (runtight first) can authenticate end-users with GitHub through a proper consent flow — no more PATs in request bodies. Replaces the 501 `.well-known` stubs from #278 with real RFC 9728 / RFC 8414 metadata, mediates PKCE S256 on the server side (GitHub OAuth Apps don't natively support PKCE), and ships with comprehensive flow tests.

## Changes

New modules under `packages/mcp-hosted/src/oauth/`:

- **`state-store.ts`** — ephemeral TTL map for authorize state + single-use auth codes. Hard cap at 100k entries to bound memory under attack. Swappable for Redis later (interface is deliberately small).
- **`pkce.ts`** — S256 verify + challenge-shape validator. Constant-time compare via `timingSafeEqual`. RFC 7636 §4.1 / §4.2 charset + length enforcement.
- **`github.ts`** — thin GitHub OAuth App client. Authorize-URL builder, code→token exchange. `GithubExchangeError` distinguishes upstream failures from internal bugs.
- **`well-known.ts`** — RFC 9728 PRM + RFC 8414 AS metadata generators.
- **`routes.ts`** — `/oauth/register`, `/oauth/authorize`, `/oauth/callback`, `/oauth/token` handlers. Mounts all routes + the two real well-known docs.

Config additions (all required except TTL):
- `GHP_GITHUB_OAUTH_CLIENT_ID`
- `GHP_GITHUB_OAUTH_CLIENT_SECRET`
- `GHP_ALLOWED_REDIRECT_URIS` (exact-match allowlist, comma-separated)
- `GHP_OAUTH_STATE_TTL_SECONDS` (default 600)

Other:
- Default `PORT` shifted from 3000 → 8731 to avoid common local collisions.
- WWW-Authenticate 401 header on `/mcp` now emits the absolute `resource_metadata` URL.
- Form-encoded body parser mounted narrowly on `/oauth/token` only; `/mcp` stays JSON-only.
- README: new OAuth flow diagram, Tailscale Funnel quickstart, env-table entries, explicit note that redirect_uri matching is exact-binary.

## Why

Runtight's MCP client infrastructure (`server/utils/ai/mcp-oauth-flow.ts`) already speaks RFC 9728 + RFC 8414 + RFC 7591 + PKCE. The only missing piece was a compliant AS on the GHP side. This PR closes that gap and makes the hosted MCP genuinely consumable by any MCP-Authorization-spec client without PAT handoff.

## Decisions made

- **Pass-through token strategy.** `/oauth/token` returns the raw GitHub Bearer. Simpler, stateless, matches MCP spec intent. Revocation is GitHub-controlled. **Wrapping tokens** (where we issue our own opaque tokens mapping to GitHub tokens, enabling independent revocation) are a possible future iteration when multi-tenant accounting lands.
- **In-memory state store, not Redis.** Hard cap + short TTL make a single-instance deploy safe. `StateStore<T>` has a deliberately minimal interface so Redis is a straight swap when horizontal scaling arrives.
- **PKCE mediation on server side.** GitHub OAuth Apps don't accept `code_challenge`. So the MCP client's challenge is stashed in our authorize store; GitHub only sees our server-side state. The client's original state is echoed back unchanged on the final redirect, ensuring end-to-end CSRF protection.
- **Static DCR client_id.** `ghp-mcp-hosted-public-client` for v1. Pass-through tokens mean per-tenant client records aren't load-bearing. Real DCR lands when we move to wrapping tokens.
- **Exact-match redirect_uri allowlist.** No normalization beyond whitespace trimming. Trailing slash / host case / explicit default port all count. Strict by design — any normalization is a potential bypass.

## Code review applied

Seven findings from `pr-review-toolkit:code-reviewer`, all addressed in commit \`51406c9\`:

| # | Severity | Finding | Fix |
|---|----------|---------|-----|
| 1 | critical | `verifyPkce` length check was incidentally correct — stored `code_challenge` shape was never validated at authorize time | New `isValidChallenge()` (43-char base64url), called from `handleAuthorize` |
| 2 | critical | pkce test "rejects disallowed chars" actually tested a valid case + a length-rejected one | Restructured to a 43-char verifier with embedded `!` so charset rejection is unambiguous; added dedicated `isValidChallenge` suite |
| 3 | important | StateStore uncapped — attacker floods `/oauth/authorize` to exhaust memory | `maxEntries` cap (default 100k) + `StateStoreCapacityError`; authorize route returns 503 + `Retry-After` |
| 4 | important | Redirect_uri allowlist is raw string match — operators will fight trailing-slash/case differences | README called out explicitly |
| 5 | important | GitHub error_description echoed back through client-controlled redirect | Generic client-facing message; real reason logged server-side |
| 6 | important | `res.json()` on non-JSON body throws bare SyntaxError | Wrapped in try/catch; throws `GithubExchangeError` with a controlled message |
| 7 | important | No tests for expired state or expired auth code | Added two TTL-expiry tests with `vi.useFakeTimers()` |

## Tests

|                                 | before | after |
|---------------------------------|--------|-------|
| `@bretwardjames/ghp-mcp-hosted` | 31     | **68** |
| workspace total                 | 258    | **296** |

New coverage:
- `pkce.test.ts` — S256 match/mismatch, length + charset validation, method rejection, isValidChallenge
- `state-store.test.ts` — set/take/single-use/TTL/sweep/capacity cap
- `routes.test.ts` — 3-leg happy path, DCR allowlist, PKCE mismatch, redirect_uri mismatch, code reuse, state reuse, GitHub consent error bubble-up, TTL expiry for both stores
- `http-server.test.ts` — updated for real well-known metadata + absolute resource_metadata URL

## Test plan

- [x] `pnpm --filter @bretwardjames/ghp-mcp-hosted build` clean
- [x] `pnpm --filter @bretwardjames/ghp-mcp-hosted test` — 68/68
- [x] `pnpm build` (workspace) clean
- [x] `pnpm test` (workspace) — 296/296
- [ ] Create a test GitHub OAuth App (user side), run through the flow end-to-end behind Tailscale Funnel, confirm user→github consent→callback→token exchange returns the GitHub Bearer
- [ ] Verify runtight's `server/utils/ai/mcp-oauth-flow.ts:discoverAndRegister()` can drive the flow without modification (it implements the same RFCs we advertise)

## Follow-ups

- **#280** — Dockerfile + Railway deploy config (needed before runtight can point at a real URL)
- **#281** — Register in runtight + E2E integration test
- Wrapping-token strategy (independent revocation) — deferred until tenant accounting warrants it

---
Generated with [Claude Code](https://claude.ai/code)