### PR TITLE
Re-enable create_issue on hosted MCP by gating the hook dispatch behind GHP_MCP_MODE

### DIFF
--- a/packages/mcp-hosted/src/http-server.test.ts
+++ b/packages/mcp-hosted/src/http-server.test.ts
@@ -220,8 +220,9 @@ describe('hosted http server', () => {
             expect(names).not.toContain('sync_merged_prs');
             expect(names).not.toContain('start_work');
             expect(names).not.toContain('get_tags');
-            // create_issue is local-only until #278 hook gate lands
-            expect(names).not.toContain('create_issue');
+            // create_issue is now pure-api on hosted: its hook dispatch
+            // is gated behind GHP_MCP_MODE=hosted (see #288).
+            expect(names).toContain('create_issue');
         });
     });
 });

--- a/packages/mcp/src/tool-registry.test.ts
+++ b/packages/mcp/src/tool-registry.test.ts
@@ -226,9 +226,6 @@ describe('tool-registry', () => {
             expect(pureNames).not.toContain('start_work');
             expect(pureNames).not.toContain('get_tags');
 
-            // create_issue dispatches user-configurable hooks — keep it
-            // local-only until hosted mode gates the hook block (#278).
-            expect(pureNames).not.toContain('create_issue');
         });
 
         it('pure-api list includes GraphQL-only tools', () => {
@@ -241,6 +238,9 @@ describe('tool-registry', () => {
             expect(pureNames).toContain('add_comment');
             // stop_work only removes a label via GraphQL — no git, no hooks
             expect(pureNames).toContain('stop_work');
+            // create_issue hooks are gated behind GHP_MCP_MODE=hosted
+            // (see #288), so the tool is safe on hosted servers.
+            expect(pureNames).toContain('create_issue');
         });
 
         it('getToolsByCapability returns the same result as direct exports', () => {
@@ -284,12 +284,12 @@ describe('tool-registry', () => {
             expect(registered).not.toContain('merge_pr');
             expect(registered).not.toContain('list_worktrees');
             expect(registered).not.toContain('remove_worktree');
-            expect(registered).not.toContain('create_issue');
             // pure-api still registered
             expect(registered).toContain('link_branch');
             expect(registered).toContain('unlink_branch');
             expect(registered).toContain('get_my_work');
             expect(registered).toContain('update_issue');
+            expect(registered).toContain('create_issue');
         });
     });
 

--- a/packages/mcp/src/tools/add-issue.ts
+++ b/packages/mcp/src/tools/add-issue.ts
@@ -13,13 +13,11 @@ import {
 export const meta: ToolMeta = {
     name: 'create_issue',
     category: 'action',
-    // Hook dispatch (`executeHooksForEvent('issue-created', ...)`) can run
-    // user-supplied shell commands via `loadHooksConfig` + `runCommand`.
-    // Classified local-only to match other hook-dispatching tools
-    // (start_work, create_pr, remove_worktree). Re-enabling on hosted is
-    // tracked in #288 — a single-line GHP_MCP_MODE guard around the hook
-    // block is enough to flip this back to pure-api safely.
-    capability: 'local-only',
+    // Safe for hosted: the `issue-created` hook dispatch (which runs
+    // user-supplied shell commands) is gated on `GHP_MCP_MODE !== 'hosted'`
+    // inside the handler. On hosted that block is skipped entirely, so
+    // the tool is pure GitHub API. Stdio users retain the full hook path.
+    capability: 'pure-api',
 };
 
 /**
@@ -128,8 +126,14 @@ export function register(server: McpServer, context: ServerContext): void {
                     }
                 }
 
-                // Fire issue-created hook
-                if (hasHooksForEvent('issue-created')) {
+                // Fire issue-created hook — skipped in hosted mode where
+                // hooks would execute untrusted shell commands on a
+                // multi-tenant container that has no per-user config
+                // boundary. Stdio users keep hooks unchanged.
+                if (
+                    process.env.GHP_MCP_MODE !== 'hosted' &&
+                    hasHooksForEvent('issue-created')
+                ) {
                     const payload: IssueCreatedPayload = {
                         repo: `${repo.owner}/${repo.name}`,
                         issue: {


### PR DESCRIPTION
Closes #288.

## Summary

Gates the `issue-created` hook dispatch in `add-issue.ts` behind `GHP_MCP_MODE !== 'hosted'`, then flips `create_issue`'s classification from `local-only` back to `pure-api`. End result: `create_issue` surfaces on hosted again without introducing a shell-execution trust hole on the multi-tenant container.

## Why

- Hooks are user-supplied shell commands loaded from `~/.config/ghp-cli/config.json` / `.ghp/config.json`. Designed for local dev. On a shared hosted container there's no per-tenant trust boundary — any hook that landed on disk would execute under every tenant's context.
- After #282, this classification made `create_issue` invisible on `@bretwardjames/ghp-mcp-hosted`, which is a significant tool-surface gap. runtight users couldn't file issues from chat against a planning/triage flow.
- One-line env guard is the smallest change that closes the gap without forking the handler.

## Changes

- `packages/mcp/src/tools/add-issue.ts`:
  - Hook block now `if (process.env.GHP_MCP_MODE !== 'hosted' && hasHooksForEvent(...))`.
  - `meta.capability: 'pure-api'` (was `local-only`). Comment rewritten.
- `packages/mcp/src/tool-registry.test.ts`:
  - Removes the "create_issue is local-only" assertion.
  - Adds "create_issue is in pure-api" assertion.
  - Updates the `registerEnabledTools with capability filter` test so `create_issue` is expected to register under `pure-api`.
- `packages/mcp-hosted/src/http-server.test.ts`:
  - `tools/list contains only pure-api tools` now asserts `create_issue` IS present.

## Decisions made

- **Runtime env check vs build-time fork:** single source-of-truth handler, no drift risk. Downside: stdio + hosted share a file, so an edit in the wrong spot could regress. Mitigated by explicit tests.
- **No dedicated test for the env branch:** existing mock has `hasHooksForEvent: vi.fn(() => false)`, so the guard is unobservable in unit tests. Observable outcome (tool registration on hosted) IS tested via the capability partition + tools/list tests.

## Tests

| Package | Tests |
|---------|-------|
| core | 157/157 |
| mcp | 18/18 |
| mcp-hosted | 68/68 |
| cli | 113/113 |
| **total** | **356/356** |

## Test plan

- [x] `pnpm test` workspace — 356/356
- [x] `pnpm build` workspace — clean
- [ ] After merge: Railway redeploy picks up new tool list; runtight tool cache refreshes; `create_issue` appears on hosted instance
- [ ] Quick stdio smoke: rebuild `@bretwardjames/ghp-mcp`, restart Claude Code, confirm `create_issue` still registers and hooks still fire locally (no env var set)

---
Generated with [Claude Code](https://claude.ai/code)