### PR TITLE
Planning meeting driver: interactive session tools (start/next/decide/park/status/end)

### DIFF
--- a/packages/core/src/planning/index.ts
+++ b/packages/core/src/planning/index.ts
@@ -12,3 +12,16 @@ export {
     type ReviewSentinel,
 } from './review-sentinel.js';
 export { PlanningSessionStore } from './session-store.js';
+export {
+    buildQueue,
+    type QueueInputItem,
+    type QueueBuildInput,
+} from './queue-builder.js';
+export {
+    parsePriority,
+    priorityRank,
+    daysSince,
+    isFreshEnoughToSurface,
+    compareStalenessAndPriority,
+    type PriorityTier,
+} from './ranking.js';

--- a/packages/core/src/planning/queue-builder.test.ts
+++ b/packages/core/src/planning/queue-builder.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect } from 'vitest';
+import { buildQueue, type QueueInputItem } from './queue-builder.js';
+
+const NOW = new Date('2026-04-22T00:00:00Z');
+
+function item(overrides: Partial<QueueInputItem>): QueueInputItem {
+    return {
+        number: 1,
+        title: 'Test issue',
+        url: 'https://example.com/1',
+        status: 'Backlog',
+        priority: null,
+        size: null,
+        assignees: [],
+        lastReviewed: null,
+        iterationTitle: null,
+        ...overrides,
+    };
+}
+
+describe('buildQueue — weekly', () => {
+    const base = {
+        meetingType: 'weekly' as const,
+        currentSprintTitle: 'Sprint 42',
+        upcomingSprintTitles: ['Sprint 43', 'Sprint 44'] as const,
+        minDaysSinceLastReview: 7,
+        now: NOW,
+    };
+
+    it('surfaces untriaged backlog + unscheduled kill list in meeting-step order', () => {
+        const queue = buildQueue({
+            ...base,
+            items: [
+                item({ number: 1, status: 'Backlog', lastReviewed: null }),
+                item({ number: 2, status: 'Kill List', iterationTitle: null }),
+                item({
+                    number: 3,
+                    status: 'Kill List',
+                    iterationTitle: 'Sprint 42',
+                    assignees: [],
+                }),
+            ],
+        });
+        // current-sprint-unassigned (#3) must come first (step 4 before step 5)
+        expect(queue.map((q) => q.number)).toEqual([3, 1, 2]);
+        expect(queue.map((q) => q.bucket)).toEqual([
+            'current-sprint-unassigned',
+            'untriaged-backlog',
+            'unscheduled-kill-list',
+        ]);
+    });
+
+    it('excludes items reviewed within the freshness window (don\'t resurface weekly)', () => {
+        const queue = buildQueue({
+            ...base,
+            items: [
+                item({ number: 1, status: 'Backlog', lastReviewed: '2026-04-21' }), // 1d ago
+                item({ number: 2, status: 'Backlog', lastReviewed: '2026-04-10' }), // 12d ago
+            ],
+        });
+        expect(queue.map((q) => q.number)).toEqual([2]);
+    });
+
+    it('within a bucket, ranks by staleness desc then priority desc', () => {
+        const queue = buildQueue({
+            ...base,
+            items: [
+                item({ number: 1, status: 'Backlog', lastReviewed: '2026-04-08', priority: 'Low' }),
+                item({ number: 2, status: 'Backlog', lastReviewed: '2026-03-20', priority: 'Low' }),
+                item({ number: 3, status: 'Backlog', lastReviewed: '2026-03-20', priority: 'High' }),
+            ],
+        });
+        // #2 + #3 are tied on staleness (older than #1). Priority breaks tie.
+        // Overall order: [3 (older + high), 2 (older + low), 1 (newer + low)]
+        expect(queue.map((q) => q.number)).toEqual([3, 2, 1]);
+    });
+
+    it('current-sprint-unassigned skips the freshness filter', () => {
+        const queue = buildQueue({
+            ...base,
+            items: [
+                item({
+                    number: 1,
+                    status: 'Kill List',
+                    iterationTitle: 'Sprint 42',
+                    assignees: [],
+                    lastReviewed: '2026-04-21', // 1d ago — fresh
+                }),
+            ],
+        });
+        // Freshness filter shouldn't apply to sprint-assignment bucket.
+        expect(queue.map((q) => q.number)).toEqual([1]);
+    });
+
+    it('items in the current sprint with an assignee are NOT surfaced', () => {
+        const queue = buildQueue({
+            ...base,
+            items: [
+                item({
+                    number: 1,
+                    status: 'Kill List',
+                    iterationTitle: 'Sprint 42',
+                    assignees: ['bret'],
+                }),
+            ],
+        });
+        expect(queue).toEqual([]);
+    });
+
+    it('past-sprint-stuck: kill-list items in an old iteration get flagged', () => {
+        const queue = buildQueue({
+            ...base,
+            items: [
+                item({
+                    number: 1,
+                    status: 'Kill List',
+                    iterationTitle: 'Sprint 39', // neither current nor upcoming
+                }),
+            ],
+        });
+        expect(queue[0]?.bucket).toBe('past-sprint-stuck');
+    });
+
+    it('forward-planning buckets split next vs next+1', () => {
+        const queue = buildQueue({
+            ...base,
+            items: [
+                item({ number: 1, status: 'Kill List', iterationTitle: 'Sprint 43' }),
+                item({ number: 2, status: 'Kill List', iterationTitle: 'Sprint 44' }),
+            ],
+        });
+        const byNum = Object.fromEntries(queue.map((q) => [q.number, q.bucket]));
+        expect(byNum[1]).toBe('next-sprint');
+        expect(byNum[2]).toBe('next-plus-one-sprint');
+    });
+
+    it('ready-for-release items surface last', () => {
+        const queue = buildQueue({
+            ...base,
+            items: [
+                item({ number: 1, status: 'Backlog', lastReviewed: null }),
+                item({ number: 2, status: 'Ready for Release', lastReviewed: null }),
+            ],
+        });
+        expect(queue.map((q) => q.number)).toEqual([1, 2]);
+    });
+
+    it('items with no matching bucket are dropped', () => {
+        const queue = buildQueue({
+            ...base,
+            items: [
+                item({ number: 1, status: 'In Progress' }),
+                item({ number: 2, status: 'Done' }),
+            ],
+        });
+        expect(queue).toEqual([]);
+    });
+});

