### PR TITLE
bretwardjames/fix-crypto-dynamic-require

### DIFF
--- a/packages/mcp/src/tools/planning-session.ts
+++ b/packages/mcp/src/tools/planning-session.ts
@@ -1,4 +1,5 @@
 import { planning } from '@bretwardjames/ghp-core';
+import { randomBytes } from 'crypto';
 
 /**
  * Process-wide planning session store.
@@ -28,7 +29,6 @@ export function ownerKeyForProcess(): string {
 export function newSessionId(): string {
     // 16 bytes of crypto-random, base64url-encoded. Collision-resistant
     // enough for the ~2h session lifetime without bringing in uuid.
-    const { randomBytes } = require('crypto') as typeof import('crypto');
     return randomBytes(16)
         .toString('base64')
         .replace(/=+$/, '')


### PR DESCRIPTION
## Summary

\`planning_start\` threw \`Dynamic require of "crypto" is not supported\` on the hosted Railway deploy. My bug — `newSessionId` in `planning-session.ts` used CommonJS-style `require('crypto')` which the tsup ESM build + Railway Node runtime reject.

## Fix

Hoist to top-level ESM import:

\`\`\`diff
+ import { randomBytes } from 'crypto';

  export function newSessionId(): string {
-     const { randomBytes } = require('crypto') as typeof import('crypto');
      return randomBytes(16).toString('base64')...
  }
\`\`\`

## Checked

Scanned the monorepo for the same antipattern:
- \`packages/mcp/src/server.ts\` uses \`createRequire(import.meta.url)\` for JSON — supported ESM idiom, fine.
- \`packages/cli/src/terminal-utils.ts\` has \`require('child_process')\` but only executes in stdio CLI paths, never hosted.

Only the one spot was broken.

## Tests

356/356 workspace-wide unchanged. The broken call site had no unit test (no tool-handler unit tests in this repo today).

## Post-merge

Railway auto-redeploys → planning_start becomes callable on the hosted instance. Local stdio unaffected (Node resolves top-level imports either way).

---
Generated with [Claude Code](https://claude.ai/code)