### PR TITLE
bretwardjames/planning-body-hydrate

### DIFF
--- a/packages/core/src/planning/types.ts
+++ b/packages/core/src/planning/types.ts
@@ -147,6 +147,13 @@ export interface PlanningItem {
     assignees: string[];
     /** Queue slot this item came from (used by tests + UI). */
     bucket: PlanningBucket;
+    /**
+     * Issue body. Populated lazily when the item becomes the active
+     * discussion subject (via planning_next / planning_decide /
+     * planning_park) — we don't eagerly fetch bodies at queue-build
+     * time because that would scale linearly with queue size.
+     */
+    body?: string;
 }
 
 export type PlanningBucket =

--- a/packages/mcp/src/tools/planning-decide.ts
+++ b/packages/mcp/src/tools/planning-decide.ts
@@ -3,7 +3,7 @@ import * as z from 'zod';
 import type { ServerContext } from '../server.js';
 import type { ToolMeta } from '../types.js';
 import { planning } from '@bretwardjames/ghp-core';
-import { getPlanningStore } from './planning-session.js';
+import { getPlanningStore, hydrateActiveItemBody } from './planning-session.js';
 
 /** Tool metadata for registry */
 export const meta: ToolMeta = {
@@ -134,6 +134,7 @@ export function register(server: McpServer, context: ServerContext): void {
             session.queue = session.queue.slice(1);
             session.activeItem = nextItem;
             session.activeItemSince = nextItem ? Date.now() : null;
+            await hydrateActiveItemBody(context, repo, session.activeItem);
             store.update(session);
 
             return {

--- a/packages/mcp/src/tools/planning-next.ts
+++ b/packages/mcp/src/tools/planning-next.ts
@@ -2,7 +2,7 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import * as z from 'zod';
 import type { ServerContext } from '../server.js';
 import type { ToolMeta } from '../types.js';
-import { getPlanningStore } from './planning-session.js';
+import { getPlanningStore, hydrateActiveItemBody } from './planning-session.js';
 
 /** Tool metadata for registry */
 export const meta: ToolMeta = {
@@ -20,13 +20,13 @@ export const meta: ToolMeta = {
  * For the normal flow, callers should prefer `planning_decide` which
  * records the verdict and advances in one step.
  */
-export function register(server: McpServer, _context: ServerContext): void {
+export function register(server: McpServer, context: ServerContext): void {
     server.registerTool(
         'planning_next',
         {
             title: 'Next Planning Item',
             description:
-                'Advance the planning queue to the next item without recording a decision. Returns { active, queueLength, remaining } or { active: null } when the queue is exhausted.',
+                'Advance the planning queue to the next item without recording a decision. Returns { active, queueLength, remaining } or { active: null } when the queue is exhausted. Active item\'s body is fetched lazily so the LLM has full discussion context.',
             inputSchema: {
                 sessionId: z.string().describe('Session id from planning_start'),
             },
@@ -50,6 +50,11 @@ export function register(server: McpServer, _context: ServerContext): void {
             session.queue = session.queue.slice(1);
             session.activeItem = nextItem;
             session.activeItemSince = nextItem ? Date.now() : null;
+
+            const repo = await context.getRepo();
+            if (repo) {
+                await hydrateActiveItemBody(context, repo, session.activeItem);
+            }
             store.update(session);
 
             return {

--- a/packages/mcp/src/tools/planning-park.ts
+++ b/packages/mcp/src/tools/planning-park.ts
@@ -2,7 +2,7 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import * as z from 'zod';
 import type { ServerContext } from '../server.js';
 import type { ToolMeta } from '../types.js';
-import { getPlanningStore } from './planning-session.js';
+import { getPlanningStore, hydrateActiveItemBody } from './planning-session.js';
 
 /** Tool metadata for registry */
 export const meta: ToolMeta = {
@@ -17,7 +17,7 @@ export const meta: ToolMeta = {
  * the same meeting if there's time. No Last Reviewed update means
  * parked items will resurface next week exactly as they would have.
  */
-export function register(server: McpServer, _context: ServerContext): void {
+export function register(server: McpServer, context: ServerContext): void {
     server.registerTool(
         'planning_park',
         {
@@ -69,6 +69,11 @@ export function register(server: McpServer, _context: ServerContext): void {
             const nextItem = session.queue.shift() ?? null;
             session.activeItem = nextItem;
             session.activeItemSince = nextItem ? Date.now() : null;
+
+            const repo = await context.getRepo();
+            if (repo) {
+                await hydrateActiveItemBody(context, repo, session.activeItem);
+            }
             store.update(session);
 
             return {

--- a/packages/mcp/src/tools/planning-session.ts
+++ b/packages/mcp/src/tools/planning-session.ts
@@ -1,5 +1,7 @@
 import { planning } from '@bretwardjames/ghp-core';
+import type { RepoInfo } from '@bretwardjames/ghp-core';
 import { randomBytes } from 'crypto';
+import type { ServerContext } from '../server.js';
 
 /**
  * Process-wide planning session store.
@@ -34,4 +36,30 @@ export function newSessionId(): string {
         .replace(/=+$/, '')
         .replace(/\+/g, '-')
         .replace(/\//g, '_');
+}
+
+/**
+ * Populate an active item's `body` in-place by fetching from GitHub.
+ * Called each time a new item becomes active (planning_start's first
+ * pop + every planning_next / planning_decide / planning_park
+ * advance) so the LLM has the full description, not just the title.
+ *
+ * Body is cached on the item after first fetch within a session to
+ * avoid a re-fetch if the same item is parked and returns later.
+ */
+export async function hydrateActiveItemBody(
+    context: ServerContext,
+    repo: RepoInfo,
+    item: planning.PlanningItem | null
+): Promise<planning.PlanningItem | null> {
+    if (!item) return null;
+    if (typeof item.body === 'string') return item; // already fetched
+    try {
+        const details = await context.api.getIssueDetails(repo, item.number);
+        item.body = details?.body ?? '';
+    } catch {
+        // Non-fatal — LLM can still operate on title + fields.
+        item.body = '';
+    }
+    return item;
 }

--- a/packages/mcp/src/tools/planning-start.ts
+++ b/packages/mcp/src/tools/planning-start.ts
@@ -5,6 +5,7 @@ import type { ToolMeta } from '../types.js';
 import { planning } from '@bretwardjames/ghp-core';
 import {
     getPlanningStore,
+    hydrateActiveItemBody,
     newSessionId,
     ownerKeyForProcess,
 } from './planning-session.js';
@@ -160,6 +161,9 @@ export function register(server: McpServer, context: ServerContext): void {
 
             const sessionId = newSessionId();
             const active = queue.length > 0 ? queue[0] : null;
+            // Hydrate the first item's body before we return so the LLM
+            // has context for the opening discussion, not just the title.
+            await hydrateActiveItemBody(context, repo, active);
             const session: planning.PlanningSession = {
                 id: sessionId,
                 startedAt: Date.now(),


### PR DESCRIPTION
## Summary

Planning queue carried only title + fields; LLM was making triage calls without issue description. Fix: lazy-fetch body when item becomes active.

## Where hydration runs

| Tool | Trigger |
|------|---------|
| \`planning_start\` | First item's body before returning |
| \`planning_next\` | Newly-popped item |
| \`planning_decide\` | Post-decision next item |
| \`planning_park\` | Active after push-to-back |

## Why lazy, not eager

Eager at queue-build time = N × round-trip. A 46-item queue → ~9s planning_start. Lazy = 1 round-trip per transition, near-instant.

## Implementation

- \`PlanningItem.body?: string\` (optional).
- New \`hydrateActiveItemBody(context, repo, item)\` in \`planning-session.ts\`. Idempotent — skips fetch when \`item.body\` already set (parked items returning don't re-fetch). Non-fatal on error — sets body to '' so LLM still has title + fields.
- 4 tool handlers wired.

## Tests

356/356 unchanged. No new test — body presence flows through to JSON output; behavior observable in E2E only.

## Post-merge

Railway redeploys → runtight next \`planning_start\` returns bodies on the active item.

---
Generated with [Claude Code](https://claude.ai/code)