### PR TITLE
bretwardjames/fix-planning-body-hydration-silent

### DIFF
--- a/packages/core/src/github-api.ts
+++ b/packages/core/src/github-api.ts
@@ -1939,6 +1939,33 @@ export class GitHubAPI {
     }
 
     /**
+     * Lean body-only fetch for the planning hydration path. Works for
+     * both issues and PRs. Returns `null` when the record doesn't
+     * exist or can't be resolved; throws on transport / auth errors
+     * so the caller can surface them instead of silently swallowing.
+     */
+    async getIssueBody(repo: RepoInfo, issueNumber: number): Promise<string | null> {
+        if (!this.graphqlWithAuth) throw new Error('Not authenticated');
+
+        const response: {
+            repository: {
+                issueOrPullRequest: {
+                    __typename: string;
+                    body?: string;
+                } | null;
+            };
+        } = await this.graphqlWithRetry(queries.ISSUE_BODY_QUERY, {
+            owner: repo.owner,
+            name: repo.name,
+            number: issueNumber,
+        });
+
+        const node = response.repository?.issueOrPullRequest;
+        if (!node) return null;
+        return node.body ?? '';
+    }
+
+    /**
      * Fetch open milestones for a repo with enough context to run the
      * planning-meeting timeline audit. Returns dueOn as an ISO date
      * (or null) and the open issue count per milestone.

--- a/packages/core/src/planning/queue-builder.test.ts
+++ b/packages/core/src/planning/queue-builder.test.ts
@@ -14,6 +14,7 @@ function item(overrides: Partial<QueueInputItem>): QueueInputItem {
         assignees: [],
         lastReviewed: null,
         iterationTitle: null,
+        repository: 'owner/repo',
         ...overrides,
     };
 }

--- a/packages/core/src/planning/queue-builder.ts
+++ b/packages/core/src/planning/queue-builder.ts
@@ -19,6 +19,8 @@ export interface QueueInputItem {
     /** ISO date from the Last Reviewed field, or sentinel, or null. */
     lastReviewed: string | null;
     iterationTitle: string | null;
+    /** `owner/name` the issue lives in — multi-repo projects need this. */
+    repository: string | null;
 }
 
 export interface QueueBuildInput {
@@ -78,6 +80,7 @@ export function buildQueue(input: QueueBuildInput): PlanningItem[] {
             lastReviewed: item.lastReviewed,
             assignees: item.assignees,
             bucket,
+            repository: item.repository,
         });
     }
 

--- a/packages/core/src/planning/types.ts
+++ b/packages/core/src/planning/types.ts
@@ -154,6 +154,13 @@ export interface PlanningItem {
      * time because that would scale linearly with queue size.
      */
     body?: string;
+    /**
+     * `owner/name` of the repo this issue lives in. A GitHub Project
+     * can aggregate items across multiple repos, so each item carries
+     * its own repo here — hydration + sentinel writes target THIS
+     * repo, not the session's default.
+     */
+    repository: string | null;
 }
 
 export type PlanningBucket =

--- a/packages/core/src/queries.ts
+++ b/packages/core/src/queries.ts
@@ -807,3 +807,22 @@ export const REPO_OPEN_MILESTONES_QUERY = `
         }
     }
 `;
+
+/**
+ * Lean body-only fetch for the planning-meeting hydration path.
+ * Avoids the fuller ISSUE_DETAILS_QUERY (which also grabs labels,
+ * comments, author, etc.) — body is the only field the planning
+ * loop needs and one failure mode deep in an unrelated field would
+ * otherwise take out the whole response.
+ */
+export const ISSUE_BODY_QUERY = `
+    query($owner: String!, $name: String!, $number: Int!) {
+        repository(owner: $owner, name: $name) {
+            issueOrPullRequest(number: $number) {
+                __typename
+                ... on Issue { body }
+                ... on PullRequest { body }
+            }
+        }
+    }
+`;

--- a/packages/mcp/src/tools/planning-session.ts
+++ b/packages/mcp/src/tools/planning-session.ts
@@ -44,22 +44,57 @@ export function newSessionId(): string {
  * pop + every planning_next / planning_decide / planning_park
  * advance) so the LLM has the full description, not just the title.
  *
