### PR TITLE
Fix: queue builder drops backlog when project has no iterations + status aliases

### DIFF
--- a/packages/core/src/planning/queue-builder.test.ts
+++ b/packages/core/src/planning/queue-builder.test.ts
@@ -155,4 +155,40 @@ describe('buildQueue — weekly', () => {
         });
         expect(queue).toEqual([]);
     });
+
+    it('projects without iterations still surface backlog items', () => {
+        // Regression: when currentSprintTitle is null, a `null === null`
+        // match in the sprint-assignment branch used to drop every
+        // item. Backlog items should still flow through.
+        const queue = buildQueue({
+            ...base,
+            currentSprintTitle: null,
+            upcomingSprintTitles: [],
+            items: [
+                item({ number: 1, status: 'Backlog', lastReviewed: null }),
+                item({ number: 2, status: 'Todo' }),
+            ],
+        });
+        expect(queue.map((q) => q.number).sort()).toEqual([1, 2]);
+    });
+
+    it('aliases common status names to the flow-doc buckets', () => {
+        // Todo / To Do / Committed all map to kill-list per STATUS_ALIASES.
+        const queue = buildQueue({
+            ...base,
+            currentSprintTitle: null,
+            upcomingSprintTitles: [],
+            items: [
+                item({ number: 1, status: 'Todo' }),
+                item({ number: 2, status: 'To Do' }),
+                item({ number: 3, status: 'Committed' }),
+                item({ number: 4, status: 'Ready' }),
+            ],
+        });
+        const buckets = Object.fromEntries(queue.map((q) => [q.number, q.bucket]));
+        expect(buckets[1]).toBe('unscheduled-kill-list');
+        expect(buckets[2]).toBe('unscheduled-kill-list');
+        expect(buckets[3]).toBe('unscheduled-kill-list');
+        expect(buckets[4]).toBe('ready-for-release');
+    });
 });

--- a/packages/core/src/planning/queue-builder.ts
+++ b/packages/core/src/planning/queue-builder.ts
@@ -121,37 +121,63 @@ export function buildQueue(input: QueueBuildInput): PlanningItem[] {
     return order.flatMap((b) => bucketed[b]);
 }
 
