### PR TITLE
bretwardjames/fix-planning-body-null-scope

### DIFF
--- a/packages/core/src/github-api.ts
+++ b/packages/core/src/github-api.ts
@@ -1940,20 +1940,33 @@ export class GitHubAPI {
 
     /**
      * Lean body-only fetch for the planning hydration path. Works for
-     * both issues and PRs. Returns `null` when the record doesn't
-     * exist or can't be resolved; throws on transport / auth errors
-     * so the caller can surface them instead of silently swallowing.
+     * both issues and PRs. Throws on transport / auth errors so the
+     * caller can surface them instead of silently swallowing.
+     *
+     * Return shape distinguishes:
+     *   - `{ found: false }` — record doesn't exist / token can't resolve
+     *   - `{ body: null }`  — node resolved but body came back null
+     *                        (scope-limited / permission-filtered response)
+     *   - `{ body: '' }`    — issue legitimately has no body
+     *   - `{ body: '...' }` — normal case
      */
-    async getIssueBody(repo: RepoInfo, issueNumber: number): Promise<string | null> {
+    async getIssueBody(
+        repo: RepoInfo,
+        issueNumber: number
+    ): Promise<
+        | { found: false }
+        | { found: true; title: string | null; body: string | null }
+    > {
         if (!this.graphqlWithAuth) throw new Error('Not authenticated');
 
         const response: {
             repository: {
                 issueOrPullRequest: {
                     __typename: string;
-                    body?: string;
+                    title?: string | null;
+                    body?: string | null;
                 } | null;
-            };
+            } | null;
         } = await this.graphqlWithRetry(queries.ISSUE_BODY_QUERY, {
             owner: repo.owner,
             name: repo.name,
@@ -1961,8 +1974,12 @@ export class GitHubAPI {
         });
 
         const node = response.repository?.issueOrPullRequest;
-        if (!node) return null;
-        return node.body ?? '';
+        if (!node) return { found: false };
+        return {
+            found: true,
+            title: node.title ?? null,
+            body: typeof node.body === 'string' ? node.body : null,
+        };
     }
 
     /**

--- a/packages/core/src/queries.ts
+++ b/packages/core/src/queries.ts
@@ -820,8 +820,8 @@ export const ISSUE_BODY_QUERY = `
         repository(owner: $owner, name: $name) {
             issueOrPullRequest(number: $number) {
                 __typename
-                ... on Issue { body }
-                ... on PullRequest { body }
+                ... on Issue { title body }
+                ... on PullRequest { title body }
             }
         }
     }

--- a/packages/mcp/src/tools/planning-session.ts
+++ b/packages/mcp/src/tools/planning-session.ts
@@ -66,11 +66,28 @@ export async function hydrateActiveItemBody(
         // Lean body-only fetch. Distinct from getIssueDetails (which
         // also pulls comments/labels/author/etc.) so one failing
         // sub-field doesn't take out the whole response.
-        const body = await context.api.getIssueBody(itemRepo, item.number);
-        if (body === null) {
-            item.body = `(issue ${itemRepo.fullName}#${item.number} not found — may have been deleted or moved)`;
+        const result = await context.api.getIssueBody(itemRepo, item.number);
+        if (!result.found) {
+            item.body = `(issue ${itemRepo.fullName}#${item.number} not found — may have been deleted, moved, or the token cannot resolve this repo)`;
+        } else if (result.body === null) {
+            // GraphQL returned the node but body is null. Most common
+            // cause: OAuth token has read:project (sufficient for
+            // title/fields via the projects graph) but not full `repo`
+            // scope for this owner — GitHub filters body content
+            // rather than erroring. Signal the operator clearly so
+            // they can re-authorize with correct scope.
+            console.error(
+                JSON.stringify({
+                    level: 'warn',
+                    msg: 'planning_body_null_probable_scope_issue',
+                    repo: itemRepo.fullName,
+                    issue: item.number,
+                    titleReturned: result.title !== null,
+                })
+            );
+            item.body = `(body not returned by GitHub for ${itemRepo.fullName}#${item.number}. Title came through${result.title !== null ? ' ✓' : ' ✗'}. Most likely the token lacks full \`repo\` scope for this owner — re-authorize the GHP MCP OAuth app including the target org.)`;
         } else {
-            item.body = body;
+            item.body = result.body;
         }
     } catch (err) {
         // Surface the error in the body field so the LLM (and the


### PR DESCRIPTION
## The bug behind the bug

Previous fix (#300) made hydration error-aware. But the actual case on user's runtight session was neither an error nor a missing issue — GitHub returned the issue node with \`body: null\`. \`node.body ?? ''\` flattened to empty string. Silent "success" with no body.

Root cause: the hosted user's OAuth token has \`read:project\` scope (works for title + project fields via the projects graph) but lacks full \`repo\` scope for the \`true-impact\` owner. When the repo-direct query runs, GitHub filters out body content rather than erroring.

## Fix

- \`ISSUE_BODY_QUERY\` pulls title alongside body. Title presence is a tell.
- \`getIssueBody\` now returns a discriminated shape distinguishing found/not-found, title presence, body null vs empty string.
- \`hydrateActiveItemBody\` emits a specific actionable message when body is null but title came through — tells operator to re-authorize the OAuth app with full \`repo\` scope including the target org. Logs structured warn line for server-side grep.

## LLM experience

Before: body = ''. LLM made decisions without issue context. No signal anything was wrong.

After: body = "(body not returned by GitHub for true-impact/care#579. Title came through ✓. Most likely the token lacks full \`repo\` scope for this owner — re-authorize the GHP MCP OAuth app including the target org.)"

LLM now has actionable error text to surface to the user.

## Tests

356/356 unchanged.

## Post-merge

- Railway auto-deploy (if fixed) OR manual redeploy → runtight agent's next session shows the scope diagnostic
- User re-auths OAuth including true-impact org → bodies start flowing

---
Generated with [Claude Code](https://claude.ai/code)