+ * The fetch targets the item's OWN repo (parsed from `item.repository`),
+ * not the session's default repo — GitHub Projects can aggregate items
+ * from multiple repos and hydration must follow the actual source.
+ *
  * Body is cached on the item after first fetch within a session to
  * avoid a re-fetch if the same item is parked and returns later.
  */
 export async function hydrateActiveItemBody(
     context: ServerContext,
-    repo: RepoInfo,
     item: planning.PlanningItem | null
 ): Promise<planning.PlanningItem | null> {
     if (!item) return null;
     if (typeof item.body === 'string') return item; // already fetched
+    const itemRepo = parseItemRepository(item.repository);
+    if (!itemRepo) {
+        item.body = '(no repo attached to project item — likely a draft issue)';
+        return item;
+    }
     try {
-        const details = await context.api.getIssueDetails(repo, item.number);
-        item.body = details?.body ?? '';
-    } catch {
-        // Non-fatal — LLM can still operate on title + fields.
-        item.body = '';
+        // Lean body-only fetch. Distinct from getIssueDetails (which
+        // also pulls comments/labels/author/etc.) so one failing
+        // sub-field doesn't take out the whole response.
+        const body = await context.api.getIssueBody(itemRepo, item.number);
+        if (body === null) {
+            item.body = `(issue ${itemRepo.fullName}#${item.number} not found — may have been deleted or moved)`;
+        } else {
+            item.body = body;
+        }
+    } catch (err) {
+        // Surface the error in the body field so the LLM (and the
+        // operator looking at logs) can see WHY hydration failed,
+        // instead of seeing a mysterious empty string.
+        const msg = err instanceof Error ? err.message : String(err);
+        console.error(
+            JSON.stringify({
+                level: 'warn',
+                msg: 'planning_hydrate_body_failed',
+                repo: itemRepo.fullName,
+                issue: item.number,
+                error: msg,
+            })
+        );
+        item.body = `(failed to fetch body: ${msg})`;
     }
     return item;
+}
+
+function parseItemRepository(repoString: string | null): RepoInfo | null {
+    if (!repoString || !repoString.includes('/')) return null;
+    const [owner, ...rest] = repoString.split('/');
+    const name = rest.join('/');
+    if (!owner || !name) return null;
+    return { owner, name, fullName: `${owner}/${name}` };
 }

--- a/packages/mcp/src/tools/planning-start.ts
+++ b/packages/mcp/src/tools/planning-start.ts
@@ -152,6 +152,7 @@ export function register(server: McpServer, context: ServerContext): void {
                         assignees: it.assignees,
                         lastReviewed: it.fields['Last Reviewed'] ?? null,
                         iterationTitle: it.fields['Sprint'] ?? null,
+                        repository: it.repository,
                     })),
                 meetingType,
                 currentSprintTitle,
@@ -163,7 +164,9 @@ export function register(server: McpServer, context: ServerContext): void {
             const active = queue.length > 0 ? queue[0] : null;
             // Hydrate the first item's body before we return so the LLM
             // has context for the opening discussion, not just the title.
-            await hydrateActiveItemBody(context, repo, active);
+            // Uses the item's own repo (multi-repo projects have items
+            // outside the session's default repo).
+            await hydrateActiveItemBody(context, active);
             const session: planning.PlanningSession = {
                 id: sessionId,
                 startedAt: Date.now(),


### PR DESCRIPTION
## Bug

Runtight agent reported `Body: (empty)` for issue #579 during planning despite the issue having a 2760-char body. `planning_status` returned same. Other fields (title, priority, bucket) flowed through fine.

## Root cause

Two independent bugs compounding:

### 1. Silent catch in getIssueDetails swallows everything

`hydrateActiveItemBody` used `getIssueDetails()` which fetches body + comments + labels + author in one query. `getIssueDetails` has outer `catch {}` that swallows ALL errors and returns null. A transient failure on ANY sub-field silently produced empty body. No log, no signal.

### 2. Multi-repo projects (latent)

`PlanningItem` didn't carry `repository`. Hydration used SESSION repo. Multi-repo Projects would target wrong repo for non-default items. Not the trigger here but real latent bug.

## Fixes

- New `ISSUE_BODY_QUERY` + `GitHubAPI.getIssueBody()` — lean body-only fetch. Throws on errors instead of swallowing.
- `hydrateActiveItemBody` distinguishes "not found" / "fetch threw" / "no repo (draft)" / normal paths. Prefixes diagnostic text with `(…)`. Emits structured warn log.
- `PlanningItem.repository` threaded through queue. Multi-repo Projects now hydrate correctly.

## Tests

356/356 workspace.

---
Generated with [Claude Code](https://claude.ai/code)