--- a/packages/core/src/planning/queue-builder.ts
+++ b/packages/core/src/planning/queue-builder.ts
@@ -1,0 +1,176 @@
+import type { PlanningBucket, PlanningItem, MeetingType } from './types.js';
+import { parsePriority, isFreshEnoughToSurface, compareStalenessAndPriority } from './ranking.js';
+
+/**
+ * Minimal shape of a project item the queue builder consumes. Mirrors
+ * the subset of `ProjectItem` (from core/types.ts) we need, plus one
+ * derived field (`iterationTitle`) the caller resolves from the
+ * project's iteration field. Kept as a local interface so the queue
+ * builder is trivially testable with literals.
+ */
+export interface QueueInputItem {
+    number: number;
+    title: string;
+    url: string | null;
+    status: string | null;
+    priority: string | null;
+    size: string | null;
+    assignees: string[];
+    /** ISO date from the Last Reviewed field, or sentinel, or null. */
+    lastReviewed: string | null;
+    iterationTitle: string | null;
+}
+
+export interface QueueBuildInput {
+    items: ReadonlyArray<QueueInputItem>;
+    meetingType: MeetingType;
+    currentSprintTitle: string | null;
+    upcomingSprintTitles: ReadonlyArray<string>; // ordered: [next, next+1, ...]
+    minDaysSinceLastReview: number;
+    now?: Date;
+}
+
+/**
+ * Compose a ranked planning queue from project items. The queue
+ * preserves bucket order (the flow doc's meeting steps) and ranks
+ * within each bucket by (staleness desc, priority desc).
+ *
+ * Fresh items (reviewed within `minDaysSinceLastReview`) are excluded
+ * outright — per the flow-doc goal of not resurfacing the same ticket
+ * week after week. Exception: items in the current sprint still need
+ * assignment, so the current-sprint bucket doesn't apply the fresh-
+ * ness filter.
+ */
+export function buildQueue(input: QueueBuildInput): PlanningItem[] {
+    const now = input.now ?? new Date();
+    const weekly = input.meetingType === 'weekly' || input.meetingType === 'milestone-boundary';
+
+    const bucketed: Record<PlanningBucket, PlanningItem[]> = {
+        'current-sprint-unassigned': [],
+        'past-sprint-stuck': [],
+        'untriaged-backlog': [],
+        'resurfacing-backlog': [],
+        'next-sprint': [],
+        'next-plus-one-sprint': [],
+        'unscheduled-kill-list': [],
+        'ready-for-release': [],
+        'milestone-open': [],
+        'full-backlog': [],
+    };
+
+    for (const item of input.items) {
+        const bucket = classifyBucket(item, input);
+        if (!bucket) continue;
+        // Freshness filter — the current-sprint bucket is exempt because
+        // sprint assignment isn't the same as a review, and we'd lock
+        // out sprint planning otherwise.
+        if (bucket !== 'current-sprint-unassigned' && bucket !== 'past-sprint-stuck') {
+            if (!isFreshEnoughToSurface(item.lastReviewed, input.minDaysSinceLastReview, now)) {
+                continue;
+            }
+        }
+        bucketed[bucket].push({
+            number: item.number,
+            title: item.title,
+            url: item.url ?? '',
+            priority: item.priority,
+            size: item.size,
+            lastReviewed: item.lastReviewed,
+            assignees: item.assignees,
+            bucket,
+        });
+    }
+
+    // Rank within each bucket.
+    for (const key of Object.keys(bucketed) as PlanningBucket[]) {
+        bucketed[key].sort((a, b) =>
+            compareStalenessAndPriority(
+                {
+                    number: a.number,
+                    lastReviewed: a.lastReviewed,
+                    priority: parsePriority(a.priority),
+                },
+                {
+                    number: b.number,
+                    lastReviewed: b.lastReviewed,
+                    priority: parsePriority(b.priority),
+                },
+                now
+            )
+        );
+    }
+
+    // Concatenate buckets in the flow-doc meeting-step order.
+    const weeklyOrder: PlanningBucket[] = [
+        'current-sprint-unassigned',
+        'past-sprint-stuck',
+        'untriaged-backlog',
+        'resurfacing-backlog',
+        'next-sprint',
+        'next-plus-one-sprint',
+        'unscheduled-kill-list',
+        'ready-for-release',
+    ];
+    const boundaryExtras: PlanningBucket[] = ['milestone-open', 'full-backlog'];
+    const order = weekly
+        ? input.meetingType === 'milestone-boundary'
+            ? [...weeklyOrder, ...boundaryExtras]
+            : weeklyOrder
+        : weeklyOrder;
+
+    return order.flatMap((b) => bucketed[b]);
+}
+
+function classifyBucket(
+    item: QueueInputItem,
+    input: QueueBuildInput
+): PlanningBucket | null {
+    const status = (item.status ?? '').toLowerCase();
+
+    // Step 4 — sprint assignment
+    if (item.iterationTitle === input.currentSprintTitle) {
+        if (item.assignees.length === 0 && status === 'kill list') {
+            return 'current-sprint-unassigned';
+        }
+        return null; // current sprint, already assigned → not surfaced
+    }
+    if (
+        item.iterationTitle &&
+        input.currentSprintTitle &&
+        item.iterationTitle !== input.currentSprintTitle &&
+        !input.upcomingSprintTitles.includes(item.iterationTitle) &&
+        status === 'kill list'
+    ) {
+        return 'past-sprint-stuck';
+    }
+
+    // Step 5 — triage + backlog resurface
+    if (status === 'backlog') {
+        if (!item.lastReviewed) return 'untriaged-backlog';
+        return 'resurfacing-backlog';
+    }
+
+    // Step 6 — forward planning
+    if (status === 'kill list') {
+        if (item.iterationTitle === input.upcomingSprintTitles[0]) {
+            return 'next-sprint';
+        }
+        if (item.iterationTitle === input.upcomingSprintTitles[1]) {
+            return 'next-plus-one-sprint';
+        }
+        if (!item.iterationTitle) {
+            return 'unscheduled-kill-list';
+        }
+    }
+
+    // Step 7 — release check
+    if (status === 'ready for release') {
+        return 'ready-for-release';
+    }
+
+    // Milestone-boundary extras are bucketed separately by the caller
+    // passing the right meetingType; for now they share the backlog
+    // buckets (the full-backlog pass is additive, not corrective).
+
+    return null;
+}

--- a/packages/core/src/planning/ranking.test.ts
+++ b/packages/core/src/planning/ranking.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from 'vitest';
+import {
+    compareStalenessAndPriority,
+    daysSince,
+    isFreshEnoughToSurface,
+    parsePriority,
+    priorityRank,
+} from './ranking.js';
+
+const NOW = new Date('2026-04-22T00:00:00Z');
+
+describe('parsePriority', () => {
+    it('accepts every flow-doc label + common aliases', () => {
+        expect(parsePriority('Urgent')).toBe('urgent');
+        expect(parsePriority('HIGH')).toBe('high');
+        expect(parsePriority('med')).toBe('med');
+        expect(parsePriority('Medium')).toBe('med');
+        expect(parsePriority('low')).toBe('low');
+    });
+    it('falls back to unset for null / unknown', () => {
+        expect(parsePriority(null)).toBe('unset');
+        expect(parsePriority('')).toBe('unset');
+        expect(parsePriority('P0')).toBe('unset');
+    });
+});
+
+describe('priorityRank', () => {
+    it('ranks urgent > high > med > low > unset', () => {
+        expect(priorityRank('urgent')).toBeGreaterThan(priorityRank('high'));
+        expect(priorityRank('high')).toBeGreaterThan(priorityRank('med'));
+        expect(priorityRank('med')).toBeGreaterThan(priorityRank('low'));
+        expect(priorityRank('low')).toBeGreaterThan(priorityRank('unset'));
+    });
+});
+
+describe('daysSince', () => {
+    it('returns null when never reviewed', () => {
+        expect(daysSince(null, NOW)).toBeNull();
+    });
+    it('returns age in days (UTC)', () => {
+        expect(daysSince('2026-04-15', NOW)).toBe(7);
+        expect(daysSince('2026-04-22', NOW)).toBe(0);
+    });
+    it('returns null on unparseable input', () => {
+        expect(daysSince('not-a-date', NOW)).toBeNull();
+    });
+});
+
+describe('isFreshEnoughToSurface', () => {
+    it('never-reviewed items always pass', () => {
+        expect(isFreshEnoughToSurface(null, 7, NOW)).toBe(true);
+    });
+    it('excludes items reviewed within the threshold', () => {
+        expect(isFreshEnoughToSurface('2026-04-20', 7, NOW)).toBe(false); // 2d ago
+    });
+    it('passes items older than the threshold', () => {
+        expect(isFreshEnoughToSurface('2026-04-10', 7, NOW)).toBe(true); // 12d ago
+    });
+    it('boundary: exactly at threshold counts as fresh enough', () => {
+        expect(isFreshEnoughToSurface('2026-04-15', 7, NOW)).toBe(true); // exactly 7d
+    });
+});
+
+describe('compareStalenessAndPriority', () => {
+    it('never-reviewed items come first regardless of priority', () => {
+        const untriagedLow = {
+            number: 1,
+            lastReviewed: null,
+            priority: 'low' as const,
+        };
+        const recentUrgent = {
+            number: 2,
+            lastReviewed: '2026-04-21',
+            priority: 'urgent' as const,
+        };
+        expect(
+            compareStalenessAndPriority(untriagedLow, recentUrgent, NOW)
+        ).toBeLessThan(0);
+    });
+
+    it('within same staleness, higher priority wins', () => {
+        const a = { number: 1, lastReviewed: '2026-04-10', priority: 'high' as const };
+        const b = { number: 2, lastReviewed: '2026-04-10', priority: 'low' as const };
+        expect(compareStalenessAndPriority(a, b, NOW)).toBeLessThan(0);
+    });
+
+    it('stalest-first: older lastReviewed comes first', () => {
+        const older = {
+            number: 1,
+            lastReviewed: '2026-03-01',
+            priority: 'low' as const,
+        };
+        const newer = {
+            number: 2,
+            lastReviewed: '2026-04-10',
+            priority: 'low' as const,
+        };
+        expect(compareStalenessAndPriority(older, newer, NOW)).toBeLessThan(0);
+    });
+
+    it('ties break on issue number (deterministic)', () => {
+        const a = {
+            number: 10,
+            lastReviewed: '2026-04-10',
+            priority: 'high' as const,
+        };
+        const b = {
+            number: 5,
+            lastReviewed: '2026-04-10',
+            priority: 'high' as const,
+        };
+        expect(compareStalenessAndPriority(a, b, NOW)).toBeGreaterThan(0);
+        expect(compareStalenessAndPriority(b, a, NOW)).toBeLessThan(0);
+    });
+});