+/**
+ * Project-customizable status aliases. Teams name their columns
+ * differently ("Kill List" / "Todo" / "To Do" / "Committed" all map
+ * to the flow doc's "committed work not yet in progress" concept).
+ * Case-insensitive exact match against the item's status.
+ */
+const STATUS_ALIASES: Record<string, 'backlog' | 'kill-list' | 'ready-for-release'> = {
+    backlog: 'backlog',
+    'kill list': 'kill-list',
+    todo: 'kill-list',
+    'to do': 'kill-list',
+    committed: 'kill-list',
+    ready: 'ready-for-release',
+    'ready for release': 'ready-for-release',
+    'ready for release ✓': 'ready-for-release',
+};
+
+function normalizeStatus(
+    status: string | null
+): 'backlog' | 'kill-list' | 'ready-for-release' | 'other' {
+    const key = (status ?? '').trim().toLowerCase();
+    return STATUS_ALIASES[key] ?? 'other';
+}
+
 function classifyBucket(
     item: QueueInputItem,
     input: QueueBuildInput
 ): PlanningBucket | null {
-    const status = (item.status ?? '').toLowerCase();
+    const normalized = normalizeStatus(item.status);
 
-    // Step 4 — sprint assignment
-    if (item.iterationTitle === input.currentSprintTitle) {
-        if (item.assignees.length === 0 && status === 'kill list') {
-            return 'current-sprint-unassigned';
+    // Step 4 — sprint assignment. Skip entirely when the project has
+    // no iteration concept; `null === null` would otherwise pass the
+    // "item is in the current sprint" check for every item.
+    if (input.currentSprintTitle != null) {
+        if (item.iterationTitle === input.currentSprintTitle) {
+            if (item.assignees.length === 0 && normalized === 'kill-list') {
+                return 'current-sprint-unassigned';
+            }
+            return null; // current sprint, already assigned → not surfaced
         }
-        return null; // current sprint, already assigned → not surfaced
-    }
-    if (
-        item.iterationTitle &&
-        input.currentSprintTitle &&
-        item.iterationTitle !== input.currentSprintTitle &&
-        !input.upcomingSprintTitles.includes(item.iterationTitle) &&
-        status === 'kill list'
-    ) {
-        return 'past-sprint-stuck';
+        if (
+            item.iterationTitle &&
+            !input.upcomingSprintTitles.includes(item.iterationTitle) &&
+            normalized === 'kill-list'
+        ) {
+            return 'past-sprint-stuck';
+        }
     }
 
     // Step 5 — triage + backlog resurface
-    if (status === 'backlog') {
+    if (normalized === 'backlog') {
         if (!item.lastReviewed) return 'untriaged-backlog';
         return 'resurfacing-backlog';
     }
 
     // Step 6 — forward planning
-    if (status === 'kill list') {
+    if (normalized === 'kill-list') {
         if (item.iterationTitle === input.upcomingSprintTitles[0]) {
             return 'next-sprint';
         }
@@ -164,13 +190,9 @@ function classifyBucket(
     }
 
     // Step 7 — release check
-    if (status === 'ready for release') {
+    if (normalized === 'ready-for-release') {
         return 'ready-for-release';
     }
-
-    // Milestone-boundary extras are bucketed separately by the caller
-    // passing the right meetingType; for now they share the backlog
-    // buckets (the full-backlog pass is additive, not corrective).
 
     return null;
 }

--- a/scripts/inspect-picklexp.mjs
+++ b/scripts/inspect-picklexp.mjs
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+import { execSync } from 'node:child_process';
+import { GitHubAPI } from '../packages/core/dist/index.js';
+
+const token = execSync('gh auth token', { encoding: 'utf-8' }).trim();
+const api = new GitHubAPI({ tokenProvider: { getToken: async () => token } });
+await api.authenticate();
+const repo = { owner: 'Daxman95', name: 'PickleXP', fullName: 'Daxman95/PickleXP' };
+
+const projects = await api.getProjects(repo);
+const sel = projects[0];
+const items = await api.getProjectItems(sel.id, sel.title);
+
+const statusCounts = {};
+const fieldKeys = new Set();
+for (const it of items) {
+    const s = it.status ?? '<null>';
+    statusCounts[s] = (statusCounts[s] ?? 0) + 1;
+    for (const k of Object.keys(it.fields)) fieldKeys.add(k);
+}
+console.log('status distribution:', statusCounts);
+console.log('field keys on items:', [...fieldKeys]);
+
+console.log('\nsample first 3 items:');
+for (const it of items.slice(0, 3)) {
+    console.log({
+        number: it.number,
+        title: it.title,
+        status: it.status,
+        assignees: it.assignees,
+        fields: it.fields,
+    });
+}

--- a/scripts/test-planning-session.mjs
+++ b/scripts/test-planning-session.mjs
@@ -1,0 +1,173 @@
+#!/usr/bin/env node
+/**
+ * Smoke test: walk the full planning-session loop against a real repo
+ * using core logic directly (no MCP transport).
+ *
+ *   node scripts/test-planning-session.mjs owner/name [project-title]
+ */
+
+import { execSync } from 'node:child_process';
+import {
+    GitHubAPI,
+    planning,
+} from '../packages/core/dist/index.js';
+
+const [, , repoArg, projectArg] = process.argv;
+if (!repoArg?.includes('/')) {
+    console.error('Usage: node scripts/test-planning-session.mjs owner/name [project]');
+    process.exit(1);
+}
+const [owner, name] = repoArg.split('/');
+const repo = { owner, name, fullName: `${owner}/${name}` };
+
+const token = process.env.GITHUB_TOKEN
+    ?? process.env.GH_TOKEN
+    ?? execSync('gh auth token', { encoding: 'utf-8' }).trim();
+const api = new GitHubAPI({ tokenProvider: { getToken: async () => token } });
+await api.authenticate();
+
+const projects = await api.getProjects(repo);
+const selected = projectArg
+    ? projects.find((p) => p.title.toLowerCase() === projectArg.toLowerCase())
+    : projects[0];
+if (!selected) {
+    console.error(`No project matching "${projectArg ?? '<default>'}"`);
+    process.exit(1);
+}
+console.log(`project: ${selected.title}`);
+
+const fields = await api.getProjectFields(selected.id);
+const fieldProbe = planning.probeProjectFields(selected.id, selected.title, fields);
+
+const sprintField = fields.find(
+    (f) => f.name.toLowerCase() === 'sprint' && (f.type.toLowerCase() === 'iteration' || f.dataType?.toLowerCase() === 'iteration')
+);
+const iterations = [];
+for (const iter of sprintField?.iterations ?? []) {
+    if (!iter.completed) {
+        iterations.push({ id: iter.id, title: iter.title, startDate: iter.startDate, duration: iter.duration });
+    }
+}
+let milestones = [];
+try { milestones = (await api.listOpenMilestones(repo)).milestones; } catch {}
+
+const timeline = planning.auditTimeline({ iterations, completedIterationCount: 0, milestones });
+const currentSprintTitle = timeline.iterations.current?.title ?? null;
+const upcomingSprintTitles = timeline.iterations.upcoming.map((i) => i.title);
+
+const items = await api.getProjectItems(selected.id, selected.title);
+console.log(`  ${items.length} items in project`);
+
+const queueInput = items
+    .filter((it) => it.number != null)
+    .map((it) => ({
+        number: it.number,
+        title: it.title,
+        url: it.url,
+        status: it.status,
+        priority: it.fields['Priority'] ?? null,
+        size: it.fields['Size'] ?? null,
+        assignees: it.assignees,
+        lastReviewed: it.fields['Last Reviewed'] ?? null,
+        iterationTitle: it.fields['Sprint'] ?? null,
+    }));
+
+const queue = planning.buildQueue({
+    items: queueInput,
+    meetingType: 'weekly',
+    currentSprintTitle,
+    upcomingSprintTitles,
+    minDaysSinceLastReview: 7,
+});
+
+console.log(`\n=== QUEUE (${queue.length} items, meeting-step order) ===\n`);
+// Show queue summary + bucket breakdown
+const byBucket = queue.reduce((acc, q) => {
+    acc[q.bucket] = (acc[q.bucket] ?? 0) + 1;
+    return acc;
+}, {});
+console.log('bucket counts:', byBucket);
+
+console.log('\nfirst 10 items in meeting order:');
+for (const it of queue.slice(0, 10)) {
+    const age = it.lastReviewed ? `${planning.daysSince(it.lastReviewed)}d` : 'never';
+    const pr = it.priority ?? '-';
+    console.log(
+        `  [${it.bucket.padEnd(30)}] #${String(it.number).padEnd(4)}  priority=${pr.padEnd(8)}  reviewed=${age.padEnd(6)}  ${it.title}`
+    );
+}
+
+if (queue.length === 0) {
+    console.log('\n(queue empty — no items to discuss under current freshness + status filter)');
+    process.exit(0);
+}
+
+console.log('\n=== SESSION SIMULATION ===');
+const store = new planning.PlanningSessionStore();
+const sessionId = 'smoke-session';
+const active = queue[0];
+const session = {
+    id: sessionId,
+    startedAt: Date.now(),
+    ownerKey: 'smoke',
+    meetingType: 'weekly',
+    maxMinutesPerTicket: 3,
+    minDaysSinceLastReview: 7,
+    capability: { ...fieldProbe, timeline },
+    queue: queue.slice(1),
+    decisions: {},
+    parked: [],
+    activeItem: active,
+    activeItemSince: Date.now(),
+};
+store.start(session);
+
+console.log(`start → active=#${active.number}  queueLength=${session.queue.length}`);
+
+// Simulate 3 decisions + 1 park
+const actions = [
+    { kind: 'decide', decision: 'backlog', notes: 'no change — revisit next cycle' },
+    { kind: 'decide', decision: 'kill-list', notes: 'committed for next sprint' },
+    { kind: 'park', reason: 'needs more context' },
+    { kind: 'decide', decision: 'close', notes: 'stale, closing' },
+];
+
+for (const a of actions) {
+    const s = store.get(sessionId);
+    if (!s?.activeItem) {
+        console.log('  (queue exhausted)');
+        break;
+    }
+    const curr = s.activeItem;
+    if (a.kind === 'decide') {
+        s.decisions[curr.number] = {
+            decision: a.decision,
+            notes: a.notes,
+            decidedAt: Date.now(),
+            sentinelWritten: false, // smoke-only, we don't actually write
+        };
+        console.log(
+            `  decide #${curr.number} → ${a.decision}   "${a.notes}"`
+        );
+    } else if (a.kind === 'park') {
+        s.queue.push(curr);
+        s.parked.push(curr.number);
+        console.log(`  park   #${curr.number}   "${a.reason}"`);
+    }
+    const next = s.queue.shift() ?? null;
+    s.activeItem = next;
+    s.activeItemSince = next ? Date.now() : null;
+    store.update(s);
+}
+
+const final = store.end(sessionId);
+console.log('\nfinal session:');
+console.log(JSON.stringify(
+    {
+        decisions: Object.entries(final.decisions).map(([n, d]) => ({ number: Number(n), decision: d.decision })),
+        parked: final.parked,
+        remainingInQueue: final.queue.length,
+    },
+    null,
+    2
+));


### PR DESCRIPTION
Hotfix surfaced by smoke-testing against PickleXP (130 items, no Sprint iteration field, uses 'Todo' instead of 'Kill List'). Queue came back empty; investigation revealed two bugs.

## Bugs

### 1. null-sprint false-positive kills every item

\`classifyBucket\` had:
\`\`\`ts
if (item.iterationTitle === input.currentSprintTitle) {
    // both null → true
    if (item.assignees.length === 0 && status === 'kill list') {
        return 'current-sprint-unassigned';
    }
    return null; // drops the item
}
\`\`\`

When a project has no Sprint field, both sides are null, the strict-equality check passes, and every item hits the \`return null\` — even clear Backlog-triage candidates.

**Fix:** gate the entire sprint-assignment branch on \`currentSprintTitle != null\`.

### 2. Status matching was flow-doc-only

The flow doc uses "Kill List" / "Ready for Release". Real projects use variants:
- PickleXP: "Todo" for committed work
- Others commonly: "To Do", "Committed"

**Fix:** added \`STATUS_ALIASES\` map:
\`\`\`ts
backlog           → backlog
kill list         → kill-list
todo              → kill-list
to do             → kill-list
committed         → kill-list
ready             → ready-for-release
ready for release → ready-for-release
\`\`\`

## Verification

Before fix: \`node scripts/test-planning-session.mjs Daxman95/PickleXP\` → queue empty despite 130 items.

After fix: 46-item queue returns, all untriaged Backlog items. Session simulation walks 4 items (3 decide + 1 park) cleanly.

## Tests

+2 regression tests in \`queue-builder.test.ts\`:
- "projects without iterations still surface backlog items" — locks bug #1
- "aliases common status names to the flow-doc buckets" — locks bug #2

60/60 planning tests pass.

## Scripts

Committing \`scripts/test-planning-session.mjs\` + \`scripts/inspect-picklexp.mjs\` as dev utilities for future smoke testing.

Relates to #291