--- a/packages/core/src/planning/ranking.ts
+++ b/packages/core/src/planning/ranking.ts
@@ -1,0 +1,97 @@
+/**
+ * Priority + staleness helpers for the queue builder.
+ *
+ * Pure functions, fixture-driven. Tests live in ranking.test.ts and
+ * drive every branch without touching GraphQL.
+ */
+
+/**
+ * Priority labels the flow doc defines: Low / Med / High / Urgent.
+ * We accept any casing plus the common alias "Medium".
+ */
+export type PriorityTier = 'urgent' | 'high' | 'med' | 'low' | 'unset';
+
+const PRIORITY_RANK: Record<PriorityTier, number> = {
+    urgent: 4,
+    high: 3,
+    med: 2,
+    low: 1,
+    unset: 0,
+};
+
+export function parsePriority(raw: string | null | undefined): PriorityTier {
+    if (!raw) return 'unset';
+    const v = raw.trim().toLowerCase();
+    if (v === 'urgent') return 'urgent';
+    if (v === 'high') return 'high';
+    if (v === 'medium' || v === 'med') return 'med';
+    if (v === 'low') return 'low';
+    return 'unset';
+}
+
+export function priorityRank(p: PriorityTier): number {
+    return PRIORITY_RANK[p];
+}
+
+/**
+ * Days since the item was last reviewed. Returns null when the item
+ * has never been reviewed — those are the highest-signal items for the
+ * planning meeting and get special-cased in the queue builder.
+ */
+export function daysSince(
+    lastReviewed: string | null,
+    now: Date = new Date()
+): number | null {
+    if (!lastReviewed) return null;
+    const then = Date.parse(lastReviewed);
+    if (Number.isNaN(then)) return null;
+    const diffMs = now.getTime() - then;
+    return Math.floor(diffMs / (24 * 60 * 60 * 1000));
+}
+
+/**
+ * Rolling-window freshness filter. Items reviewed within the last
+ * `minDays` are EXCLUDED from the queue so the same item doesn't
+ * resurface week over week. Never-reviewed items always pass.
+ */
+export function isFreshEnoughToSurface(
+    lastReviewed: string | null,
+    minDaysSinceLastReview: number,
+    now: Date = new Date()
+): boolean {
+    const age = daysSince(lastReviewed, now);
+    if (age === null) return true; // never reviewed
+    return age >= minDaysSinceLastReview;
+}
+
+/**
+ * Two-key sort comparator:
+ *   1. Staleness (oldest first; never-reviewed = +Infinity stale)
+ *   2. Priority (Urgent > High > Med > Low > unset)
+ *
+ * Returns negative when a should come first. Stable-by-default — same-
+ * staleness-same-priority ties fall back to issue number asc so
+ * identical configurations always sort the same way.
+ */
+export function compareStalenessAndPriority(
+    a: {
+        lastReviewed: string | null;
+        priority: PriorityTier;
+        number: number;
+    },
+    b: {
+        lastReviewed: string | null;
+        priority: PriorityTier;
+        number: number;
+    },
+    now: Date = new Date()
+): number {
+    const aAge = daysSince(a.lastReviewed, now);
+    const bAge = daysSince(b.lastReviewed, now);
+    const aStale = aAge === null ? Number.POSITIVE_INFINITY : aAge;
+    const bStale = bAge === null ? Number.POSITIVE_INFINITY : bAge;
+    if (aStale !== bStale) return bStale - aStale; // older first
+    const prDelta = priorityRank(b.priority) - priorityRank(a.priority);
+    if (prDelta !== 0) return prDelta;
+    return a.number - b.number; // deterministic tiebreak
+}

--- a/packages/core/src/planning/session-store.test.ts
+++ b/packages/core/src/planning/session-store.test.ts
@@ -28,7 +28,7 @@ function fixture(
         queue: [],
         decisions: {},
         parked: [],
-        activeItemNumber: null,
+        activeItem: null,
         activeItemSince: null,
         ...overrides,
     };
@@ -82,9 +82,18 @@ describe('PlanningSessionStore', () => {
     it('update mutates an existing session without touching inactive ones', () => {
         store.start(fixture());
         const session = store.get('s1')!;
-        session.activeItemNumber = 42;
+        session.activeItem = {
+            number: 42,
+            title: 'T',
+            url: '',
+            priority: null,
+            size: null,
+            lastReviewed: null,
+            assignees: [],
+            bucket: 'untriaged-backlog',
+        };
         store.update(session);
-        expect(store.get('s1')?.activeItemNumber).toBe(42);
+        expect(store.get('s1')?.activeItem?.number).toBe(42);
     });
 
     it('update on unknown id is a no-op', () => {

--- a/packages/core/src/planning/types.ts
+++ b/packages/core/src/planning/types.ts
@@ -185,7 +185,7 @@ export interface PlanningSession {
     /** Stack of items explicitly parked (returned to the bottom). */
     parked: number[];
     /** Currently-in-front-of-the-team item, for `planning.status` timing. */
-    activeItemNumber: number | null;
+    activeItem: PlanningItem | null;
     activeItemSince: number | null; // epoch ms
 }
 

--- a/packages/mcp/src/tool-registry.test.ts
+++ b/packages/mcp/src/tool-registry.test.ts
@@ -48,6 +48,31 @@ vi.mock('@bretwardjames/ghp-core', () => ({
     validateNumericInput: vi.fn((n) => n),
     validateSafeString: vi.fn((s) => s),
     BranchLinker: vi.fn(),
+    planning: {
+        probeProjectFields: vi.fn(() => ({
+            projectId: 'P',
+            projectTitle: 'T',
+            detected: {},
+            fallbacks: [],
+            suggestions: [],
+        })),
+        auditTimeline: vi.fn(() => ({
+            iterations: { current: null, upcoming: [], completed: 0 },
+            milestones: { current: null, upcoming: [], stale: [] },
+            findings: [],
+        })),
+        buildQueue: vi.fn(() => []),
+        PlanningSessionStore: class {
+            start() {}
+            get() { return null; }
+            getActiveForOwner() { return null; }
+            update() {}
+            end() { return null; }
+            size() { return 0; }
+        },
+        upsertSentinel: vi.fn((body) => body ?? ''),
+        todayIsoDate: vi.fn(() => '2026-04-22'),
+    },
 }));
 
 // Import after mocks

--- a/packages/mcp/src/tool-registry.ts
+++ b/packages/mcp/src/tool-registry.ts
@@ -41,6 +41,12 @@ import * as fieldsTool from './tools/fields.js';
 import * as tagsTool from './tools/tags.js';
 // Planning meeting driver
 import * as planningAuditTool from './tools/planning-audit.js';
+import * as planningStartTool from './tools/planning-start.js';
+import * as planningNextTool from './tools/planning-next.js';
+import * as planningDecideTool from './tools/planning-decide.js';
+import * as planningParkTool from './tools/planning-park.js';
+import * as planningStatusTool from './tools/planning-status.js';
+import * as planningEndTool from './tools/planning-end.js';
 
 // Re-export types
 export type { ToolCategory, ToolCapability, McpConfig, McpToolsConfig } from './types.js';
@@ -94,8 +100,14 @@ const TOOLS: ToolModule[] = [
     // Worktree tools
     worktreeTool,
     removeWorktreeTool,
-    // Planning
+    // Planning — readiness + stateful meeting driver
     planningAuditTool,
+    planningStartTool,
+    planningNextTool,
+    planningDecideTool,
+    planningParkTool,
+    planningStatusTool,
+    planningEndTool,
 ];
 
 /**

--- a/packages/mcp/src/tools/planning-decide.ts
+++ b/packages/mcp/src/tools/planning-decide.ts
@@ -1,0 +1,181 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import * as z from 'zod';
+import type { ServerContext } from '../server.js';
+import type { ToolMeta } from '../types.js';
+import { planning } from '@bretwardjames/ghp-core';
+import { getPlanningStore } from './planning-session.js';
+
+/** Tool metadata for registry */
+export const meta: ToolMeta = {
+    name: 'planning_decide',
+    category: 'action',
+    capability: 'pure-api',
+};
+
+/**
+ * Record a verdict for the active item and advance to the next one.
+ *
+ * The tool writes "Last Reviewed" either to the project's Date field
+ * (when present) or as a sentinel comment in the issue body (fallback).
+ * This is what prevents the same item resurfacing next week.
+ *
+ * The tool DOES NOT change the issue's status — the LLM invokes
+ * existing tools (move_issue, mark_done, add_comment, …) for the
+ * actual mutation. `planning_decide` is strictly a "we discussed this
+ * and decided X, move on" signal.
+ */
+export function register(server: McpServer, context: ServerContext): void {
+    server.registerTool(
+        'planning_decide',
+        {
+            title: 'Record Planning Decision',
+            description:
+                'Record a decision on the currently-active planning item: write Last Reviewed (via project field or sentinel comment), store the verdict, and advance to the next item. Does NOT change issue status — run move_issue / mark_done / etc. separately for that.',
+            inputSchema: {
+                sessionId: z.string().describe('Session id from planning_start'),
+                issueNumber: z
+                    .number()
+                    .int()
+                    .positive()
+                    .describe('The issue number we are deciding on (must match active item).'),
+                decision: z
+                    .enum([
+                        'kill-list',
+                        'backlog',
+                        'close',
+                        'bump',
+                        'assign',
+                        'no-change',
+                    ])
+                    .describe('Verdict recorded in the review sentinel.'),
+                notes: z
+                    .string()
+                    .max(500)
+                    .optional()
+                    .describe('Optional short note to include in the session summary.'),
+            },
+        },
+        async ({ sessionId, issueNumber, decision, notes }) => {
+            const store = getPlanningStore();
+            const session = store.get(sessionId);
+            if (!session) return errorResponse('Session not found or expired.');
+
+            if (!session.activeItem || session.activeItem.number !== issueNumber) {
+                return errorResponse(
+                    `Active item is #${session.activeItem?.number ?? 'none'}, but decision targets #${issueNumber}. Call planning_next first.`
+                );
+            }
+
+            const repo = await context.getRepo();
+            if (!repo) return errorResponse('Not in a GitHub repo.');
+
+            // Prefer the real Last Reviewed Date field when the probe
+            // said it exists; fall back to the body sentinel otherwise.
+            const hasRealField =
+                session.capability.detected['Last Reviewed'] === true;
+
+            let sentinelWritten = false;
+            const today = planning.todayIsoDate();
+
+            if (hasRealField) {
+                // Write via the project field. Need the item's project
+                // item ID + the Last Reviewed field ID.
+                const fields = await context.api.getProjectFields(
+                    session.capability.projectId
+                );
+                const lastReviewedField = fields.find(
+                    (f) => f.name.toLowerCase() === 'last reviewed'
+                );
+                const items = await context.api.getProjectItems(
+                    session.capability.projectId,
+                    session.capability.projectTitle
+                );
+                const projectItem = items.find((it) => it.number === issueNumber);
+                if (lastReviewedField && projectItem) {
+                    const result = await context.api.setFieldValue(
+                        session.capability.projectId,
+                        projectItem.id,
+                        lastReviewedField.id,
+                        { date: today }
+                    );
+                    sentinelWritten = result.success;
+                }
+            } else {
+                // Fallback path: upsert the sentinel into the issue body.
+                const details = await context.api.getIssueDetails(
+                    repo,
+                    issueNumber
+                );
+                if (details) {
+                    const actor = await resolveActor(context);
+                    const newBody = planning.upsertSentinel(details.body, {
+                        reviewedOn: today,
+                        decision,
+                        by: actor,
+                    });
+                    const ok = await context.api.updateIssueBody(
+                        repo,
+                        issueNumber,
+                        newBody
+                    );
+                    sentinelWritten = ok;
+                }
+            }
+
+            session.decisions[issueNumber] = {
+                decision,
+                notes: notes ?? '',
+                decidedAt: Date.now(),
+                sentinelWritten,
+            };
+
+            // Advance to next item.
+            const nextItem = session.queue[0] ?? null;
+            session.queue = session.queue.slice(1);
+            session.activeItem = nextItem;
+            session.activeItemSince = nextItem ? Date.now() : null;
+            store.update(session);
+
+            return {
+                content: [
+                    {
+                        type: 'text' as const,
+                        text: JSON.stringify(
+                            {
+                                recorded: {
+                                    issueNumber,
+                                    decision,
+                                    sentinelWritten,
+                                    sentinelMode: hasRealField ? 'field' : 'body-sentinel',
+                                },
+                                active: session.activeItem,
+                                queueLength: session.queue.length,
+                                decided: Object.keys(session.decisions).length,
+                            },
+                            null,
+                            2
+                        ),
+                    },
+                ],
+            };
+        }
+    );
+}
+
+async function resolveActor(context: ServerContext): Promise<string> {
+    // `api.authenticate()` caches viewer login via ensureAuthenticated;
+    // we look at the exposed getter if present. Fall back to 'reviewer'
+    // so the sentinel regex still matches even when the login cannot
+    // be resolved.
+    const api = context.api as unknown as { viewerLogin?: string };
+    return typeof api.viewerLogin === 'string' && api.viewerLogin.length > 0
+        ? api.viewerLogin
+        : 'reviewer';
+}
+
+function errorResponse(text: string) {
+    return {
+        content: [{ type: 'text' as const, text: `Error: ${text}` }],
+        isError: true,
+    };
+}

--- a/packages/mcp/src/tools/planning-end.ts
+++ b/packages/mcp/src/tools/planning-end.ts
@@ -1,0 +1,77 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import * as z from 'zod';
+import type { ServerContext } from '../server.js';
+import type { ToolMeta } from '../types.js';
+import { getPlanningStore } from './planning-session.js';
+
+/** Tool metadata for registry */
+export const meta: ToolMeta = {
+    name: 'planning_end',
+    category: 'action',
+    capability: 'pure-api',
+};
+
+/**
+ * Close the session. Returns a summary of decisions + parked items for
+ * the LLM to render as the meeting recap. Does NOT auto-post a recap
+ * comment — the caller can hand the summary back through add_comment
+ * or a separate write if they want it captured in an issue.
+ */
+export function register(server: McpServer, _context: ServerContext): void {
+    server.registerTool(
+        'planning_end',
+        {
+            title: 'End Planning Meeting',
+            description:
+                'Close the active planning session and return a summary: decisions recorded, items parked, items left in the queue, elapsed time. The LLM can hand this summary to add_comment if the team wants it persisted to an issue.',
+            inputSchema: {
+                sessionId: z.string().describe('Session id from planning_start'),
+            },
+        },
+        async ({ sessionId }) => {
+            const store = getPlanningStore();
+            const session = store.end(sessionId);
+            if (!session) {
+                return {
+                    content: [
+                        { type: 'text' as const, text: 'Error: session not found or already ended.' },
+                    ],
+                    isError: true,
+                };
+            }
+
+            const elapsedMinutes = Math.round((Date.now() - session.startedAt) / 60_000);
+            const decisions = Object.entries(session.decisions).map(([num, d]) => ({
+                issueNumber: Number(num),
+                decision: d.decision,
+                notes: d.notes,
+                sentinelWritten: d.sentinelWritten,
+            }));
+
+            return {
+                content: [
+                    {
+                        type: 'text' as const,
+                        text: JSON.stringify(
+                            {
+                                meetingType: session.meetingType,
+                                elapsedMinutes,
+                                totalsReviewed: decisions.length,
+                                decisions,
+                                parked: session.parked,
+                                remainingInQueue: session.queue.length,
+                                remainingItems: session.queue.map((q) => ({
+                                    number: q.number,
+                                    title: q.title,
+                                    bucket: q.bucket,
+                                })),
+                            },
+                            null,
+                            2
+                        ),
+                    },
+                ],
+            };
+        }
+    );
+}

--- a/packages/mcp/src/tools/planning-next.ts
+++ b/packages/mcp/src/tools/planning-next.ts
@@ -1,0 +1,74 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import * as z from 'zod';
+import type { ServerContext } from '../server.js';
+import type { ToolMeta } from '../types.js';
+import { getPlanningStore } from './planning-session.js';
+
+/** Tool metadata for registry */
+export const meta: ToolMeta = {
+    name: 'planning_next',
+    category: 'read',
+    capability: 'pure-api',
+};
+
+/**
+ * Advance to the next item in the queue without recording a decision.
+ * Useful when the team wants to peek at what's coming or the active
+ * item was handled outside the tool (e.g., someone already closed it
+ * manually during the meeting).
+ *
+ * For the normal flow, callers should prefer `planning_decide` which
+ * records the verdict and advances in one step.
+ */
+export function register(server: McpServer, _context: ServerContext): void {
+    server.registerTool(
+        'planning_next',
+        {
+            title: 'Next Planning Item',
+            description:
+                'Advance the planning queue to the next item without recording a decision. Returns { active, queueLength, remaining } or { active: null } when the queue is exhausted.',
+            inputSchema: {
+                sessionId: z.string().describe('Session id from planning_start'),
+            },
+        },
+        async ({ sessionId }) => {
+            const store = getPlanningStore();
+            const session = store.get(sessionId);
+            if (!session) {
+                return {
+                    content: [
+                        {
+                            type: 'text' as const,
+                            text: 'Error: session not found or expired. Start a new one with planning_start.',
+                        },
+                    ],
+                    isError: true,
+                };
+            }
+
+            const nextItem = session.queue[0] ?? null;
+            session.queue = session.queue.slice(1);
+            session.activeItem = nextItem;
+            session.activeItemSince = nextItem ? Date.now() : null;
+            store.update(session);
+
+            return {
+                content: [
+                    {
+                        type: 'text' as const,
+                        text: JSON.stringify(
+                            {
+                                active: session.activeItem,
+                                queueLength: session.queue.length,
+                                decided: Object.keys(session.decisions).length,
+                                parked: session.parked.length,
+                            },
+                            null,
+                            2
+                        ),
+                    },
+                ],
+            };
+        }
+    );
+}

--- a/packages/mcp/src/tools/planning-park.ts
+++ b/packages/mcp/src/tools/planning-park.ts
@@ -1,0 +1,93 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import * as z from 'zod';
+import type { ServerContext } from '../server.js';
+import type { ToolMeta } from '../types.js';
+import { getPlanningStore } from './planning-session.js';
+
+/** Tool metadata for registry */
+export const meta: ToolMeta = {
+    name: 'planning_park',
+    category: 'action',
+    capability: 'pure-api',
+};
+
+/**
+ * Defer the active item: move it to the bottom of the queue without
+ * writing a review sentinel. The team can come back to it later in
+ * the same meeting if there's time. No Last Reviewed update means
+ * parked items will resurface next week exactly as they would have.
+ */
+export function register(server: McpServer, _context: ServerContext): void {
+    server.registerTool(
+        'planning_park',
+        {
+            title: 'Park Planning Item',
+            description:
+                'Defer the active planning item to the end of this session\'s queue. Does NOT record a review (item will resurface next week normally). Use this when a discussion is getting long and the team wants to come back to it with more context.',
+            inputSchema: {
+                sessionId: z.string().describe('Session id from planning_start'),
+                issueNumber: z
+                    .number()
+                    .int()
+                    .positive()
+                    .describe('Active item number. Guards against stale calls.'),
+                reason: z
+                    .string()
+                    .max(280)
+                    .optional()
+                    .describe('Optional short note for the session summary.'),
+            },
+        },
+        async ({ sessionId, issueNumber, reason }) => {
+            const store = getPlanningStore();
+            const session = store.get(sessionId);
+            if (!session) {
+                return {
+                    content: [
+                        { type: 'text' as const, text: 'Error: session not found or expired.' },
+                    ],
+                    isError: true,
+                };
+            }
+            if (!session.activeItem || session.activeItem.number !== issueNumber) {
+                return {
+                    content: [
+                        {
+                            type: 'text' as const,
+                            text: `Error: active item is #${session.activeItem?.number ?? 'none'}, not #${issueNumber}.`,
+                        },
+                    ],
+                    isError: true,
+                };
+            }
+
+            // Move active to the bottom of the queue.
+            const parkedItem = session.activeItem;
+            session.queue.push(parkedItem);
+            session.parked.push(parkedItem.number);
+
+            const nextItem = session.queue.shift() ?? null;
+            session.activeItem = nextItem;
+            session.activeItemSince = nextItem ? Date.now() : null;
+            store.update(session);
+
+            return {
+                content: [
+                    {
+                        type: 'text' as const,
+                        text: JSON.stringify(
+                            {
+                                parked: { number: parkedItem.number, reason: reason ?? null },
+                                active: session.activeItem,
+                                queueLength: session.queue.length,
+                                totalParked: session.parked.length,
+                            },
+                            null,
+                            2
+                        ),
+                    },
+                ],
+            };
+        }
+    );
+}

--- a/packages/mcp/src/tools/planning-session.ts
+++ b/packages/mcp/src/tools/planning-session.ts
@@ -1,0 +1,37 @@
+import { planning } from '@bretwardjames/ghp-core';
+
+/**
+ * Process-wide planning session store.
+ *
+ * Stdio: one MCP process = one user, `ownerKey: 'default'` is fine.
+ * Hosted: each request creates a fresh McpServer, but imports share
+ * the same Node process → this singleton persists across requests in
+ * one container. Hosted must set `ownerKey` from a per-user signal
+ * (bearer token hash, userId, etc.) so tenants don't clobber each
+ * other. That wiring is a follow-up; today hosted would coalesce all
+ * users onto 'default' which is only safe for single-user deploys.
+ */
+const planningStore = new planning.PlanningSessionStore();
+
+export function getPlanningStore(): planning.PlanningSessionStore {
+    return planningStore;
+}
+
+/**
+ * Derive an owner key for the session. Stdio uses a fixed literal;
+ * hosted will override by reading from the request's bearer context.
+ */
+export function ownerKeyForProcess(): string {
+    return process.env.GHP_PLANNING_OWNER_KEY ?? 'default';
+}
+
+export function newSessionId(): string {
+    // 16 bytes of crypto-random, base64url-encoded. Collision-resistant
+    // enough for the ~2h session lifetime without bringing in uuid.
+    const { randomBytes } = require('crypto') as typeof import('crypto');
+    return randomBytes(16)
+        .toString('base64')
+        .replace(/=+$/, '')
+        .replace(/\+/g, '-')
+        .replace(/\//g, '_');
+}

--- a/packages/mcp/src/tools/planning-start.ts
+++ b/packages/mcp/src/tools/planning-start.ts
@@ -1,0 +1,211 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import * as z from 'zod';
+import type { ServerContext } from '../server.js';
+import type { ToolMeta } from '../types.js';
+import { planning } from '@bretwardjames/ghp-core';
+import {
+    getPlanningStore,
+    newSessionId,
+    ownerKeyForProcess,
+} from './planning-session.js';
+
+/** Tool metadata for registry */
+export const meta: ToolMeta = {
+    name: 'planning_start',
+    category: 'action',
+    capability: 'pure-api',
+};
+
+/**
+ * Open an interactive planning-meeting session. Probes the project,
+ * builds a ranked queue of items to discuss, and returns the first
+ * item. The LLM then drives the meeting via planning_next /
+ * planning_decide / planning_park / planning_status / planning_end.
+ */
+export function register(server: McpServer, context: ServerContext): void {
+    server.registerTool(
+        'planning_start',
+        {
+            title: 'Start Planning Meeting',
+            description:
+                'Open a planning-meeting session: capability-probe the project, build a ranked queue of items that need discussion, and return the first item. Freshness filter excludes items reviewed in the last N days so the same ticket does not resurface week over week. Subsequent calls to planning_next / planning_decide / planning_park advance through the queue.',
+            inputSchema: {
+                meetingType: z
+                    .enum(['weekly', 'milestone-boundary'])
+                    .default('weekly')
+                    .describe(
+                        'Weekly: steps 4-7 of the flow doc (sprint assign, triage, forward plan, release check). milestone-boundary: adds milestone wrap-up + full backlog review.'
+                    ),
+                minDaysSinceLastReview: z
+                    .number()
+                    .int()
+                    .min(0)
+                    .max(180)
+                    .default(7)
+                    .describe(
+                        'Skip items reviewed within this many days. Default 7 matches the weekly meeting cadence.'
+                    ),
+                maxMinutesPerTicket: z
+                    .number()
+                    .int()
+                    .min(1)
+                    .max(60)
+                    .default(3)
+                    .describe(
+                        'Soft cap on wall-clock per item. planning_status flags items past this limit so the LLM can suggest parking them.'
+                    ),
+                project: z
+                    .string()
+                    .optional()
+                    .describe(
+                        'Project name. Defaults to the first project linked to the repo.'
+                    ),
+            },
+        },
+        async ({ meetingType, minDaysSinceLastReview, maxMinutesPerTicket, project }) => {
+            const authenticated = await context.ensureAuthenticated();
+            if (!authenticated) return errorResponse('Not authenticated.');
+            const repo = await context.getRepo();
+            if (!repo) return errorResponse('Not in a GitHub repo.');
+
+            const projects = await context.api.getProjects(repo);
+            if (projects.length === 0) {
+                return errorResponse(`No projects linked to ${repo.fullName}.`);
+            }
+            const selected = project
+                ? projects.find((p) => p.title.toLowerCase() === project.toLowerCase())
+                : projects[0];
+            if (!selected) {
+                return errorResponse(
+                    `Project "${project}" not found. Available: ${projects.map((p) => p.title).join(', ')}`
+                );
+            }
+
+            // Probe + timeline (reuses the same logic as get_planning_audit).
+            const fields = await context.api.getProjectFields(selected.id);
+            const fieldProbe = planning.probeProjectFields(
+                selected.id,
+                selected.title,
+                fields
+            );
+            const sprintField = fields.find(
+                (f) =>
+                    f.name.toLowerCase() === 'sprint' &&
+                    (f.type.toLowerCase() === 'iteration' ||
+                        f.dataType?.toLowerCase() === 'iteration')
+            );
+            const liveIterations: planning.IterationInfo[] = [];
+            let completedIterationCount = 0;
+            for (const iter of sprintField?.iterations ?? []) {
+                if (iter.completed) {
+                    completedIterationCount += 1;
+                    continue;
+                }
+                liveIterations.push({
+                    id: iter.id,
+                    title: iter.title,
+                    startDate: iter.startDate,
+                    duration: iter.duration,
+                });
+            }
+
+            let milestones: planning.MilestoneInfo[] = [];
+            const warnings: string[] = [];
+            try {
+                const ms = await context.api.listOpenMilestones(repo);
+                milestones = ms.milestones;
+                if (ms.truncated) warnings.push('Milestone list truncated at 50.');
+            } catch (err) {
+                warnings.push(
+                    `listOpenMilestones failed: ${err instanceof Error ? err.message : err}`
+                );
+            }
+
+            const timeline = planning.auditTimeline({
+                iterations: liveIterations,
+                completedIterationCount,
+                milestones,
+            });
+
+            const capability: planning.PlanningCapabilityReport = {
+                ...fieldProbe,
+                timeline,
+            };
+
+            // Fetch items and turn them into QueueInputItems.
+            const items = await context.api.getProjectItems(selected.id, selected.title);
+            const currentSprintTitle = timeline.iterations.current?.title ?? null;
+            const upcomingSprintTitles = timeline.iterations.upcoming.map(
+                (i) => i.title
+            );
+            const queue = planning.buildQueue({
+                items: items
+                    .filter((it) => it.number != null)
+                    .map((it) => ({
+                        number: it.number!,
+                        title: it.title,
+                        url: it.url,
+                        status: it.status,
+                        priority: it.fields['Priority'] ?? null,
+                        size: it.fields['Size'] ?? null,
+                        assignees: it.assignees,
+                        lastReviewed: it.fields['Last Reviewed'] ?? null,
+                        iterationTitle: it.fields['Sprint'] ?? null,
+                    })),
+                meetingType,
+                currentSprintTitle,
+                upcomingSprintTitles,
+                minDaysSinceLastReview,
+            });
+
+            const sessionId = newSessionId();
+            const active = queue.length > 0 ? queue[0] : null;
+            const session: planning.PlanningSession = {
+                id: sessionId,
+                startedAt: Date.now(),
+                ownerKey: ownerKeyForProcess(),
+                meetingType,
+                maxMinutesPerTicket,
+                minDaysSinceLastReview,
+                capability,
+                queue: active ? queue.slice(1) : queue,
+                decisions: {},
+                parked: [],
+                activeItem: active,
+                activeItemSince: active ? Date.now() : null,
+            };
+
+            getPlanningStore().start(session);
+
+            return {
+                content: [
+                    {
+                        type: 'text' as const,
+                        text: JSON.stringify(
+                            {
+                                sessionId,
+                                meetingType,
+                                projectTitle: selected.title,
+                                capability,
+                                warnings,
+                                queueLength: session.queue.length,
+                                active: session.activeItem,
+                                totalItemsToReview:
+                                    session.queue.length + (active ? 1 : 0),
+                            },
+                            null,
+                            2
+                        ),
+                    },
+                ],
+            };
+        }
+    );
+}
+
+function errorResponse(text: string) {
+    return {
+        content: [{ type: 'text' as const, text: `Error: ${text}` }],
+        isError: true,
+    };
+}

--- a/packages/mcp/src/tools/planning-status.ts
+++ b/packages/mcp/src/tools/planning-status.ts
@@ -1,0 +1,83 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import * as z from 'zod';
+import type { ServerContext } from '../server.js';
+import type { ToolMeta } from '../types.js';
+import { getPlanningStore } from './planning-session.js';
+
+/** Tool metadata for registry */
+export const meta: ToolMeta = {
+    name: 'planning_status',
+    category: 'read',
+    capability: 'pure-api',
+};
+
+/**
+ * Snapshot of the active session: queue remaining, items already
+ * decided, items parked, and a flag when the active item has been
+ * in front of the team longer than the session's per-ticket cap.
+ */
+export function register(server: McpServer, _context: ServerContext): void {
+    server.registerTool(
+        'planning_status',
+        {
+            title: 'Planning Session Status',
+            description:
+                'Snapshot of the active planning session: active item, queue length, decisions so far, parked items, and a time-in-debate warning when the active item has been discussed longer than maxMinutesPerTicket. Useful for the LLM to nudge "we\'ve been on this a while — park or decide?"',
+            inputSchema: {
+                sessionId: z.string().describe('Session id from planning_start'),
+            },
+        },
+        async ({ sessionId }) => {
+            const store = getPlanningStore();
+            const session = store.get(sessionId);
+            if (!session) {
+                return {
+                    content: [
+                        { type: 'text' as const, text: 'Error: session not found or expired.' },
+                    ],
+                    isError: true,
+                };
+            }
+
+            const minutesOnActive =
+                session.activeItemSince
+                    ? (Date.now() - session.activeItemSince) / 60_000
+                    : 0;
+            const overTimebox =
+                !!session.activeItem &&
+                minutesOnActive > session.maxMinutesPerTicket;
+
+            return {
+                content: [
+                    {
+                        type: 'text' as const,
+                        text: JSON.stringify(
+                            {
+                                sessionId: session.id,
+                                meetingType: session.meetingType,
+                                active: session.activeItem,
+                                minutesOnActive: Math.round(minutesOnActive * 10) / 10,
+                                overTimebox,
+                                maxMinutesPerTicket: session.maxMinutesPerTicket,
+                                queueLength: session.queue.length,
+                                decisions: Object.entries(session.decisions).map(
+                                    ([num, d]) => ({
+                                        issueNumber: Number(num),
+                                        decision: d.decision,
+                                        sentinelWritten: d.sentinelWritten,
+                                    })
+                                ),
+                                parked: session.parked,
+                                sessionElapsedMinutes: Math.round(
+                                    (Date.now() - session.startedAt) / 60_000
+                                ),
+                            },
+                            null,
+                            2
+                        ),
+                    },
+                ],
+            };
+        }
+    );
+}

--- a/scripts/test-planning-audit.mjs
+++ b/scripts/test-planning-audit.mjs
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+/**
+ * Smoke test: run the planning-audit logic end-to-end against a real repo
+ * without standing up the full MCP stdio/HTTP server. Imports from the
+ * built `dist/` of core (+ uses the bundled GitHubAPI class) so the path
+ * exercised matches what Claude Desktop / runtight would hit.
+ *
+ * Usage:
+ *   node scripts/test-planning-audit.mjs true-impact/care
+ *   node scripts/test-planning-audit.mjs true-impact/care "Project Name"
+ *
+ * Auth: uses `gh auth token` by default. Override with GITHUB_TOKEN.
+ */
+
+import { execSync } from 'node:child_process';
+import {
+    GitHubAPI,
+    planning,
+} from '../packages/core/dist/index.js';
+
+const [, , repoArg, projectArg] = process.argv;
+if (!repoArg || !repoArg.includes('/')) {
+    console.error('Usage: node scripts/test-planning-audit.mjs owner/name [project-title]');
+    process.exit(1);
+}
+const [owner, name] = repoArg.split('/');
+const repo = { owner, name, fullName: `${owner}/${name}` };
+
+function resolveToken() {
+    if (process.env.GITHUB_TOKEN) return process.env.GITHUB_TOKEN;
+    if (process.env.GH_TOKEN) return process.env.GH_TOKEN;
+    try {
+        return execSync('gh auth token', { encoding: 'utf-8' }).trim();
+    } catch {
+        console.error('Could not resolve a GitHub token. Set GITHUB_TOKEN or run `gh auth login`.');
+        process.exit(1);
+    }
+}
+
+const token = resolveToken();
+const api = new GitHubAPI({
+    tokenProvider: { getToken: async () => token },
+});
+await api.authenticate();
+
+console.log(`→ Fetching projects for ${repo.fullName}`);
+const projects = await api.getProjects(repo);
+if (projects.length === 0) {
+    console.error(`No projects linked to ${repo.fullName}.`);
+    process.exit(1);
+}
+const selected = projectArg
+    ? projects.find((p) => p.title.toLowerCase() === projectArg.toLowerCase())
+    : projects[0];
+if (!selected) {
+    console.error(
+        `Project "${projectArg}" not found. Available: ${projects.map((p) => p.title).join(', ')}`
+    );
+    process.exit(1);
+}
+console.log(`  project: ${selected.title}  (id=${selected.id})`);
+
+console.log('→ Probing project fields');
+const fields = await api.getProjectFields(selected.id);
+const probe = planning.probeProjectFields(selected.id, selected.title, fields);
+
+console.log('→ Extracting iteration metadata');
+const sprintField = fields.find(
+    (f) =>
+        f.name.toLowerCase() === 'sprint' &&
+        (f.type.toLowerCase() === 'iteration' || f.dataType?.toLowerCase() === 'iteration')
+);
+const iterations = [];
+let completedIterationCount = 0;
+for (const iter of sprintField?.iterations ?? []) {
+    if (iter.completed) {
+        completedIterationCount += 1;
+        continue;
+    }
+    iterations.push({
+        id: iter.id,
+        title: iter.title,
+        startDate: iter.startDate,
+        duration: iter.duration,
+    });
+}
+
+console.log('→ Fetching open milestones');
+const warnings = [];
+let milestones = [];
+try {
+    const ms = await api.listOpenMilestones(repo);
+    milestones = ms.milestones;
+    if (ms.truncated) {
+        warnings.push('Milestone list truncated at 50');
+    }
+} catch (err) {
+    warnings.push(`listOpenMilestones failed: ${err instanceof Error ? err.message : err}`);
+}
+
+console.log('→ Running timeline audit');
+const timeline = planning.auditTimeline({
+    iterations,
+    completedIterationCount,
+    milestones,
+});
+
+const report = { ...probe, timeline, ...(warnings.length ? { warnings } : {}) };
+console.log('\n=== PLANNING AUDIT REPORT ===\n');
+console.log(JSON.stringify(report, null, 2));


### PR DESCRIPTION
Closes #291. Builds on #292 (capability probe + audit + sentinel + session store).

## Summary

Six new MCP tools wired to the planning infra shipped in #292. The LLM can now drive a full planning meeting from chat: open a session, walk through a ranked queue of items one at a time, record decisions (writing Last Reviewed via field or sentinel fallback), park items mid-discussion, check status, and close with a summary. \`capability: 'pure-api'\` → both stdio and hosted see the tools automatically.

## Changes

### New core modules
- \`packages/core/src/planning/ranking.ts\` — \`parsePriority\`, \`priorityRank\`, \`daysSince\`, \`isFreshEnoughToSurface\`, \`compareStalenessAndPriority\`. Stable tiebreak (issue number asc) so identical configs always sort the same way.
- \`packages/core/src/planning/queue-builder.ts\` — classifies project items into flow-doc buckets (\`current-sprint-unassigned\`, \`untriaged-backlog\`, \`resurfacing-backlog\`, \`next-sprint\`, \`next-plus-one-sprint\`, \`unscheduled-kill-list\`, \`ready-for-release\`, \`past-sprint-stuck\`) and concatenates in meeting-step order. Freshness filter drops items reviewed within \`minDaysSinceLastReview\` — directly targets the "don't resurface same issue week-over-week" goal. Current-sprint bucket is exempt so sprint assignment still works.
- Session type gained \`activeItem: PlanningItem | null\` + \`activeItemSince\` to support \`planning_status\`'s minutes-in-debate + overtimebox flag.

### MCP tools
| Tool | Role |
|------|------|
| \`planning_start\` | Probe project, build ranked queue, return first item + session id |
| \`planning_next\` | Peek/advance without recording a decision |
| \`planning_decide\` | Record verdict, write Last Reviewed (field or sentinel), advance |
| \`planning_park\` | Defer active item to queue bottom — does NOT write sentinel, so item resurfaces next week normally |
| \`planning_status\` | Active item + minutes-in-debate + overtimebox flag + decisions so far |
| \`planning_end\` | Close session, return summary the LLM can pass to \`add_comment\` |

### Session management
- Module-level \`PlanningSessionStore\` singleton (\`packages/mcp/src/tools/planning-session.ts\`). In stdio, one process = one user, \`ownerKey: 'default'\` is safe. In hosted, the singleton persists across requests in one container — **requires per-bearer \`ownerKey\` derivation before multi-tenant use** (noted as follow-up in the file comment).
- Sessions TTL out at 2h via the \`PlanningSessionStore\` infra shipped in #292.

## Why

Addresses all four goals from the user's ask:
- **(a) Keep conversation going** — \`planning_next\` returns one item at a time; no wall-of-text agenda
- **(b) Don't over-discuss** — \`planning_status\` flags \`overTimebox: true\` when active item > configured minutes so LLM can nudge "park it?"
- **(c) Don't resurface same issues** — freshness filter in \`queue-builder\` drops items reviewed within N days
- **(d) Prevent staleness** — ranking prioritizes never-reviewed > stale > recent within each bucket

\`planning_decide\`'s sentinel write is what closes the loop on (c) — subsequent \`planning_start\` calls won't re-surface an item that was reviewed in this session.

## Decisions made

- **\`planning_decide\` does NOT change issue status.** It only records Last Reviewed + the verdict. The LLM runs existing tools (\`move_issue\`, \`mark_done\`, \`add_comment\`) for status mutations. Keeps the meeting-driver surface focused.
- **Session singleton is stdio-safe, hosted-mode gated.** Wrote an in-file comment flagging that multi-tenant hosted needs ownerKey derivation from the bearer token before use. For single-user hosted deploys (my current Railway setup) it works today.
- **Freshness filter exempts current-sprint-unassigned.** Sprint assignment isn't a review — would otherwise lock teams out of planning if they'd touched the item recently.
- **\`planning_setup\` deferred.** Executing \`timeline.findings[*].suggestedAction\` (create iteration, close milestone, add missing field) is substantial and has its own security surface (mutations with user consent). Will be next PR.

## Tests

| Package | Before | After |
|---------|--------|-------|
| core | 132 | **155** (+23 — ranking + queue-builder) |
| mcp | 18 | 18 (mock extended for new \`planning\` namespace) |
| mcp-hosted | 68 | 68 |
| cli | 113 | 113 |
| **total** | **331** | **354** |

New coverage:
- ranking: priority parsing (every alias), staleness math, freshness threshold at boundary, compareStalenessAndPriority with every tiebreak path
- queue-builder: every bucket classification, freshness filter on/off, within-bucket sort order, current-sprint exemption, past-sprint-stuck detection, forward-planning next vs next+1 split, unmatched statuses dropped

Tool handlers are not unit-tested here (heavy \`ServerContext.api\` mocking required). Manual smoke scripts live in \`scripts/test-planning-audit.mjs\`; an analogous \`test-planning-session.mjs\` driving the full 6-tool flow would be a reasonable follow-up.

## Test plan

- [x] \`pnpm test\` workspace — 354/354
- [x] \`pnpm build\` workspace — clean
- [ ] Local stdio smoke: \`pnpm --filter @bretwardjames/ghp-mcp build\` → restart Claude Code → confirm 6 new tools visible
- [ ] Run an actual planning session against \`bretwardjames/ghp\`: \`planning_start\` → walk through queue with \`planning_decide\` → \`planning_end\` → verify McpUserAuth... wait, this is the GHP project, not runtight. Verify Last Reviewed is written on decided items via Prisma Studio / GitHub UI
- [ ] Hosted: redeploy Railway → runtight tool discovery picks up 6 new tools → OAuth user can run a meeting end-to-end

## Follow-ups

- \`planning_setup\` — execute \`timeline.findings[*].suggestedAction\` (create iteration / close milestone / add missing field) with user consent
- Hosted-mode ownerKey derivation from bearer token (required before runtight uses the planning tools in real multi-tenant deploys)
- Milestone-boundary meeting type fine-tuning (bucket composition currently weekly + same backlog buckets — per flow doc it should add \`milestone-open\` and \`full-backlog\`)

---
Generated with [Claude Code](https://claude.ai/code)